### PR TITLE
Enable WasmEdge roofs support and start writing OCI tests for Wasmedge and Wasmtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
           args: --all --verbose
       - name: Validate docs
         run: ./scripts/validate-docs.sh
+      - name: Setup rust-wasm target and compile test modules
+        run: |
+          rustup target add wasm32-wasi
+          make test/wasm-modules
       - name: Run tests
         run: |
           make test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,6 +2962,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi-modules-for-testing"
+version = "0.1.0"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "containerd-shim-wasm",
+ "containerd-shim-wasmedge",
+ "containerd-shim-wasmtime",
+ "libc",
+ "oci-spec",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "wasmedge-sdk",
+ "wasmtime",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/oci-tar-builder",
     "crates/containerd-shim-wasmedge",
     "crates/containerd-shim-wasmtime",
+    "test/wasi-modules-for-testing",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/containerd-shim-wasmedge",
     "crates/containerd-shim-wasmtime",
     "test/wasi-modules-for-testing",
+    "test/oci-tests",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ test/k8s: test/k8s/cluster
 test/k8s/clean: bin/kind
 	bin/kind delete cluster --name $(KIND_CLUSTER_NAME)
 
+test/wasm-modules:
+	cargo build -p wasi-modules-for-testing --target wasm32-wasi
+
 .PHONY: bin/k3s
 bin/k3s:
 	mkdir -p bin && \

--- a/crates/containerd-shim-wasmedge/src/executor.rs
+++ b/crates/containerd-shim-wasmedge/src/executor.rs
@@ -71,7 +71,7 @@ impl WasmEdgeExecutor {
         wasi_module.initialize(
             Some(args.iter().map(|s| s as &str).collect()),
             Some(envs.iter().map(|s| s as &str).collect()),
-            None,
+            Some(vec!["/:/"]), // map the container root filesystem to be available to the WASI module
         );
         let vm = vm
             .register_module_from_file("main", cmd)

--- a/test/oci-tests/Cargo.toml
+++ b/test/oci-tests/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "oci-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+containerd-shim-wasm = { path = "../../crates/containerd-shim-wasm" }
+containerd-shim-wasmedge = { path = "../../crates/containerd-shim-wasmedge" }
+containerd-shim-wasmtime = { path = "../../crates/containerd-shim-wasmtime" }
+libc = { workspace = true }
+oci-spec = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = "3.0"
+wasmedge-sdk = { version = "0.10.1", features = [ "standalone", "static" ] }
+wasmtime = { version = "11.0", default-features = false, features = [
+    'cache',
+    'wat',
+    'jitdump',
+    'parallel-compilation',
+    'cranelift',
+    'pooling-allocator',
+    'vtune',
+]}
+
+[dev-dependencies]
+tempfile = "3.0"
+pretty_assertions = "1"
+serial_test = "*"

--- a/test/oci-tests/tests/common/mod.rs
+++ b/test/oci-tests/tests/common/mod.rs
@@ -1,0 +1,100 @@
+use std::fs::{create_dir, read_to_string, File, OpenOptions};
+use std::io::prelude::*;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+use libc::SIGKILL;
+use oci_spec::runtime::Spec;
+use serde::{Deserialize, Serialize};
+use tempfile::tempdir;
+
+use containerd_shim_wasm::sandbox::instance::Wait;
+use containerd_shim_wasm::sandbox::{EngineGetter, Error, Instance, InstanceConfig};
+
+#[derive(Serialize, Deserialize)]
+struct Options {
+    root: Option<PathBuf>,
+}
+
+pub static WASM_FILENAME: &str = "./file.wasm";
+
+pub(crate) fn get_external_wasm_module(name: String) -> Result<Vec<u8>, Error> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let target = Path::new(manifest_dir)
+        .join("../../target/wasm32-wasi/debug")
+        .join(name.clone());
+    std::fs::read(target).map_err(|e| {
+            Error::Others(format!(
+                "failed to read requested Wasm module ({}): {}. Perhaps you need to run 'make test/wasm-modules' first.",
+                name, e
+            ))
+        })
+}
+
+pub(crate) fn run_test_with_spec<I, E>(spec: &Spec, bytes: &[u8]) -> Result<(String, u32), Error>
+where
+    I: Instance<E = E> + EngineGetter<E = E>,
+    E: Sync + Send + Clone,
+{
+    let dir = tempdir().unwrap();
+    create_dir(dir.path().join("rootfs"))?;
+    let rootdir = dir.path().join("runwasi");
+    create_dir(&rootdir)?;
+    let opts = Options {
+        root: Some(rootdir),
+    };
+    let opts_file = OpenOptions::new()
+        .read(true)
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(dir.path().join("options.json"))?;
+    write!(&opts_file, "{}", serde_json::to_string(&opts)?)?;
+
+    let wasm_path = dir.path().join("rootfs").join(WASM_FILENAME);
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(wasm_path)?;
+    f.write_all(bytes)?;
+
+    let stdout = File::create(dir.path().join("stdout"))?;
+    drop(stdout);
+
+    spec.save(dir.path().join("config.json"))?;
+
+    let mut cfg = InstanceConfig::new(
+        I::new_engine()?,
+        "test_namespace".into(),
+        "/containerd/address".into(),
+    );
+    let cfg = cfg
+        .set_bundle(dir.path().to_str().unwrap().to_string())
+        .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string());
+
+    let wasi = I::new("test".to_string(), Some(cfg));
+
+    wasi.start()?;
+
+    let (tx, rx) = channel();
+    let waiter = Wait::new(tx);
+    wasi.wait(&waiter).unwrap();
+
+    let res = match rx.recv_timeout(Duration::from_secs(600)) {
+        Ok(res) => res,
+        Err(e) => {
+            wasi.kill(SIGKILL as u32).unwrap();
+            return Err(Error::Others(format!(
+                "error waiting for module to finish: {0}",
+                e
+            )));
+        }
+    };
+    wasi.delete()?;
+    let output = read_to_string(dir.path().join("stdout"))?;
+    Ok((output, res.0))
+}

