### PR TITLE
Move call of the prestart hooks over to the lib part

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -958,6 +958,10 @@ where
 
         debug!("create done");
 
+        // Per the spec, the prestart hook must be called as part of the create operation
+        debug!("call prehook before the start");
+        oci::setup_prestart_hooks(&spec.hooks())?;
+
         Ok(api::CreateTaskResponse {
             pid: std::process::id(),
             ..Default::default()

--- a/crates/wasmedge/src/instance.rs
+++ b/crates/wasmedge/src/instance.rs
@@ -194,9 +194,6 @@ impl Instance for Wasi {
         debug!("preparing module");
         let spec = load_spec(self.bundle.clone())?;
 
-        debug!("call prehook before the start");
-        oci::setup_prestart_hooks(spec.hooks())?;
-
         let vm = prepare_module(engine, &spec, stdin, stdout, stderr)
             .map_err(|e| Error::Others(format!("error setting up module: {}", e)))?;
 

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -165,9 +165,6 @@ impl Instance for Wasi {
         debug!("preparing module");
         let spec = load_spec(self.bundle.clone())?;
 
-        debug!("call prehook before the start");
-        oci::setup_prestart_hooks(spec.hooks())?;
-
         let m = prepare_module(engine.clone(), &spec, stdin, stdout, stderr)
             .map_err(|e| Error::Others(format!("error setting up module: {}", e)))?;
 


### PR DESCRIPTION
Moving this makes pre-start hooks work for all the instances.