### PR TITLE
Fix code docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           command: build
           args: --all --verbose
+      - name: Validate docs
+        run: ./scripts/validate-docs.sh
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "caps",

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -4,7 +4,7 @@ description = "Library for building containerd shims for wasm"
 version = "0.1.1"
 edition.workspace = true
 license.workspace = true
-readme.workspace = true
+readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
 
@@ -42,3 +42,4 @@ rand = "0.8"
 [features]
 default = []
 generate_bindings = ["ttrpc-codegen"]
+generate_doc = []

--- a/crates/containerd-shim-wasm/README.md
+++ b/crates/containerd-shim-wasm/README.md
@@ -1,0 +1,40 @@
+![runwasi logo](../../art/logo/runwasi_logo_icon.svg)
+
+# containerd-shim-wasm
+
+A library to help build containerd shims for wasm workloads.
+
+## Usage
+
+```rust
+use containerd_shim as shim;
+use containerd_shim_wasm::sandbox::{ShimCli, Instance, Nop}
+
+fn main() {
+    shim::run::<ShimCli<Nop>>("io.containerd.nop.v1", opts);
+}
+```
+
+The above example uses the built-in `Nop` instance which does nothing.
+You can build your own instance by implementing the `Instance` trait.
+
+```rust
+use containerd_shim as shim;
+use containerd_shim_wasm::sandbox::{ShimCli, Instance}
+
+struct MyInstance {
+ // ...
+}
+
+impl Instance for MyInstance {
+    // ...
+}
+
+fn main() {
+    shim::run::<ShimCli<MyInstance>>("io.containerd.myshim.v1", opts);
+}
+```
+
+containerd expects the shim binary to be installed into `$PATH` (as seen by the containerd process) with a binary name like `containerd-shim-myshim-v1` which maps to the `io.containerd.myshim.v1` runtime which would need to be configured in containerd. It (containerd) also supports specifying a path to the shim binary but needs to be configured to do so.
+
+This crate is not tied to any specific wasm engine.

--- a/crates/containerd-shim-wasm/build.rs
+++ b/crates/containerd-shim-wasm/build.rs
@@ -5,7 +5,18 @@ use std::fs;
 use ttrpc_codegen::{Codegen, ProtobufCustomize};
 
 #[cfg(not(feature = "generate_bindings"))]
+#[cfg(not(feature = "generate_doc"))]
 fn main() {}
+
+#[cfg(feature = "generate_doc")]
+fn main() {
+    use std::io::Write;
+    println!("cargo:rerun-if-changed=doc");
+    println!("cargo:rerun-if-missing=README.md");
+    let mut f = std::fs::File::create("README.md").unwrap();
+    f.write_all(include_bytes!("doc/header.md")).unwrap();
+    f.write_all(include_bytes!("doc/doc.md")).unwrap();
+}
 
 #[cfg(feature = "generate_bindings")]
 fn main() {

--- a/crates/containerd-shim-wasm/doc/doc.md
+++ b/crates/containerd-shim-wasm/doc/doc.md
@@ -1,0 +1,36 @@
+A library to help build containerd shims for wasm workloads.
+
+## Usage
+
+```rust
+use containerd_shim as shim;
+use containerd_shim_wasm::sandbox::{ShimCli, Instance, Nop}
+
+fn main() {
+    shim::run::<ShimCli<Nop>>("io.containerd.nop.v1", opts);
+}
+```
+
+The above example uses the built-in `Nop` instance which does nothing.
+You can build your own instance by implementing the `Instance` trait.
+
+```rust
+use containerd_shim as shim;
+use containerd_shim_wasm::sandbox::{ShimCli, Instance}
+
+struct MyInstance {
+ // ...
+}
+
+impl Instance for MyInstance {
+    // ...
+}
+
+fn main() {
+    shim::run::<ShimCli<MyInstance>>("io.containerd.myshim.v1", opts);
+}
+```
+
+containerd expects the shim binary to be installed into `$PATH` (as seen by the containerd process) with a binary name like `containerd-shim-myshim-v1` which maps to the `io.containerd.myshim.v1` runtime which would need to be configured in containerd. It (containerd) also supports specifying a path to the shim binary but needs to be configured to do so.
+
+This crate is not tied to any specific wasm engine.

--- a/crates/containerd-shim-wasm/doc/header.md
+++ b/crates/containerd-shim-wasm/doc/header.md
@@ -1,0 +1,4 @@
+![runwasi logo](../../art/logo/runwasi_logo_icon.svg)
+
+# containerd-shim-wasm
+

--- a/crates/containerd-shim-wasm/src/lib.rs
+++ b/crates/containerd-shim-wasm/src/lib.rs
@@ -1,3 +1,8 @@
+#![doc = include_str!("../doc/doc.md")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/containerd/runwasi/e251de3307bbdc8bf3229020ea2ae2711f31aafa/art/logo/runwasi_logo_icon.svg"
+)]
+
 pub mod sandbox;
 
 pub mod services;