--- a/test/oci-tests/tests/devices.rs
+++ b/test/oci-tests/tests/devices.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder};
+use wasmedge_sdk::Vm as WasmEdgeVm;
+use wasmtime::Engine as WasmtimeVm;
+
+use containerd_shim_wasm::function;
+use containerd_shim_wasm::sandbox::testutil::{has_cap_sys_admin, run_test_with_sudo};
+use containerd_shim_wasm::sandbox::Error;
+
+use containerd_shim_wasmedge::instance::Wasi as WasmEdgeWasi;
+use containerd_shim_wasmtime::instance::Wasi as WasmtimeWasi;
+
+#[derive(Serialize, Deserialize)]
+struct Options {
+    root: Option<PathBuf>,
+}
+
+mod common;
+
+#[test]
+#[serial]
+fn test_has_default_devices() -> Result<(), Error> {
+    if !has_cap_sys_admin() {
+        println!("running test with sudo: {}", function!());
+        return run_test_with_sudo("test_has_default_devices");
+    }
+
+    let wasmbytes = common::get_external_wasm_module("has-default-devices.wasm".to_string())?;
+
+    let spec = SpecBuilder::default()
+        .root(RootBuilder::default().path("rootfs").build()?)
+        .process(
+            ProcessBuilder::default()
+                .cwd("/")
+                .args(vec![common::WASM_FILENAME.to_string()])
+                .build()?,
+        )
+        .build()?;
+
+    let bytes = Cow::from(wasmbytes);
+
+    let (output, retval) = common::run_test_with_spec::<WasmtimeWasi, WasmtimeVm>(&spec, &bytes)?;
+    assert_eq!(retval, 0, "error: {}", output);
+
+    let (output, retval) = common::run_test_with_spec::<WasmEdgeWasi, WasmEdgeVm>(&spec, &bytes)?;
+    assert_eq!(retval, 0, "error: {}", output);
+
+    Ok(())
+}

