### PR TITLE
Fix drop() calls.

### DIFF
--- a/crates/wasmedge/src/instance.rs
+++ b/crates/wasmedge/src/instance.rs
@@ -62,8 +62,6 @@ mod tests {
         drop(temp);
         let f = maybe_open_stdio(dir.path().join("testfile").as_path().to_str().unwrap())?;
         assert!(f.is_some());
-        drop(f);
-
         Ok(())
     }
 }

--- a/crates/wasmedge/src/instance.rs
+++ b/crates/wasmedge/src/instance.rs
@@ -230,7 +230,7 @@ impl Instance for Wasi {
                     debug!("wasi instance exited with status {}", status.status);
                     let mut ec = lock.lock().unwrap();
                     *ec = Some((status.status, Utc::now()));
-                    drop(lock);
+                    drop(ec);
                     cvar.notify_all();
                 });
                 Ok(tid)

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -215,7 +215,7 @@ impl Instance for Wasi {
                     debug!("wasi instance exited with status {}", status.status);
                     let mut ec = lock.lock().unwrap();
                     *ec = Some((status.status, Utc::now()));
-                    drop(lock);
+                    drop(ec);
                     cvar.notify_all();
                 });
                 Ok(tid)


### PR DESCRIPTION
It looks like the `drop(lock)` operation is a no-op, since `lock` is a reference. Looking at the code, I think the idea is that the MutexGuard would be dropped, so I changed the implementation to that. @cpuguy83 can you confirm? Also drop one drop from tests, where the "dropped" value derives Copy.