--- a/crates/containerd-shim-wasm/src/lib.rs
+++ b/crates/containerd-shim-wasm/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod sandbox;
+
 pub mod services;

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv1.rs
@@ -1,3 +1,5 @@
+//! Module for interacting with and applying OCI specs for cgroups v1.
+
 use super::super::{Error, Result};
 use super::{
     ensure_write_file, find_cgroup_mounts, list_cgroup_controllers, new_mount_iter, safe_join,
@@ -11,6 +13,7 @@ use std::io::prelude::Write;
 use std::ops::Not;
 use std::path::PathBuf;
 
+// Manager for a cgroup v1 hierarchy.
 pub struct CgroupV1 {
     path: PathBuf,
     controllers: HashMap<String, PathBuf>,

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/cgroupv2.rs
@@ -1,3 +1,5 @@
+//! Module for interacting with and applying OCI specs for cgroups v2.
+
 use super::super::{Error, Result};
 use super::RawFD;
 use super::{
@@ -11,6 +13,7 @@ use std::fs;
 use std::ops::Not;
 use std::path::PathBuf;
 
+/// Manages a cgroup v2 heirarchy.
 pub struct CgroupV2 {
     base: PathBuf,
     path: PathBuf,

--- a/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cgroups/mod.rs
@@ -1,3 +1,6 @@
+//! This module provides a unified interface for interacting with cgroup v1 and v2.
+//! cgroup version can be automatically detected, or can be specified by the caller by using the specific cgroup submodules.
+
 use super::{Error, Result};
 use nix::sys::statfs;
 pub use oci_spec::runtime::LinuxResources as Resources;
@@ -40,6 +43,7 @@ fn new_mount_iter() -> Result<MountIter<FileMountIter>> {
     Ok(MountIter::new()?)
 }
 
+/// Abstracts cgroup operations so we can support both cgroups v1 and v2.
 pub trait Cgroup {
     fn version(&self) -> Version;
 

--- a/crates/containerd-shim-wasm/src/sandbox/error.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/error.rs
@@ -1,3 +1,6 @@
+//! Error types used by shims
+//! This handles converting to the appropriate ttrpc error codes
+
 use anyhow::Error as AnyError;
 use containerd_shim::Error as ShimError;
 use oci_spec::OciSpecError;
@@ -6,26 +9,36 @@ use ttrpc;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    /// An error occurred while parsing the OCI spec
     #[error("{0}")]
     Oci(#[from] OciSpecError),
+    /// An error that can occur while setting up the environment for the container
     #[error("{0}")]
     Stdio(#[from] std::io::Error),
     #[error("{0}")]
     Others(String),
+    /// Errors to/from the containerd shim library.
     #[error("{0}")]
     Shim(#[from] ShimError),
+    /// Requested item is not found
     #[error("not found: {0}")]
     NotFound(String),
+    /// Requested item already exists
     #[error("already exists: {0}")]
     AlreadyExists(String),
+    /// Supplied arguments/options/config is invalid
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
+    /// Any other error
     #[error("{0}")]
     Any(#[from] AnyError),
+    /// The operation was rejected because the system is not in a state required for the operation's
     #[error("{0}")]
     FailedPrecondition(String),
+    /// Error while parsing JSON
     #[error("{0}")]
     Json(#[from] serde_json::Error),
+    /// Error from the system
     #[error("{0}")]
     Errno(#[from] nix::errno::Errno),
 }

--- a/crates/containerd-shim-wasm/src/sandbox/manager.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/manager.rs
@@ -1,3 +1,7 @@
+//! This experimental module implements a manager service which can be used to
+//! manage multiple instances of a sandbox in-process.
+//! The idea behind this module is to only need a single shim process for the entire node rather than one per pod/container.
+
 use std::collections::HashMap;
 use std::env::current_dir;
 use std::fs::File;
@@ -27,6 +31,7 @@ use super::oci;
 use super::sandbox;
 use crate::services::sandbox_ttrpc::{Manager, ManagerClient};
 
+/// Sandbox wraps an Instance and is used with the `Service` to manage multiple instances.
 pub trait Sandbox<E>: Task + Send + Sync
 where
     E: Send + Sync + Clone,
@@ -36,6 +41,7 @@ where
     fn new(namespace: String, id: String, engine: E, publisher: RemotePublisher) -> Self;
 }
 
+/// Service is a manager service which can be used to manage multiple instances of a sandbox in-process.
 pub struct Service<E, T>
 where
     E: Send + Sync + Clone,

--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -1,3 +1,5 @@
+//! Abstracts the sandboxing environment and execution context for a container.
+
 use crate::services::sandbox;
 
 pub mod cgroups;

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -1,3 +1,5 @@
+//! Generic helpers for working with OCI specs that can be consumed by any runtime.
+
 use std::fs::File;
 use std::path::{Path, PathBuf};
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -1,3 +1,7 @@
+//! The shim is the entrypoint for the containerd shim API. It is responsible
+//! for commmuincating with the containerd daemon and managing the lifecycle of
+//! the container/sandbox.
+
 use std::collections::HashMap;
 use std::env::current_dir;
 use std::fs::{self, File};
@@ -1307,7 +1311,7 @@ fn setup_namespaces(spec: &runtime::Spec) -> Result<()> {
     Ok(())
 }
 
-// Cli implements the containerd-shim cli interface using Local<T> as the task service.
+/// Cli implements the containerd-shim cli interface using `Local<T>` as the task service.
 pub struct Cli<T, E>
 where
     T: Instance<E = E> + Sync + Send,

--- a/crates/containerd-shim-wasm/src/sandbox/testutil.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/testutil.rs
@@ -1,6 +1,11 @@
+//! Testing utilities used across different modules
+
 use super::{Error, Result};
 use std::process::{Command, Stdio};
 
+/// Re-execs the current process with sudo and runs the given test.
+/// Unless this is run in a CI environment, this may prompt the user for a password.
+/// This is significantly faster than expecting the user to run the tests with sudo due to build and crate caching.
 pub fn run_test_with_sudo(test: &str) -> Result<()> {
     // This uses piped stdout/stderr.
     // This makes it so cargo doesn't mess up the caller's TTY.

--- a/crates/containerd-shim-wasm/src/services.rs
+++ b/crates/containerd-shim-wasm/src/services.rs
@@ -1,2 +1,4 @@
+//! Generated service definitions from the protobuf definitions.
+
 pub mod sandbox;
 pub mod sandbox_ttrpc;

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+cargo build --all --verbose --features generate_doc
+git status --porcelain | grep README.md || exit 0
+
+echo "README.md is not up to date. Please run 'cargo build --all --features generate_doc' and commit the changes." >&2
+exit 1


### PR DESCRIPTION
1. Docs were using godoc style docs rather than rustdoc, so were not being picked up by rustdoc
2. Added some missing docs
3. Gave containerd-shim-wasm crate its own README.md so it makes more sense on crates.io


Example rustdoc:

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/799078/223555218-68eb5720-b7fb-4c3f-85c8-6b1996491a17.png">
