### PR TITLE
Inherit workspace's dependencies and other metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,29 +160,10 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0e103ce36d217d568903ad27b14ec2238ecb5d65bad2e756a8f3c0d651506e"
 dependencies = [
- "cap-primitives 0.26.1",
- "cap-std 0.26.1",
+ "cap-primitives",
+ "cap-std",
  "io-lifetimes 0.7.5",
  "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8fca3e81fae1d91a36e9784ca22a39ef623702b5f7904d89dc31f10184a178"
-dependencies = [
- "ambient-authority",
- "errno",
- "fs-set-times 0.15.0",
- "io-extras 0.13.2",
- "io-lifetimes 0.5.3",
- "ipnet",
- "maybe-owned",
- "rustix 0.33.7",
- "winapi",
- "winapi-util",
- "winx 0.31.0",
 ]
 
 [[package]]
@@ -192,15 +173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3f336aa91cce16033ed3c94ac91d98956c49b420e6d6cd0dd7d0e386a57085"
 dependencies = [
  "ambient-authority",
- "fs-set-times 0.17.1",
- "io-extras 0.15.0",
+ "fs-set-times",
+ "io-extras",
  "io-lifetimes 0.7.5",
  "ipnet",
  "maybe-owned",
  "rustix 0.35.13",
  "winapi-util",
  "windows-sys 0.36.1",
- "winx 0.33.0",
+ "winx",
 ]
 
 [[package]]
@@ -215,25 +196,12 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2247568946095c7765ad2b441a56caffc08027734c634a6d5edda648f04e32eb"
-dependencies = [
- "cap-primitives 0.24.4",
- "io-extras 0.13.2",
- "io-lifetimes 0.5.3",
- "ipnet",
- "rustix 0.33.7",
-]
-
-[[package]]
-name = "cap-std"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d6e70b626eceac9d6fc790fe2d72cc3f2f7bc3c35f467690c54a526b0f56db"
 dependencies = [
- "cap-primitives 0.26.1",
- "io-extras 0.15.0",
+ "cap-primitives",
+ "io-extras",
  "io-lifetimes 0.7.5",
  "ipnet",
  "rustix 0.35.13",
@@ -245,10 +213,10 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3a0524f7c4cff2ea547ae2b652bf7a348fd3e48f76556dc928d8b45ab2f1d50"
 dependencies = [
- "cap-primitives 0.26.1",
+ "cap-primitives",
  "once_cell",
  "rustix 0.35.13",
- "winx 0.33.0",
+ "winx",
 ]
 
 [[package]]
@@ -405,7 +373,6 @@ name = "containerd-shim-wasm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cap-std 0.24.4",
  "caps",
  "chrono",
  "clone3",
@@ -889,17 +856,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fs-set-times"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df62ee66ee2d532ea8d567b5a3f0d03ecd64636b98bad5be1e93dcc918b92aa"
-dependencies = [
- "io-lifetimes 0.5.3",
- "rustix 0.33.7",
- "winapi",
-]
-
-[[package]]
-name = "fs-set-times"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a267b6a9304912e018610d53fe07115d8b530b160e85db4d2d3a59f3ddde1aec"
@@ -1083,16 +1039,6 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c937cc9891c12eaa8c63ad347e4a288364b1328b924886970b47a14ab8f8f8"
-dependencies = [
- "io-lifetimes 0.5.3",
- "winapi",
-]
-
-[[package]]
-name = "io-extras"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5d8c2ab5becd8720e30fd25f8fa5500d8dc3fceadd8378f05859bd7b46fc49"
@@ -1100,12 +1046,6 @@ dependencies = [
  "io-lifetimes 0.7.5",
  "windows-sys 0.36.1",
 ]
-
-[[package]]
-name = "io-lifetimes"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
 name = "io-lifetimes"
@@ -1252,12 +1192,6 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1875,7 +1809,7 @@ name = "runwasmedge"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cap-std 0.26.1",
+ "cap-std",
  "chrono",
  "containerd-shim",
  "containerd-shim-wasm",
@@ -1895,7 +1829,7 @@ name = "runwasmtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cap-std 0.26.1",
+ "cap-std",
  "chrono",
  "containerd-shim",
  "containerd-shim-wasm",
@@ -1924,22 +1858,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.33.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938a344304321a9da4973b9ff4f9f8db9caf4597dfd9dda6a60b523340a0fff0"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 0.5.3",
- "itoa",
- "libc",
- "linux-raw-sys 0.0.42",
- "once_cell",
- "winapi",
-]
 
 [[package]]
 name = "rustix"
@@ -2127,11 +2045,11 @@ dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
- "cap-std 0.26.1",
+ "cap-std",
  "io-lifetimes 0.7.5",
  "rustix 0.35.13",
  "windows-sys 0.36.1",
- "winx 0.33.0",
+ "winx",
 ]
 
 [[package]]
