### PR TITLE
benchmarks: add initial benchmarking support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "webassembly-benchmarks"]
+	path = benches/webassembly-benchmarks
+	url = https://github.com/jedisct1/webassembly-benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +339,33 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -439,6 +478,23 @@ dependencies = [
  "thiserror",
  "time 0.3.22",
  "uuid 0.8.2",
+]
+
+[[package]]
+name = "containerd-shim-benchmarks"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "containerd-shim-wasm",
+ "containerd-shim-wasmedge",
+ "containerd-shim-wasmtime",
+ "criterion",
+ "libc",
+ "oci-spec 0.6.0",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -665,6 +721,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1234,6 +1326,12 @@ checksum = "6b4a40c9ca507513f573aabaf6a8558173a1ac9aa1363d8de30c7f89b34f8d2b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -1806,6 +1904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,6 +2001,34 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2319,6 +2451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2773,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,6 +2983,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -3275,6 +3436,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5abe520f0ab205366e9ac7d3e6b2fc71de44e32a2b58f2ec871b6b575bdcea3b"
 dependencies = [
  "wast 60.0.0",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/oci-tar-builder",
     "crates/containerd-shim-wasmedge",
     "crates/containerd-shim-wasmtime",
+    "benches/containerd-shim-benchmarks",
 ]
 
 [workspace.package]

--- a/benches/containerd-shim-benchmarks/Cargo.toml
+++ b/benches/containerd-shim-benchmarks/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "containerd-shim-benchmarks"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+containerd-shim-wasm = { path = "../../crates/containerd-shim-wasm" }
+containerd-shim-wasmedge = { path = "../../crates/containerd-shim-wasmedge" }
+containerd-shim-wasmtime = { path = "../../crates/containerd-shim-wasmtime" }
+libc = { workspace = true }
+oci-spec = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = "3.0"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "webassembly-benchmarks"
+harness = false

