### PR TITLE
Add custom buildx builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,13 @@ install:
 # TODO: build this manually instead of requiring buildx
 test/out/img.tar: test/image/Dockerfile test/image/src/main.rs test/image/Cargo.toml test/image/Cargo.lock
 	mkdir -p $(@D)
+	docker buildx rm wasmbuilder || true
+	docker buildx create --name wasmbuilder --use
 	docker buildx build --platform=wasi/wasm -o type=docker,dest=$@ -t $(TEST_IMG_NAME) ./test/image
 
 load: test/out/img.tar
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import $<
+
+clean:
+	rm -rf target/$(TARGET)
+	rm test/out/img.tar


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

When running `make load` I ended up not being able to build due to using the docker target in buildx:

```
error: Docker exporter feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
make: *** [Makefile:25: test/out/img.tar] Error 1
```

This fixes it by using a custom builder and adds a `clean` target

