### PR TITLE
Cleanups from static code analysis

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
@@ -413,7 +413,7 @@ fn format_device(device: &LinuxDeviceCgroup) -> String {
 
     match device.minor() {
         Some(minor) => s.push_str(&minor.to_string()),
-        None => s.push_str("*"),
+        None => s.push('*'),
     }
     s.push(' ');
 

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
@@ -100,7 +100,7 @@ impl Cgroup for CgroupV1 {
     }
 
     fn delete(&self) -> Result<()> {
-        (&self.controllers).into_iter().try_for_each(|(kind, _)| {
+        (&self.controllers).iter().try_for_each(|(kind, _)| {
             let dir = self.get_controller(kind)?;
             if dir.exists() {
                 return fs::remove_dir(&dir).map_err(|e| {
@@ -114,7 +114,7 @@ impl Cgroup for CgroupV1 {
     fn delete_all(&self) -> Result<()> {
         let mut paths = vec![];
 
-        (&self.controllers).into_iter().for_each(|(_, cntrl)| {
+        (&self.controllers).iter().for_each(|(_, cntrl)| {
             let mut full = PathBuf::from(cntrl);
             for p in self.path.iter() {
                 if p.to_str().unwrap() == "/" {

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
@@ -100,7 +100,7 @@ impl Cgroup for CgroupV1 {
     }
 
     fn delete(&self) -> Result<()> {
-        (&self.controllers).iter().try_for_each(|(kind, _)| {
+        self.controllers.iter().try_for_each(|(kind, _)| {
             let dir = self.get_controller(kind)?;
             if dir.exists() {
                 return fs::remove_dir(&dir).map_err(|e| {
@@ -114,7 +114,7 @@ impl Cgroup for CgroupV1 {
     fn delete_all(&self) -> Result<()> {
         let mut paths = vec![];
 
-        (&self.controllers).iter().for_each(|(_, cntrl)| {
+        self.controllers.iter().for_each(|(_, cntrl)| {
             let mut full = PathBuf::from(cntrl);
             for p in self.path.iter() {
                 if p.to_str().unwrap() == "/" {
@@ -129,7 +129,7 @@ impl Cgroup for CgroupV1 {
 
         for p in paths.iter().rev() {
             debug!("Removing cgroup directory: {}", p.display());
-            match fs::remove_dir(&p) {
+            match fs::remove_dir(p) {
                 Ok(_) => continue,
                 Err(e) => {
                     if e.kind() != std::io::ErrorKind::NotFound {

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
@@ -65,7 +65,7 @@ impl CgroupV2 {
                         e
                     ))
                 })?
-                .replace(" ", " +");
+                .replace(' ', " +");
 
             let c = "+".to_string() + &controllers.to_string();
 

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
@@ -363,10 +363,7 @@ impl<T: std::io::BufRead> TryFrom<&CgroupOptions<T>> for CgroupV2 {
                     "cgroup v2 mount found but cgroup v1 mount also found: hybrid cgroup mode is not supported".to_string(),
                 ));
             }
-            return Ok(CgroupV2::new(
-                PathBuf::from(mount),
-                PathBuf::from(&opts.name.clone()),
-            ));
+            return Ok(CgroupV2::new(mount, PathBuf::from(&opts.name.clone())));
         }
 
         Err(Error::FailedPrecondition(

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
@@ -145,7 +145,7 @@ impl Cgroup for CgroupV2 {
 
         for p in paths.iter().rev() {
             debug!("Removing cgroup directory: {}", p.display());
-            match fs::remove_dir(&p) {
+            match fs::remove_dir(p) {
                 Ok(_) => continue,
                 Err(e) => {
                     if e.kind() != std::io::ErrorKind::NotFound {
@@ -355,7 +355,7 @@ impl<T: std::io::BufRead> TryFrom<&CgroupOptions<T>> for CgroupV2 {
         }
 
         let f = fs::File::open("/proc/cgroups")?;
-        let mounts = find_cgroup_mounts((&opts.mounts)()?, &list_cgroup_controllers(f)?)?;
+        let mounts = find_cgroup_mounts((opts.mounts)()?, &list_cgroup_controllers(f)?)?;
 
         if let Some(mount) = mounts.v2 {
             if mounts.v1.is_empty().not() {

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
@@ -217,7 +217,7 @@ fn list_cgroup_controllers<R: Read>(r: R) -> Result<HashSet<String>> {
     for line in std::io::BufReader::new(r).lines() {
         let line = line?;
         let line = line.trim();
-        if line.starts_with("#") {
+        if line.starts_with('#') {
             continue;
         }
         let mut parts = line.split_whitespace();

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
@@ -102,17 +102,16 @@ impl<T: std::io::BufRead> TryFrom<CgroupOptions<T>> for Box<dyn Cgroup> {
         let f = fs::File::open("/proc/cgroups")?;
         let mounts = find_cgroup_mounts((opts.mounts)()?, &list_cgroup_controllers(f)?)?;
 
-        if mounts.v1.is_empty().not() && mounts.v2.is_some() {
-            if fs::read_to_string(mounts.v2.as_ref().unwrap().join("cgroup.controllers"))?
+        if mounts.v1.is_empty().not()
+            && mounts.v2.is_some()
+            && fs::read_to_string(mounts.v2.as_ref().unwrap().join("cgroup.controllers"))?
                 .trim()
                 .is_empty()
                 .not()
-            {
-                return Err(Error::FailedPrecondition(
-                    "cgroup v1 and v2 mounts found: hybrid cgroup mode is not supported"
-                        .to_string(),
-                ));
-            }
+        {
+            return Err(Error::FailedPrecondition(
+                "cgroup v1 and v2 mounts found: hybrid cgroup mode is not supported".to_string(),
+            ));
         }
 
         // Here the caller passed in a root dir so we'll try to use that with v1/v2 directly

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
@@ -48,14 +48,14 @@ pub trait Cgroup {
     fn open(&self) -> Result<RawFD> {
         Err(Error::Others(format!(
             "open not implemented for cgroup version: {}",
-            self.version().to_string()
+            self.version()
         )))
     }
 
     fn apply(&self, _res: Option<Resources>) -> Result<()> {
         Err(Error::Others(format!(
             "cgroup {} is not supported",
-            self.version().to_string(),
+            self.version(),
         )))
     }
 

--- a/crates/containerd-shim-wasm/src/sandbox/error.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/error.rs
@@ -56,11 +56,9 @@ impl From<Error> for ttrpc::Error {
             Error::FailedPrecondition(ref s) => {
                 ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::FAILED_PRECONDITION, s))
             }
-            Error::Oci(ref s) => match s {
-                _ => {
-                    ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::UNKNOWN, e.to_string()))
-                }
-            },
+            Error::Oci(ref _s) => {
+                ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::UNKNOWN, e.to_string()))
+            }
             Error::Any(ref s) => {
                 ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::UNKNOWN, s))
             }

--- a/crates/containerd-shim-wasm/src/sandbox/exec.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/exec.rs
@@ -242,7 +242,7 @@ mod tests {
                         test_exit_code, status
                     )));
                 }
-                return Ok(());
+                Ok(())
             }
             Ok(Context::Child) => {
                 let term = Arc::new(AtomicBool::new(false));
@@ -255,9 +255,7 @@ mod tests {
 
                 std::process::exit(test_exit_code.try_into().unwrap());
             }
-            Err(e) => {
-                return Err(e);
-            }
+            Err(e) => Err(e),
         }
     }
 

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -107,7 +107,7 @@ pub fn setup_prestart_hooks(hooks: &Option<oci_spec::runtime::Hooks>) -> Result<
         let prestart_hooks = hooks.prestart().as_ref().unwrap();
 
         for hook in prestart_hooks {
-            let mut hook_command = process::Command::new(&hook.path());
+            let mut hook_command = process::Command::new(hook.path());
             // Based on OCI spec, the first argument of the args vector is the
             // arg0, which can be different from the path.  For example, path
             // may be "/usr/bin/true" and arg0 is set to "true". However, rust

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -1381,7 +1381,7 @@ where
                     OpenOptions::new()
                         .create(true)
                         .write(true)
-                        .open(&dest)
+                        .open(dest)
                         .unwrap();
                 }
 

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -123,8 +123,8 @@ impl Builder {
             }
 
             let mut annotations = HashMap::new();
-            if config.1.contains(":") {
-                let split = config.1.split(":").collect::<Vec<&str>>()[1];
+            if config.1.contains(':') {
+                let split = config.1.split(':').collect::<Vec<&str>>()[1];
                 annotations.insert(
                     "org.opencontainers.image.ref.name".to_string(),
                     split.to_string(),

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -44,12 +44,12 @@ struct DockerManifest {
 impl Builder {
     pub fn add_config(&mut self, config: ImageConfiguration, name: String) -> &mut Self {
         self.configs.push((config, name));
-        return self;
+        self
     }
 
     pub fn add_layer(&mut self, layer: &PathBuf) -> &mut Self {
         self.layers.push(layer.to_owned());
-        return self;
+        self
     }
 
     pub fn build<W: Write>(&mut self, w: W) -> Result<(), Error> {

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -117,7 +117,9 @@ impl Builder {
             let mut layers = Vec::new();
             for id in config.0.rootfs().diff_ids().iter() {
                 debug!("id: {}", id);
-                layer_digests.get(id).map(|d| layers.push(d.clone()));
+                if let Some(d) = layer_digests.get(id) {
+                    layers.push(d.clone())
+                }
             }
 
             let mut annotations = HashMap::new();

--- a/crates/wasi-demo-app/src/main.rs
+++ b/crates/wasi-demo-app/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
         "exit" => process::exit(args[2].parse::<i32>().unwrap()),
         "write" => {
             let mut file = File::create(&args[2]).unwrap();
-            file.write_all(&args[3..].join(" ").as_bytes()).unwrap();
+            file.write_all(args[3..].join(" ").as_bytes()).unwrap();
         }
         "daemon" => loop {
             println!("This is a song that never ends.\nYes, it goes on and on my friends.\nSome people started singing it not knowing what it was,\nSo they'll continue singing it forever just because...\n");

--- a/crates/wasmedge/src/instance.rs
+++ b/crates/wasmedge/src/instance.rs
@@ -199,7 +199,7 @@ impl Instance for Wasi {
         debug!("call prehook before the start");
         oci::setup_prestart_hooks(spec.hooks())?;
 
-        let vm = prepare_module(engine.clone(), &spec, stdin, stdout, stderr)
+        let vm = prepare_module(engine, &spec, stdin, stdout, stderr)
             .map_err(|e| Error::Others(format!("error setting up module: {}", e)))?;
 
         let cg = oci::get_cgroup(&spec)?;

--- a/crates/wasmedge/src/instance.rs
+++ b/crates/wasmedge/src/instance.rs
@@ -257,9 +257,9 @@ impl Instance for Wasi {
         }
 
         let lr = self.pidfd.lock().unwrap();
-        let fd = lr.as_ref().ok_or(Error::FailedPrecondition(
-            "module is not running".to_string(),
-        ))?;
+        let fd = lr
+            .as_ref()
+            .ok_or_else(|| Error::FailedPrecondition("module is not running".to_string()))?;
         fd.kill(SIGKILL as i32)
     }
 

--- a/crates/wasmedge/src/instance.rs
+++ b/crates/wasmedge/src/instance.rs
@@ -113,16 +113,16 @@ pub fn prepare_module(
     stderr_path: String,
 ) -> Result<Vm, WasmRuntimeError> {
     debug!("opening rootfs");
-    let rootfs_path = oci::get_root(&spec).to_str().unwrap();
+    let rootfs_path = oci::get_root(spec).to_str().unwrap();
     let root = format!("/:{}", rootfs_path);
     let mut preopens = vec![root.as_str()];
 
     debug!("opening mounts");
-    let mut mounts = oci_utils::get_wasm_mounts(&spec);
+    let mut mounts = oci_utils::get_wasm_mounts(spec);
     preopens.append(&mut mounts);
 
-    let args = oci::get_args(&spec);
-    let envs = oci_utils::env_to_wasi(&spec);
+    let args = oci::get_args(spec);
+    let envs = oci_utils::env_to_wasi(spec);
 
     debug!("setting up wasi");
     let mut wasi_instance = vm.wasi_module()?;
@@ -165,7 +165,7 @@ pub fn prepare_module(
         cmd = strpd.to_string();
     }
 
-    let mod_path = oci::get_root(&spec).join(cmd);
+    let mod_path = oci::get_root(spec).join(cmd);
 
     debug!("register module from file");
     let vm = vm.register_module_from_file("main", mod_path)?;
@@ -197,7 +197,7 @@ impl Instance for Wasi {
         let spec = load_spec(self.bundle.clone())?;
 
         debug!("call prehook before the start");
-        oci::setup_prestart_hooks(&spec.hooks())?;
+        oci::setup_prestart_hooks(spec.hooks())?;
 
         let vm = prepare_module(engine.clone(), &spec, stdin, stdout, stderr)
             .map_err(|e| Error::Others(format!("error setting up module: {}", e)))?;

--- a/crates/wasmedge/src/oci_utils.rs
+++ b/crates/wasmedge/src/oci_utils.rs
@@ -27,5 +27,5 @@ pub fn get_wasm_mounts(spec: &Spec) -> Vec<&str> {
             .collect(),
         _ => vec![],
     };
-    return mounts;
+    mounts
 }

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -223,7 +223,7 @@ impl Instance for Wasi {
 
                 // TODO: How to get exit code?
                 // This was relatively straight forward in go, but wasi and wasmtime are totally separate things in rust.
-                let _ret = match f.call(&mut store, &mut [], &mut []) {
+                let _ret = match f.call(&mut store, &[], &mut []) {
                     Ok(_) => std::process::exit(0),
                     Err(_) => std::process::exit(137),
                 };

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -88,9 +88,9 @@ pub fn prepare_module(
     stderr_path: String,
 ) -> Result<(WasiCtx, Module), WasmtimeError> {
     debug!("opening rootfs");
-    let rootfs = oci_wasmtime::get_rootfs(&spec)?;
-    let args = oci::get_args(&spec);
-    let env = oci_wasmtime::env_to_wasi(&spec);
+    let rootfs = oci_wasmtime::get_rootfs(spec)?;
+    let args = oci::get_args(spec);
+    let env = oci_wasmtime::env_to_wasi(spec);
 
     debug!("setting up wasi");
     let mut wasi_builder = WasiCtxBuilder::new()
@@ -126,7 +126,7 @@ pub fn prepare_module(
         cmd = strpd.to_string();
     }
 
-    let mod_path = oci::get_root(&spec).join(cmd);
+    let mod_path = oci::get_root(spec).join(cmd);
 
     debug!("loading module from file");
     let module = Module::from_file(&engine, mod_path)
@@ -165,7 +165,7 @@ impl Instance for Wasi {
         let spec = load_spec(self.bundle.clone())?;
 
         debug!("call prehook before the start");
-        oci::setup_prestart_hooks(&spec.hooks())?;
+        oci::setup_prestart_hooks(spec.hooks())?;
 
         let m = prepare_module(engine.clone(), &spec, stdin, stdout, stderr)
             .map_err(|e| Error::Others(format!("error setting up module: {}", e)))?;

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -178,11 +178,9 @@ impl Instance for Wasi {
             .map_err(|err| Error::Others(format!("error instantiating module: {}", err)))?;
 
         debug!("getting start function");
-        let f = i
-            .get_func(&mut store, "_start")
-            .ok_or(Error::InvalidArgument(
-                "module does not have a wasi start function".to_string(),
-            ))?;
+        let f = i.get_func(&mut store, "_start").ok_or_else(|| {
+            Error::InvalidArgument("module does not have a wasi start function".to_string())
+        })?;
 
         debug!("starting wasi instance");
 
@@ -241,9 +239,9 @@ impl Instance for Wasi {
         }
 
         let lr = self.pidfd.lock().unwrap();
-        let fd = lr.as_ref().ok_or(Error::FailedPrecondition(
-            "module is not running".to_string(),
-        ))?;
+        let fd = lr
+            .as_ref()
+            .ok_or_else(|| Error::FailedPrecondition("module is not running".to_string()))?;
         fd.kill(signal as i32)
     }
 


### PR DESCRIPTION
I ran clippy static code analysis, and the tool had a bunch of suggestions. Some of the fixes make a lot of sense but some are mostly style issues. I split the fixes to a number of commits, so if need be, I can easily remove some fix classes where the benefit might not be clear.

One thing that came up is that there is a lot of code duplication between wasmtime and wasmedge crates. I'm thinking a utility library would be useful for sharing code. This way the possible bugs would be just in one place. :-)