### PR TITLE
Update nix and oci-spec dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.23.2",
- "oci-spec",
+ "oci-spec 0.5.8",
  "prctl",
  "serde",
  "serde_derive",
@@ -371,8 +371,8 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
- "nix 0.25.1",
- "oci-spec",
+ "nix 0.26.2",
+ "oci-spec 0.6.0",
  "pretty_assertions",
  "proc-mounts",
  "protobuf",
@@ -680,7 +680,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.11.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -696,12 +705,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.11.2",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
  "syn",
 ]
 
@@ -1385,20 +1416,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
- "bitflags",
- "cfg-if 1.0.0",
- "libc",
- "memoffset 0.6.5",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -1479,7 +1496,20 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98135224dd4faeb24c05a2fac911ed53ea6b09ecb09d7cada1cb79963ab2ee34"
 dependencies = [
- "derive_builder",
+ "derive_builder 0.11.2",
+ "getset",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214b837f7dde5026f2028ead5ae720073277c19f82ff85623b142c39d4b843e7"
+dependencies = [
+ "derive_builder 0.12.0",
  "getset",
  "serde",
  "serde_json",
@@ -1493,7 +1523,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "log",
- "oci-spec",
+ "oci-spec 0.6.0",
  "serde",
  "serde_json",
  "sha256",
@@ -1888,7 +1918,7 @@ dependencies = [
  "containerd-shim-wasm",
  "libc",
  "log",
- "oci-spec",
+ "oci-spec 0.6.0",
  "pretty_assertions",
  "serde_json",
  "serial_test",
@@ -1909,8 +1939,8 @@ dependencies = [
  "containerd-shim-wasm",
  "libc",
  "log",
- "nix 0.25.1",
- "oci-spec",
+ "nix 0.26.2",
+ "oci-spec 0.6.0",
  "pretty_assertions",
  "serde_json",
  "tempfile",
@@ -2204,8 +2234,8 @@ dependencies = [
 name = "thirdparty"
 version = "0.1.0"
 dependencies = [
- "nix 0.25.1",
- "oci-spec",
+ "nix 0.26.2",
+ "oci-spec 0.6.0",
 ]
 
 [[package]]
@@ -2475,7 +2505,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "log",
- "oci-spec",
+ "oci-spec 0.6.0",
  "oci-tar-builder",
  "sha256",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ tar = "0.4"
 containerd-shim = "0.3.0"
 ttrpc = "0.6"
 chrono = "0.4"
-nix = "0.25"
+nix = "0.26"
 cap-std = "0.26"
 thiserror = "1.0"
 libc = "0.2.138"
-oci-spec = "0.5"
+oci-spec = "0.6"
 sha256 = "1.1"
 
 [profile.release]

--- a/crates/thirdparty/Cargo.toml
+++ b/crates/thirdparty/Cargo.toml
@@ -7,4 +7,4 @@ edition.workspace = true
 
 [dependencies]
 oci-spec = { workspace = true }
-nix = "0.25"
+nix = { workspace = true }


### PR DESCRIPTION
Updates nix and oci-spec dependencies by makeing the thrid party crate use the same dep as rest of the workspace.