### PR TITLE
Release containerd-shim-wasm v0.1.0

### DIFF
--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "containerd-shim-wasm"
 description = "Library for building containerd shims for wasm"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 readme.workspace = true
 homepage.workspace = true
 repository.workspace = true
-
 
 [lib]
 doctest = false


### PR DESCRIPTION
Sets containerd-shim-wasm crate's version so it can be tagged and published to crates.io