### PR TITLE
Add rust-toolchain.toml to pin the rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "beta"
+components = ["rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
People need to compile this project by using Rust in beta or nightly channel. 

So I add a `rust-toolchain.toml` file to pin the version, so people can run `cargo build` command directly

Signed-off-by: Manjusaka <me@manjusaka.me>