### PR TITLE
Add cargo publish step to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,35 @@ jobs:
       crate: ${{ steps.parse-ref.outputs.crate }}
       version: ${{ steps.parse-ref.outputs.version }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - id: parse-ref
+        name: Parse ref
         run: |
-          echo "CRATE=$(cut -d/ -f1 <<<"${GITHUB_REF#refs/*/}")" >> $GITHUB_OUTPUT
-          echo "VERSION=$(cut -d/ -f2 <<<"${GITHUB_REF#refs/*/}")" >> $GITHUB_OUTPUT
+          set -e
+
+          CRATE="$(cut -d/ -f1 <<<"${GITHUB_REF#refs/*/}")"
+          VERSION="$(cut -d/ -f2 <<<"${GITHUB_REF#refs/*/}")"
+
+          if [ -z "${CRATE}" ]; then
+            echo "::error::Could not determine crate name from ref '${GITHUB_REF}'"
+            exit 1
+          fi
+
+          if [ -z "${VERSION}" ]; then
+            echo "::error::Could not determine version from ref '${GITHUB_REF}'"
+            exit 1
+          fi
+
+          echo "CRATE=${CRATE}" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+          setVersion="$(./scripts/version.sh "${CRATE}")"
+          if [ ! "${VERSION#v}" = "${setVersion}" ]; then
+            echo "::error::Version mismatch: tag version ${VERSION#v} != crate version ${setVersion}"
+            exit 1
+          fi
 
   build:
     needs:
@@ -34,6 +59,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ needs.generate.outputs.crate }}
       - name: "check cgroup version"
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3
@@ -64,7 +91,7 @@ jobs:
       - name: Setup buildx
         run: docker buildx create --use
       - name: build binaries
-        run: docker buildx bake --set *.cache-from=type=gha --set *.cache-to=type=gha release-tars
+        run: docker buildx bake --set *.cache-from=type=gha,scope=buildkit-release-${CRATE} --set *.cache-to=type=gha,scope=buildkit-release-${CRATE} release-tars
         env:
           CRATE: ${{ needs.generate.outputs.crate }}
       - name: upload binary as GitHub artifact
@@ -81,3 +108,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NAME: ${{ needs.generate.outputs.crate }}/${{ needs.generate.outputs.version }}
+      - name: Cargo publish
+        run: cargo publish --package ${{ needs.generate.outputs.crate }} --verbose --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
+      - name: Check crates.io ownership
+        run: |
+          cargo owner --list ${{ needs.generate.outputs.crate }} | grep github:containerd:runwasi-committers
+          if [ $? -ne 0 ]; then
+            cargo owner --add ${{ github.actor }} ${{ needs.generate.outputs.crate }}
+          fi
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,47 @@
+# Releasing a new crate version
+
+This document describes the steps to release a new version of the crate.
+
+## Overview
+
+Releases are handled by the [release](.github/workflows/release.yml) GitHub actions workflow.
+The workflow is triggered when a new tag is pushed to the repository following the pattern `<crate>/v<version>`.
+
+In the future we may include a workflow for tagging the release but for now this is manual.
+
+The release workflow will:
+- Build the crate to be released (determined by the tag)
+- Run the tests for that crate (and only that crate!)
+- Build any associated release artifacts (e.g. the containerd-shim-wasmtime crate includes several binaries).
+- Publish the crate to crates.io
+
+The workflow utilizes a bot account (@containerd-runwasi-release-bot) to publish the crate to crates.io. The bot account is only used to get a limited-scope API token to publish the crate on crates.io. The token is stored as a secret in the repository and is only used by the release workflow.
+
+## Steps
+
+1. Open a PR to bump crate version in the Cargo.toml for that crate.
+2. PR can be merged after 2 LGTMs
+3. Tag the release with the format `<crate>/v<version>` (e.g. `containerd-shim-wasm/v0.2.0`)
+4. Wait for the release workflow to complete
+5. Manually verify the release on crates.io and on the GitHub releases page.
+6. If this is the first time publishing this crate, see the [First release of a crate](#First-release-of-a-crate) section.
+
+If step 1 and/or 2 is skipped, the release workflow will fail because the version in the Cargo.toml will not match the tag.
+
+For step 5, some crates have binaries, such as the containerd-shim-wasmtime crate. These binaries are built as part of the release workflow and uploaded to the GitHub release page. You can download the binaries from the release page and verify that they work as expected.
+
+## First release of a crate
+
+If the crate has never been published to crates.io before then ownership of the crate will need to be configured.
+The containerd/runwasi-committers team will need to be added as an owner of the crate.
+The release workflow will automatically invite the person who triggered the worrkflow run to be an owner of the crate.
+That person will need to accept the invite to be an owner of the crate and then manually add the containerd/runwasi-committers team as an owner of the crate.
+
+```
+cargo owner --add github:containerd:runwasi-committers <crate-name>
+```
+
+*This assumes you've already done `cargo login` with your personal account.
+Alternatively, the cargo cli does support setting the token via an environment variable, `CARGO_REGISTRY_TOKEN` or as a CLI flag.*
+
+Now all members of the containerd/runwasi-committers team will have access to manage the crate (after they have accepted the invite to the crate).

--- a/scripts/bins.jq
+++ b/scripts/bins.jq
@@ -1,3 +1,0 @@
-def filter_by_package(package): if package != "" then map(select(.name == package)) else . end;
-
-.packages | filter_by_package($CRATE) | map(.targets | map(select(.kind[] | contains("bin")).name))[] | select(length > 0)

--- a/scripts/bins.sh
+++ b/scripts/bins.sh
@@ -3,4 +3,11 @@
 # Get the list of binaries from the Cargo.toml file.
 # If targeting a specific crate, pass the crate name as the first argument.
 
-cargo metadata --format-version=1 | jq --arg CRATE "${1}" -f ./scripts/bins.jq
+read -r -d '' Q <<-'EOF'
+include "crates";
+.packages | filter_by_package($CRATE) | get_bins
+EOF
+
+set -e -o pipefail
+
+cargo metadata --format-version=1 --no-deps | jq -L "${BASH_SOURCE[0]%/*}" --arg CRATE "${1}" "${Q}" | jq -s 'if length > 0 then add | sort else . end'

--- a/scripts/crates.jq
+++ b/scripts/crates.jq
@@ -1,0 +1,3 @@
+def filter_by_package(package): if package != "" then map(select(.name == package)) else . end;
+
+def get_bins: map(.targets | map(select(.kind[] | contains("bin")).name))[] | select(length > 0);

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Get the list of binaries from the Cargo.toml file.
+# If targeting a specific crate, pass the crate name as the first argument.
+
+read -r -d '' Q <<-'EOF'
+include "crates";
+.packages | filter_by_package($CRATE)[0].version
+EOF
+
+set -u -e -o pipefail
+
+cargo metadata --format-version=1 --no-deps | jq -r -L "${BASH_SOURCE[0]%/*}" --arg CRATE "${1}" "${Q}"


### PR DESCRIPTION
Example successful run: https://github.com/cpuguy83/runwasi-fork/actions/runs/4347852402'
crates.io package: https://crates.io/crates/containerd-shim-wasm/versions

Note I yanked the version because it is technically incorrect since I did not set the version in Cargo.toml.
And here is a run where I added validation to ensure the Cargo.toml version matches the tag: https://github.com/cpuguy83/runwasi-fork/actions/runs/4348574593

To support this without having to create an API token from my personal account, I setup a bot account @containerd-runwasi-release-bot which has 2FA enabled.

Additionally once the crates.io package was created I manually set the owners of the package:

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/799078/223272062-8fd26bdd-ea31-474a-9cdc-c13103fbb6a1.png">

This will need to be done for the first release on crates.io for each new crate.

Also just to note, containerd-shim-wasm must first be released then the other crates need to be updated to include an explicit version of that crate before we can release those.

Closes #13