### PR TITLE
deps: do not use chrono default features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 tar = "0.4"
 containerd-shim = "0.3.0"
 ttrpc = "0.6"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 nix = "0.26"
 cap-std = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
Disable `chrono` crate default features. This is because of a [potential vulnerability](https://rustsec.org/advisories/RUSTSEC-2020-0071) in `time` crate, which is a `chrono` dependency. Runwasi shims in this repository don't appear to be affected by the vulnerability since we don't set environmental variables.