--- a/test/oci-tests/tests/seccomp.rs
+++ b/test/oci-tests/tests/seccomp.rs
@@ -1,0 +1,217 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use oci_spec::runtime::{
+    LinuxBuilder, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder, ProcessBuilder,
+    RootBuilder, SpecBuilder,
+};
+use wasmedge_sdk::Vm as WasmEdgeVm;
+use wasmtime::Engine as WasmtimeVm;
+
+use containerd_shim_wasm::function;
+use containerd_shim_wasm::sandbox::testutil::{has_cap_sys_admin, run_test_with_sudo};
+use containerd_shim_wasm::sandbox::Error;
+
+use containerd_shim_wasmedge::instance::Wasi as WasmEdgeWasi;
+use containerd_shim_wasmtime::instance::Wasi as WasmtimeWasi;
+
+#[derive(Serialize, Deserialize)]
+struct Options {
+    root: Option<PathBuf>,
+}
+
+mod common;
+
+#[test]
+#[serial]
+fn test_external_hello_world() -> Result<(), Error> {
+    if !has_cap_sys_admin() {
+        println!("running test with sudo: {}", function!());
+        return run_test_with_sudo("test_external_hello_world");
+    }
+
+    let wasmbytes = common::get_external_wasm_module("hello-world.wasm".to_string())?;
+
+    let spec = SpecBuilder::default()
+        .root(RootBuilder::default().path("rootfs").build()?)
+        .process(
+            ProcessBuilder::default()
+                .cwd("/")
+                .args(vec![common::WASM_FILENAME.to_string()])
+                .build()?,
+        )
+        .build()?;
+
+    let bytes = Cow::from(wasmbytes);
+
+    let (output, retval) = common::run_test_with_spec::<WasmEdgeWasi, WasmEdgeVm>(&spec, &bytes)?;
+    assert_eq!(retval, 0);
+    assert!(output.starts_with("hello world"));
+
+    let (output, retval) = common::run_test_with_spec::<WasmtimeWasi, WasmtimeVm>(&spec, &bytes)?;
+    assert_eq!(retval, 0);
+    assert!(output.starts_with("hello world"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_seccomp_hello_world_pass() -> Result<(), Error> {
+    if !has_cap_sys_admin() {
+        println!("running test with sudo: {}", function!());
+        return run_test_with_sudo("test_seccomp_hello_world_pass");
+    }
+
+    let wasmbytes = common::get_external_wasm_module("hello-world.wasm".to_string())?;
+
+    let spec = SpecBuilder::default()
+        .root(RootBuilder::default().path("rootfs").build()?)
+        .process(
+            ProcessBuilder::default()
+                .cwd("/")
+                .args(vec![common::WASM_FILENAME.to_string()])
+                .build()?,
+        )
+        .linux(
+            LinuxBuilder::default()
+                .seccomp(
+                    LinuxSeccompBuilder::default()
+                        .default_action(LinuxSeccompAction::ScmpActAllow)
+                        .architectures(vec![oci_spec::runtime::Arch::ScmpArchNative])
+                        .syscalls(vec![LinuxSyscallBuilder::default()
+                            .names(vec!["getcwd".to_string()])
+                            .action(LinuxSeccompAction::ScmpActAllow)
+                            .build()?])
+                        .build()?,
+                )
+                .build()?,
+        )
+        .build()?;
+
+    let bytes = Cow::from(wasmbytes);
+
+    let (output, retval) = common::run_test_with_spec::<WasmEdgeWasi, WasmEdgeVm>(&spec, &bytes)?;
+    assert_eq!(retval, 0);
+    assert!(output.starts_with("hello world"));
+
+    let (output, retval) = common::run_test_with_spec::<WasmtimeWasi, WasmtimeVm>(&spec, &bytes)?;
+    assert_eq!(retval, 0);
+    assert!(output.starts_with("hello world"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_seccomp_hello_world_fail() -> Result<(), Error> {
+    if !has_cap_sys_admin() {
+        println!("running test with sudo: {}", function!());
+        return run_test_with_sudo("test_seccomp_hello_world_fail");
+    }
+
+    let wasmbytes = common::get_external_wasm_module("hello-world.wasm".to_string())?;
+
+    let spec = SpecBuilder::default()
+        .root(RootBuilder::default().path("rootfs").build()?)
+        .process(
+            ProcessBuilder::default()
+                .cwd("/")
+                .args(vec![common::WASM_FILENAME.to_string()])
+                .build()?,
+        )
+        .linux(
+            LinuxBuilder::default()
+                .seccomp(
+                    LinuxSeccompBuilder::default()
+                        .default_action(LinuxSeccompAction::ScmpActAllow)
+                        .architectures(vec![oci_spec::runtime::Arch::ScmpArchNative])
+                        .syscalls(vec![LinuxSyscallBuilder::default()
+                            .names(vec!["sched_getaffinity".to_string(), "getcwd".to_string()]) // Do not allow sched_getaffinity()
+                            .action(LinuxSeccompAction::ScmpActKill)
+                            .build()?])
+                        .build()?,
+                )
+                .build()?,
+        )
+        .build()?;
+
+    let bytes = Cow::from(wasmbytes);
+
+    let (_, retval) = common::run_test_with_spec::<WasmEdgeWasi, WasmEdgeVm>(&spec, &bytes)?;
+    assert_ne!(retval, 0);
+
+    let (_, retval) = common::run_test_with_spec::<WasmtimeWasi, WasmtimeVm>(&spec, &bytes)?;
+    assert_ne!(retval, 0);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+#[ignore]
+fn test_seccomp_hello_world_notify() -> Result<(), Error> {
+    // Test how seccomp works together with an external notification agent.
+    // Configure the external agent to use socket /tmp/seccomp-agent.socket
+    // and set it to either allow or decline (with error) "getcwd" system
+    // call. Then configure success_expected to true if allowed and false
+    // if declined.
+
+    let success_expected = true;
+
+    if !has_cap_sys_admin() {
+        println!("running test with sudo: {}", function!());
+        return run_test_with_sudo(function!());
+    }
+
+    let wasmbytes = common::get_external_wasm_module("hello-world.wasm".to_string())?;
+
+    let spec = SpecBuilder::default()
+        .root(RootBuilder::default().path("rootfs").build()?)
+        .process(
+            ProcessBuilder::default()
+                .cwd("/")
+                .args(vec![common::WASM_FILENAME.to_string()])
+                .build()?,
+        )
+        .linux(
+            LinuxBuilder::default()
+                .seccomp(
+                    LinuxSeccompBuilder::default()
+                        .default_action(LinuxSeccompAction::ScmpActAllow)
+                        .architectures(vec![oci_spec::runtime::Arch::ScmpArchNative])
+                        .syscalls(vec![LinuxSyscallBuilder::default()
+                            .names(vec!["getcwd".to_string()]) // getcwd() is checked from an external process
+                            .action(LinuxSeccompAction::ScmpActNotify)
+                            .build()?])
+                        .listener_path("/tmp/seccomp-agent.socket")
+                        .build()?,
+                )
+                .build()?,
+        )
+        .build()?;
+
+    let bytes = Cow::from(wasmbytes);
+
+    if success_expected {
+        let (output, retval) =
+            common::run_test_with_spec::<WasmEdgeWasi, WasmEdgeVm>(&spec, &bytes)?;
+        assert_eq!(retval, 0);
+        assert!(output.starts_with("hello world"));
+
+        let (output, retval) =
+            common::run_test_with_spec::<WasmtimeWasi, WasmtimeVm>(&spec, &bytes)?;
+        assert_eq!(retval, 0);
+        assert!(output.starts_with("hello world"));
+    } else {
+        let (_, retval) = common::run_test_with_spec::<WasmEdgeWasi, WasmEdgeVm>(&spec, &bytes)?;
+        assert_ne!(retval, 0);
+
+        let (_, retval) = common::run_test_with_spec::<WasmtimeWasi, WasmtimeVm>(&spec, &bytes)?;
+        assert_ne!(retval, 0);
+    }
+
+    Ok(())
+}

--- a/test/wasi-modules-for-testing/.cargo/config.toml
+++ b/test/wasi-modules-for-testing/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/test/wasi-modules-for-testing/Cargo.toml
+++ b/test/wasi-modules-for-testing/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wasi-modules-for-testing"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "hello-world"
+path = "src/hello_world.rs"
+
+[[bin]]
+name = "has-default-devices"
+path = "src/has_default_devices.rs"
+
+[dependencies]

--- a/test/wasi-modules-for-testing/src/has_default_devices.rs
+++ b/test/wasi-modules-for-testing/src/has_default_devices.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+fn main() {
+    // Runtime must supply at least the following files regardless of OCI devices setting:
+    let devices = vec![
+        "/dev/null",
+        "/dev/zero",
+        "/dev/full",
+        "/dev/random",
+        "/dev/urandom",
+        "/dev/tty",
+    ];
+
+    for device in devices.iter() {
+        if Path::new(device).exists() {
+            println!("{} found", device);
+        } else {
+            panic!("{} not found", device);
+        }
+    }
+}

--- a/test/wasi-modules-for-testing/src/hello_world.rs
+++ b/test/wasi-modules-for-testing/src/hello_world.rs
@@ -1,0 +1,10 @@
+fn main() {
+    // Add current working dir request so that we have some known system call to
+    // test seccomp with.
+    let cwd = std::env::current_dir().unwrap();
+
+    println!(
+        "hello world, current working dir: {}",
+        cwd.to_string_lossy()
+    );
+}


### PR DESCRIPTION
Now that we have support for OCI runtime spec for Wasmedge shim, we should try to do two things:

 1. find out which OCI spec features are actually reasonable to test for runwasi shims
 2. create a set of Wasm modules which exercise those OCI spec features so that we can test them

Those OCI spec features which don't really map to Wasm modules we can try to test on the runtime level, checking for example which capabilities the runtime process has?

This PR adds an external directory for storing/building the Wasm modules and an integration test directory for Wasmedge shim for trying out the OCI spec features. I added some seccomp and device file tests for seeing how this would work in practice. Support for Wasmtime is commented out because the OCI support (https://github.com/containerd/runwasi/pull/142) hasn't been merged yet, but could be useful in testing the PR.

So, I think the first question is: which OCI features are meaningful and should be tested for Wasm/WASI containers? For example it could be argued that the Wasm _modules_ should never see the device files, but the Wasm _runtimes_ should, so that they could expose the features through the WASI APIs. The second question is that is this approach of having the test Wasm modules in-tree the right way forward? The problem is that it appears to be difficult or impossible to run `cargo build` for two architectures at the same time (making the tests depend on the Wasm module build).