### PR TITLE
MAINTAINERS: Add Toru Komatsu(utam0k) as a REVIEWER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,3 +14,4 @@
 # GitHub ID, Name, Email address
 "ipuustin","Ismo Puustinen","ismo.puustinen@intel.com"
 "rumpl","Djordje Lukic","djordje.lukic@docker.com"
+"utam0k","Toru Komatsu","k0ma@utam0k.jp"


### PR DESCRIPTION
I'd like to invite @utam0k as a reviewer. He had made major contribution to the integration of the WasmEdge shim with youki's `libcontainer` crate and demonstrated his deep knowledge in this field.

Needs explicit LGTM from @utam0k and 1/3 of the runwasi Committers according to https://github.com/containerd/project/blob/main/GOVERNANCE.md.

- [x] @devigned
- [ ] @cpuguy83
- [x] @danbugs

This PR will remain open for 7 days.