### PR TITLE
Incorrect expansion of the `$HOME` variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Instead of enabling docker-desktop official released feature `use containerd for
 
 ```terminal
 $ curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash
-$ sudo -E sh -c 'echo "$HOME/.wasmedge/lib" > /etc/ld.so.conf.d/libwasmedge.conf'
+$ echo "$HOME/.wasmedge/lib" | sudo tee /etc/ld.so.conf.d/libwasmedge.conf
 $ sudo ldconfig
 ```
 


### PR DESCRIPTION
From ` sudo -E sh -c 'echo $HOME'` we always get `/root`.
Normally the use of `sudo echo "text" > filename` is not a great idea and something like `echo "text" | sudo tee filename` might be preferable.