--- a/benches/containerd-shim-benchmarks/benches/webassembly-benchmarks.rs
+++ b/benches/containerd-shim-benchmarks/benches/webassembly-benchmarks.rs
@@ -1,0 +1,362 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use std::borrow::Cow;
+use std::fs::{create_dir, File, OpenOptions};
+use std::io::Write;
+use std::os::unix::prelude::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::bail;
+use chrono::{DateTime, Utc};
+
+use containerd_shim_wasm::sandbox::exec::has_cap_sys_admin;
+use containerd_shim_wasm::sandbox::instance::Wait;
+use containerd_shim_wasm::sandbox::{EngineGetter, Error, Instance, InstanceConfig};
+
+use containerd_shim_wasmedge::instance::{reset_stdio, Wasi as WasmEdgeWasi};
+use containerd_shim_wasmtime::instance::Wasi as WasmtimeWasi;
+use libc::SIGKILL;
+use oci_spec::runtime::{ProcessBuilder, RootBuilder, Spec, SpecBuilder};
+use serde::{Deserialize, Serialize};
+use tempfile::{tempdir, TempDir};
+
+/*
+    For benchmarking try to choose cases which run fast enough -- the idea is to
+    get a rough idea of the performance rather than run a hours-long benchmark
+    suite.
+
+    Because of this, only select the benchmarks which run in under 5 seconds on
+    a desktop computer using WasmEdge. Note that this selection is pretty
+    arbitrary and we can add or remove benchmarks easily, also from other
+    sources. This is the selection algorithm:
+
+    $ for file in *; do if timeout 5s wasmedge "${file}" > /dev/null; then echo "$file"; fi; done
+    aead_chacha20poly13052.wasm
+    aead_chacha20poly1305.wasm
+    aead_xchacha20poly1305.wasm
+    auth2.wasm
+    auth3.wasm
+    auth6.wasm
+    auth.wasm
+    box_seed.wasm
+    generichash2.wasm
+    generichash3.wasm
+    hash3.wasm
+    hash.wasm
+    kdf.wasm
+    keygen.wasm
+    onetimeauth2.wasm
+    onetimeauth.wasm
+    scalarmult2.wasm
+    scalarmult5.wasm
+    scalarmult6.wasm
+    secretbox2.wasm
+    secretbox_easy.wasm
+    secretbox.wasm
+    secretstream_xchacha20poly1305.wasm
+    shorthash.wasm
+    siphashx24.wasm
+    stream3.wasm
+    stream4.wasm
+
+    Criterion is set to run each benchmark ten times, ten being the minimum
+    number of iterations that Criterion accepts. If we need more statistically
+    meaningful results we can increase the number of iterations (with the cost
+    of a longer benchmarking time). Running the whole suite on a desktop
+    computer takes now a bit over 10 minutes.
+*/
+
+#[derive(Serialize, Deserialize)]
+struct Options {
+    root: Option<PathBuf>,
+}
+
+fn get_external_benchmark_module(name: String) -> Result<Vec<u8>, Error> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let target = Path::new(manifest_dir)
+        .join("../../benches/webassembly-benchmarks/2022-12/wasm")
+        .join(name.clone());
+    std::fs::read(target).map_err(|e| {
+        Error::Others(format!(
+            "failed to read requested Wasm module ({}): {}.",
+            name, e
+        ))
+    })
+}
+
+fn run_wasmtime_test_with_spec(
+    dir: &TempDir,
+    spec: &Spec,
+    wasmbytes: &[u8],
+) -> Result<(u32, DateTime<Utc>), Error> {
+    create_dir(dir.path().join("rootfs"))?;
+
+    let wasm_path = dir.path().join("rootfs/file.wasm");
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(wasm_path)?;
+    f.write_all(wasmbytes)?;
+
+    let stdout = File::create(dir.path().join("stdout"))?;
+    drop(stdout);
+
+    spec.save(dir.path().join("config.json"))?;
+
+    let mut cfg = InstanceConfig::new(WasmtimeWasi::new_engine()?, "test_namespace".into());
+    let cfg = cfg
+        .set_bundle(dir.path().to_str().unwrap().to_string())
+        .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string());
+
+    let wasi = Arc::new(WasmtimeWasi::new("test".to_string(), Some(cfg)));
+
+    wasi.start()?;
+
+    let w = wasi.clone();
+    let (tx, rx) = channel();
+    let waiter = Wait::new(tx);
+    w.wait(&waiter).unwrap();
+
+    let res = match rx.recv_timeout(Duration::from_secs(60)) {
+        Ok(res) => Ok(res),
+        Err(e) => {
+            wasi.kill(SIGKILL as u32).unwrap();
+            return Err(Error::Others(format!(
+                "error waiting for module to finish: {0}",
+                e
+            )));
+        }
+    };
+
+    wasi.delete()?;
+    res
+}
+
+fn run_wasmedge_test_with_spec(
+    dir: &TempDir,
+    spec: &Spec,
+    wasmbytes: &[u8],
+) -> Result<(u32, DateTime<Utc>), Error> {
+    create_dir(dir.path().join("rootfs"))?;
+    let rootdir = dir.path().join("runwasi");
+    create_dir(&rootdir)?;
+    let opts = Options {
+        root: Some(rootdir),
+    };
+    let opts_file = OpenOptions::new()
+        .read(true)
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(dir.path().join("options.json"))?;
+    write!(&opts_file, "{}", serde_json::to_string(&opts)?)?;
+
+    let wasm_path = dir.path().join("rootfs/file.wasm");
+    let mut f = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(wasm_path)?;
+    f.write_all(wasmbytes)?;
+
+    let stdout = File::create(dir.path().join("stdout"))?;
+    drop(stdout);
+
+    spec.save(dir.path().join("config.json"))?;
+
+    let mut cfg = InstanceConfig::new(WasmEdgeWasi::new_engine()?, "test_namespace".into());
+    let cfg = cfg
+        .set_bundle(dir.path().to_str().unwrap().to_string())
+        .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string());
+
+    let wasi = Arc::new(WasmEdgeWasi::new("test".to_string(), Some(cfg)));
+
+    wasi.start()?;
+
+    let (tx, rx) = channel();
+    let waiter = Wait::new(tx);
+    wasi.wait(&waiter).unwrap();
+
+    let res = match rx.recv_timeout(Duration::from_secs(600)) {
+        Ok(res) => Ok(res),
+        Err(e) => {
+            wasi.kill(SIGKILL as u32).unwrap();
+            return Err(Error::Others(format!(
+                "error waiting for module to finish: {0}",
+                e
+            )));
+        }
+    };
+    wasi.delete()?;
+    res
+}
+
+fn run_bench(c: &mut Criterion, name: &str) -> Result<(), Error> {
+    if !has_cap_sys_admin() {
+        return Err(Error::Others(String::from(
+            "Please run the benchmark with sudo",
+        )));
+    }
+
+    let wasmbytes = get_external_benchmark_module(format!("{}.wasm", name))?;
+
+    let spec = SpecBuilder::default()
+        .root(RootBuilder::default().path("rootfs").build()?)
+        .process(
+            ProcessBuilder::default()
+                .cwd("/")
+                .args(vec!["./file.wasm".to_string()])
+                .build()?,
+        )
+        .build()?;
+
+    let bytes = Cow::from(wasmbytes);
+
+    let mut group = c.benchmark_group(name);
+    group.bench_function("Wasmtime", |b| {
+        b.iter(|| {
+            let dir = tempdir().unwrap();
+            let res = run_wasmtime_test_with_spec(&dir, &spec, &bytes);
+            match res {
+                Err(e) => bail!("Error running Wasmtime benchmark: {}", e),
+                _ => Ok(()),
+            }
+        })
+    });
+    group.bench_function("WasmEdge", |b| {
+        b.iter(|| {
+            let dir = tempdir().unwrap();
+            let res = run_wasmedge_test_with_spec(&dir, &spec, &bytes);
+            match res {
+                Err(e) => bail!("Error running WasmEdge benchmark: {}", e),
+                _ => Ok(()),
+            }
+        })
+    });
+    reset_stdio();
+    group.finish();
+
+    Ok(())
+}
+
+fn bench_aead_chacha20poly1305(b: &mut Criterion) {
+    run_bench(b, "aead_chacha20poly1305").unwrap()
+}
+
+fn bench_aead_chacha20poly13052(b: &mut Criterion) {
+    run_bench(b, "aead_chacha20poly13052").unwrap()
+}
+
+fn bench_aead_xchacha20poly1305(b: &mut Criterion) {
+    run_bench(b, "aead_xchacha20poly1305").unwrap()
+}
+
+fn bench_auth2(b: &mut Criterion) {
+    run_bench(b, "auth2").unwrap()
+}
+
+fn bench_auth3(b: &mut Criterion) {
+    run_bench(b, "auth3").unwrap()
+}
+
+fn bench_auth6(b: &mut Criterion) {
+    run_bench(b, "auth6").unwrap()
+}
+
+fn bench_auth(b: &mut Criterion) {
+    run_bench(b, "auth").unwrap()
+}
+
+fn bench_box_seed(b: &mut Criterion) {
+    run_bench(b, "box_seed").unwrap()
+}
+
+fn bench_generichash2(b: &mut Criterion) {
+    run_bench(b, "generichash2").unwrap()
+}
+
+fn bench_generichash3(b: &mut Criterion) {
+    run_bench(b, "generichash3").unwrap()
+}
+
+fn bench_hash3(b: &mut Criterion) {
+    run_bench(b, "hash3").unwrap()
+}
+
+fn bench_hash(b: &mut Criterion) {
+    run_bench(b, "hash").unwrap()
+}
+
+fn bench_kdf(b: &mut Criterion) {
+    run_bench(b, "kdf").unwrap()
+}
+
+fn bench_keygen(b: &mut Criterion) {
+    run_bench(b, "keygen").unwrap()
+}
+
+fn bench_onetimeauth2(b: &mut Criterion) {
+    run_bench(b, "onetimeauth2").unwrap()
+}
+
+fn bench_onetimeauth(b: &mut Criterion) {
+    run_bench(b, "onetimeauth").unwrap()
+}
+
+fn bench_scalarmult2(b: &mut Criterion) {
+    run_bench(b, "scalarmult2").unwrap()
+}
+
+fn bench_scalarmult5(b: &mut Criterion) {
+    run_bench(b, "scalarmult5").unwrap()
+}
+
+fn bench_scalarmult6(b: &mut Criterion) {
+    run_bench(b, "scalarmult6").unwrap()
+}
+
+fn bench_secretbox2(b: &mut Criterion) {
+    run_bench(b, "secretbox2").unwrap()
+}
+
+fn bench_secretbox_easy(b: &mut Criterion) {
+    run_bench(b, "secretbox_easy").unwrap()
+}
+
+fn bench_secretbox(b: &mut Criterion) {
+    run_bench(b, "secretbox").unwrap()
+}
+
+fn bench_secretstream_xchacha20poly1305(b: &mut Criterion) {
+    run_bench(b, "secretstream_xchacha20poly1305").unwrap()
+}
+
+fn bench_shorthash(b: &mut Criterion) {
+    run_bench(b, "shorthash").unwrap()
+}
+
+fn bench_siphashx24(b: &mut Criterion) {
+    run_bench(b, "siphashx24").unwrap()
+}
+
+fn bench_stream3(b: &mut Criterion) {
+    run_bench(b, "stream3").unwrap()
+}
+
+fn bench_stream4(b: &mut Criterion) {
+    run_bench(b, "stream4").unwrap()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_aead_chacha20poly13052, bench_aead_chacha20poly1305, bench_aead_xchacha20poly1305, bench_auth2, bench_auth3, bench_auth6, bench_auth, bench_box_seed, bench_generichash2, bench_generichash3, bench_hash3, bench_hash, bench_kdf, bench_keygen, bench_onetimeauth2, bench_onetimeauth, bench_scalarmult2, bench_scalarmult5, bench_scalarmult6, bench_secretbox2, bench_secretbox_easy, bench_secretbox, bench_secretstream_xchacha20poly1305, bench_shorthash, bench_siphashx24, bench_stream3, bench_stream4
+}
+
+criterion_main!(benches);


