### PR TITLE
Missing release flag option for some targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,11 @@ install:
 
 .PHONY: target/wasm32-wasi/$(TARGET)/wasi-demo-app.wasm
 target/wasm32-wasi/$(TARGET)/wasi-demo-app.wasm:
-	cd crates/wasi-demo-app && cargo build
+	cd crates/wasi-demo-app && cargo build $(RELEASE_FLAG)
 
 .PHONY: target/wasm32-wasi/$(TARGET)/img.tar
 target/wasm32-wasi/$(TARGET)/img.tar: target/wasm32-wasi/$(TARGET)/wasi-demo-app.wasm
-	cd crates/wasi-demo-app && cargo build --features oci-v1-tar
+	cd crates/wasi-demo-app && cargo build $(RELEASE_FLAG) --features oci-v1-tar
 
 load: target/wasm32-wasi/$(TARGET)/img.tar
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import --all-platforms $<


### PR DESCRIPTION
These targets fail to compile in release mode. Any build command should contain `$(RELEASE_FLAG)`.