### PR TITLE
Fix issue with sudo test runner messing with tty

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/testutil.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/testutil.rs
@@ -1,17 +1,31 @@
 use super::{Error, Result};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 pub fn run_test_with_sudo(test: &str) -> Result<()> {
-    Command::new("sudo")
+    // This uses piped stdout/stderr.
+    // This makes it so cargo doesn't mess up the caller's TTY.
+    let mut cmd = Command::new("sudo")
         .arg("-E")
         .arg(std::fs::read_link("/proc/self/exe")?)
         .arg("--")
         .arg(test)
         .arg("--exact")
-        .stdin(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .status()
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let mut stdout = cmd.stdout.take().unwrap();
+    let mut stderr = cmd.stderr.take().unwrap();
+
+    std::thread::spawn(move || {
+        std::io::copy(&mut stdout, &mut std::io::stdout()).unwrap();
+    });
+    std::thread::spawn(move || {
+        std::io::copy(&mut stderr, &mut std::io::stderr()).unwrap();
+    });
+
+    cmd.wait()
         .and_then(|status| {
             if status.success() {
                 Ok(())


### PR DESCRIPTION
Cargo seems to really enjoy messing with the tty.
Instead of having 2 cargos (main one that executed the test originally, then the sub-test runner) access to the same terminal, make the subprocess go through a pipe for stdout and stderr.