### PR DESCRIPTION
Add a submodule "webassembly-benchmarks". The benchmark contains a set of wasm files from libsodium. Only the benchmarks which are fast to run (take under 5 seconds to complete on a desktop computer using WasmEdge) were selected for benchmarking.

The benchmark suite initializes the Wasm runtime, runs the benchmark, and cleans up the container. This is done for both WasmEdge and Wasmtime shim crates. Note that the results for the two runtimes shouldn't really be directly compared right now, because Wasmtime shim hasn't been converted to youki/libcontainer-rs yet and that changes the performance due to the extended namespacing. What this helps with is to see what is the performance impact of any given change, for example having the Youki integration done, using a seccomp filter, or setting cgroup options.

The benchmarking library used is Criterion. Run the benchmarks like this:

    # cargo bench

If you have gnuplot binary installed, Criterion will generate an HTML report with graphs in target/criterion/report/index.html file. Running the suite takes bit over ten minutes on my desktop.

This PR adds two new direct dependencies: Criterion (Apache2.0/MIT) as dev-dependency and webassembly-benchmarks (ISC) as a submodule.

Note that this PR is just the first step in the benchmarking path -- it does only pretty low-level benchmarking using a limited set of tests. Later on we can add comparison to the normal containers (by compiling and running the libsodium benchmarks as regular processes with the native Youki executor), add or remove Wasm benchmark modules, and improve the test setup. We could for example try running hunderds of containers at once to see how "dense" containers on a node would perform.

This is related to https://github.com/containerd/runwasi/issues/97 (and should fix the second point in the list).