### PR TITLE
feat: add k3s test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,48 @@ test/k8s/deploy: test/k8s/cluster
 .PHONY: test/k8s/clean
 test/k8s/clean:
 	kind delete cluster --name $(KIND_CLUSTER_NAME)
+
+.PHONY: bin/wasmedge
+bin/wasmedge:
+	curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p $(PWD)/bin/wasmedge && \
+	sudo -E sh -c 'echo "$(PWD)/bin/wasmedge/lib" > /etc/ld.so.conf.d/libwasmedge.conf' && sudo ldconfig
+
+.PHONY: bin/wasmedge/clean
+bin/wasmedge/clean:
+	sudo rm /etc/ld.so.conf.d/libwasmedge.conf && sudo ldconfig
+	curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh | bash -s -- -p $(PWD)/bin/wasmedge -q
+
+.PHONY: bin/k3s
+bin/k3s:
+	mkdir -p bin && \
+	curl -sfL https://get.k3s.io | INSTALL_K3S_BIN_DIR=$(PWD)/bin INSTALL_K3S_SYMLINK=skip INSTALL_K3S_NAME=runwasi sh -
+
+.PHONY: bin/k3s/clean
+bin/k3s/clean:
+	bin/k3s-runwasi-uninstall.sh
+
+.PHONY: test/k3s
+test/k3s: target/wasm32-wasi/$(TARGET)/img.tar bin/wasmedge bin/k3s
+	export WASMEDGE_INCLUDE_DIR=$(PWD)/bin/wasmedge/include && \
+	export WASMEDGE_LIB_DIR=$(PWD)/bin/wasmedge/lib && \
+	cargo build $(RELEASE_FLAG) && \
+	cp target/$(TARGET)/containerd-shim-wasmedge-v1 $(PWD)/bin/ && \
+	sudo cp /var/lib/rancher/k3s/agent/etc/containerd/config.toml /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
+	echo '[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
+	echo '  runtime_type = "$(PWD)/bin/containerd-shim-wasmedge-v1"' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
+	echo '  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm.options]' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
+	echo '    BinaryName = "$(PWD)/bin/wasmedge/bin/wasmedge"' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
+	echo "CONTAINERD_NAMESPACE='default'" | sudo tee /etc/systemd/system/k3s-runwasi.service.env && \
+	echo "NO_PROXY=192.168.0.0/16" | sudo tee -a /etc/systemd/system/k3s-runwasi.service.env && \
+	sudo systemctl daemon-reload && \
+	sudo systemctl restart k3s-runwasi && \
+	sudo bin/k3s ctr image import --all-platforms target/wasm32-wasi/$(TARGET)/img.tar && \
+	sudo bin/k3s kubectl apply -f test/k8s/deploy.yaml
+	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=90s && \
+	sudo bin/k3s kubectl get pods -o wide
+
+.PHONY: test/k3s/clean
+test/k3s/clean: bin/wasmedge/clean bin/k3s/clean
+	cargo clean
+	unset WASMEDGE_INCLUDE_DIR WASMEDGE_LIB_DIR
+	rm $(PWD)/bin/containerd-shim-wasmedge-v1


### PR DESCRIPTION
k3s is newbee friendly and production available. To avoid polluting the system, the binaries of k3s and wasmedge are downloaded to the bin folder, and k3s service renamed to k3s-runwasi.
Since k3s only support linux, this test can only run in linux platform. For macos platform [multipass](https://multipass.run/) or [lima](https://github.com/lima-vm/lima) needed. For windows platform wsl2 needed.