@@ -2425,10 +2343,10 @@ dependencies = [
  "async-trait",
  "cap-fs-ext",
  "cap-rand",
- "cap-std 0.26.1",
+ "cap-std",
  "cap-time-ext",
- "fs-set-times 0.17.1",
- "io-extras 0.15.0",
+ "fs-set-times",
+ "io-extras",
  "io-lifetimes 0.7.5",
  "is-terminal 0.3.0",
  "once_cell",
@@ -2448,8 +2366,8 @@ dependencies = [
  "anyhow",
  "bitflags",
  "cap-rand",
- "cap-std 0.26.1",
- "io-extras 0.15.0",
+ "cap-std",
+ "io-extras",
  "rustix 0.35.13",
  "thiserror",
  "tracing",
@@ -3013,17 +2931,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "winx"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d5973cb8cd94a77d03ad7e23bbe14889cb29805da1cec0e4aff75e21aebded"
-dependencies = [
- "bitflags",
- "io-lifetimes 0.5.3",
- "winapi",
-]
 
 [[package]]
 name = "winx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,26 @@ members = [
     "crates/wasmtime",
 ]
 
+[workspace.package]
+edition = "2021"
+version = "0.1.0"
+
+[workspace.dependencies]
+anyhow = "1.0"
+serde = "1.0"
+serde_json = "1.0"
+env_logger = "0.10"
+log = "0.4"
+tar = "0.4"
+containerd-shim = "0.3.0"
+ttrpc = "0.6"
+chrono = "0.4"
+nix = "0.25"
+cap-std = "0.26"
+thiserror = "1.0"
+libc = "0.2.138"
+oci-spec = "0.5"
+sha256 = "1.1"
+
 [profile.release]
 panic = "abort"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,28 +1,27 @@
 [package]
 name = "containerd-shim-wasm"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 doctest = false
 
 [dependencies]
-containerd-shim = "0.3"
+containerd-shim = { workspace = true }
 containerd-shim-protos = "0.1"
-anyhow = "1.0"
-serde_json = "1.0"
-oci-spec = "0.5"
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+oci-spec = { workspace = true }
 command-fds = "0.2"
-serde = "1.0"
-thiserror = "1.0"
+serde = { workspace = true }
+thiserror = { workspace = true }
 protobuf = "2.23"
-ttrpc = "0.6"
-nix = "0.25"
-cap-std = "0.24"
-chrono = "0.4"
-log = "0.4"
+ttrpc = { workspace = true }
+nix = { workspace = true }
+chrono = { workspace = true }
+log = { workspace = true }
 clone3 = "0.2"
-libc = "0.2"
+libc = { workspace = true }
 caps = "0.1"
 proc-mounts = "0.3"
 thirdparty = { path = "../thirdparty" }
@@ -34,7 +33,7 @@ ttrpc-codegen = { version = "0.3", optional = true }
 tempfile = "3"
 pretty_assertions = "1"
 signal-hook = "0.3"
-env_logger = "0.10"
+env_logger = { workspace = true }
 rand = "0.8"
 
 [features]

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -146,7 +146,7 @@ mod noptests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use libc::{SIGHUP};
+    use libc::SIGHUP;
 
     use super::*;
 

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -1,10 +1,9 @@
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::cgroups;
 use super::error::Result;
 use anyhow::Context;
-use cap_std::path::PathBuf;
 use nix::{sys::signal, unistd::Pid};
 pub use oci_spec::runtime::Spec;
 use serde_json as json;

--- a/crates/oci-tar-builder/Cargo.toml
+++ b/crates/oci-tar-builder/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "oci-tar-builder"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-tar = "0.4"
-sha256 = "1.1"
-log = "0.4"
-env_logger = "0.10"
-oci-spec =  "0.5"
-anyhow = "1.0"
-serde = "1.0"
-serde_json = "1.0"
+tar = { workspace = true }
+sha256 = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+oci-spec =  { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/thirdparty/Cargo.toml
+++ b/crates/thirdparty/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "thirdparty"
-version = "0.1.0"
+version.workspace = true
 description = "Collections from thirdparty code"
 license-file = "../../LICENSE"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
-oci-spec = "0.5"
+oci-spec = { workspace = true }
 nix = "0.25"

--- a/crates/wasi-demo-app/Cargo.toml
+++ b/crates/wasi-demo-app/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "wasi-demo-app"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [build-dependencies]
-tar = { version = "0.4", optional = true }
-sha256 = { version = "1.1", optional = true }
-log = { version = "0.4", optional = true }
-env_logger = { version = "0.10", optional = true }
-oci-spec = { version = "0.5", optional = true }
+tar = { workspace = true, optional = true }
+sha256 = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
+env_logger = { workspace = true, optional = true }
+oci-spec = { workspace = true, optional = true }
 oci-tar-builder = { optional = true, path = "../oci-tar-builder" }
-anyhow = { version = "1.0", optional = true }
+anyhow = { workspace = true, optional = true }
 
 
 

--- a/crates/wasmedge/Cargo.toml
+++ b/crates/wasmedge/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "runwasmedge"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-containerd-shim = "0.3.0"
+containerd-shim ={ workspace = true }
 containerd-shim-wasm = { path = "../containerd-shim-wasm" }
-log = "0.4"
-ttrpc = "0.6"
+log = { workspace = true }
+ttrpc = { workspace = true }
 wasmedge-sdk = { version = "0.7.1", features = ["async"] }
-chrono = "0.4"
-anyhow = "1.0"
-cap-std = "0.26"
-oci-spec = { version = "0.5", features = ["runtime"] }
-thiserror = "1.0"
-serde_json = "1.0"
-libc = "0.2.138"
+chrono = { workspace = true }
+anyhow = { workspace = true }
+cap-std = { workspace = true }
+oci-spec = { workspace = true, features = ["runtime"] }
+thiserror = { workspace = true }
+serde_json = { workspace = true }
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "runwasmtime"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-containerd-shim = "0.3.0"
+containerd-shim = { workspace = true }
 containerd-shim-wasm = { path = "../containerd-shim-wasm" }
-log = "0.4"
-ttrpc = "0.6"
+log = { workspace = true }
+ttrpc = { workspace = true }
 wasmtime = "2.0"
 wasmtime-wasi = "2.0"
 wasi-common = "2.0"
-chrono = "0.4"
-anyhow = "1.0"
-cap-std = "0.26"
-oci-spec = { version = "0.5", features = ["runtime"] }
-thiserror = "1.0"
-serde_json = "1.0"
-nix = "0.25"
+chrono = { workspace = true }
+anyhow = { workspace = true }
+cap-std = { workspace = true }
+oci-spec = { workspace = true, features = ["runtime"] }
+thiserror = { workspace = true }
+serde_json = { workspace = true }
+nix = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.0"
-libc = "0.2"
+libc = { workspace = true }
 pretty_assertions = "1"
 
 [[bin]]


### PR DESCRIPTION
This PR also modifies `use cap_std::path::PathBuf` to `std::fs::PathBuf` since it's removed from `cap_std` since `0.25`.

Signed-off-by: jiaxiao zhou <jiazho@microsoft.com>