### PR TITLE
Fixes to tests to make cargo clippy succeed

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -179,7 +179,6 @@ impl Instance for Nop {
     fn start(&self) -> Result<u32, Error> {
         Ok(std::process::id())
     }
-
     fn kill(&self, signal: u32) -> Result<(), Error> {
         let code = match signal as i32 {
             SIGKILL => 137,
@@ -208,7 +207,6 @@ impl Instance for Nop {
 #[cfg(test)]
 mod noptests {
     use std::sync::mpsc::channel;
-    use std::sync::Arc;
     use std::time::Duration;
 
     use libc::SIGHUP;
@@ -217,7 +215,7 @@ mod noptests {
 
     #[test]
     fn test_nop_kill_sigkill() -> Result<(), Error> {
-        let nop = Arc::new(Nop::new("".to_string(), None));
+        let nop = Nop::new("".to_string(), None);
         let (tx, rx) = channel();
         let waiter = Wait::new(tx);
 
@@ -230,7 +228,7 @@ mod noptests {
 
     #[test]
     fn test_nop_kill_sigterm() -> Result<(), Error> {
-        let nop = Arc::new(Nop::new("".to_string(), None));
+        let nop = Nop::new("".to_string(), None);
         let (tx, rx) = channel();
         let waiter = Wait::new(tx);
 
@@ -243,7 +241,7 @@ mod noptests {
 
     #[test]
     fn test_nop_kill_sigint() -> Result<(), Error> {
-        let nop = Arc::new(Nop::new("".to_string(), None));
+        let nop = Nop::new("".to_string(), None);
         let (tx, rx) = channel();
         let waiter = Wait::new(tx);
 
@@ -256,7 +254,7 @@ mod noptests {
 
     #[test]
     fn test_op_kill_other() -> Result<(), Error> {
-        let nop = Arc::new(Nop::new("".to_string(), None));
+        let nop = Nop::new("".to_string(), None);
 
         let err = nop.kill(SIGHUP as u32).unwrap_err();
         match err {
@@ -269,7 +267,7 @@ mod noptests {
 
     #[test]
     fn test_nop_delete_after_create() {
-        let nop = Arc::new(Nop::new("".to_string(), None));
+        let nop = Nop::new("".to_string(), None);
         nop.delete().unwrap();
     }
 }

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -219,12 +219,9 @@ mod noptests {
     fn test_nop_kill_sigkill() -> Result<(), Error> {
         let nop = Arc::new(Nop::new("".to_string(), None));
         let (tx, rx) = channel();
-
-        let n = nop.clone();
         let waiter = Wait::new(tx);
 
-        n.wait(&waiter).unwrap();
-
+        nop.wait(&waiter).unwrap();
         nop.kill(SIGKILL as u32)?;
         let ec = rx.recv_timeout(Duration::from_secs(3)).unwrap();
         assert_eq!(ec.0, 137);
@@ -235,12 +232,9 @@ mod noptests {
     fn test_nop_kill_sigterm() -> Result<(), Error> {
         let nop = Arc::new(Nop::new("".to_string(), None));
         let (tx, rx) = channel();
-
-        let n = nop.clone();
         let waiter = Wait::new(tx);
 
-        n.wait(&waiter).unwrap();
-
+        nop.wait(&waiter).unwrap();
         nop.kill(SIGTERM as u32)?;
         let ec = rx.recv_timeout(Duration::from_secs(3)).unwrap();
         assert_eq!(ec.0, 0);
@@ -251,12 +245,9 @@ mod noptests {
     fn test_nop_kill_sigint() -> Result<(), Error> {
         let nop = Arc::new(Nop::new("".to_string(), None));
         let (tx, rx) = channel();
-
-        let n = nop.clone();
         let waiter = Wait::new(tx);
 
-        n.wait(&waiter).unwrap();
-
+        nop.wait(&waiter).unwrap();
         nop.kill(SIGINT as u32)?;
         let ec = rx.recv_timeout(Duration::from_secs(3)).unwrap();
         assert_eq!(ec.0, 0);

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -424,7 +424,7 @@ mod wasitest {
             .set_bundle(dir.path().to_str().unwrap().to_string())
             .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string());
 
-        let wasi = Arc::new(Wasi::new("test".to_string(), Some(cfg)));
+        let wasi = Wasi::new("test".to_string(), Some(cfg));
 
         wasi.start()?;
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -348,7 +348,7 @@ mod wasitest {
             .set_bundle(dir.path().to_str().unwrap().to_string())
             .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string());
 
-        let wasi = Arc::new(Wasi::new("test".to_string(), Some(cfg)));
+        let wasi = Wasi::new("test".to_string(), Some(cfg));
 
         wasi.start()?;
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -352,10 +352,9 @@ mod wasitest {
 
         wasi.start()?;
 
-        let w = wasi.clone();
         let (tx, rx) = channel();
         let waiter = Wait::new(tx);
-        w.wait(&waiter).unwrap();
+        wasi.wait(&waiter).unwrap();
 
         let res = match rx.recv_timeout(Duration::from_secs(10)) {
             Ok(res) => res,
@@ -371,6 +370,8 @@ mod wasitest {
 
         let output = read_to_string(dir.path().join("stdout"))?;
         assert_eq!(output, "hello world\n");
+
+        wasi.delete()?;
 
         Ok(())
     }


### PR DESCRIPTION
Add `delete()` to Wasmtime tests. Also clean up the code a little to make `cargo clippy` succeed.