### PR TITLE
Handle args for modules with out extra first argument in prep for oci articfacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,4 +109,7 @@ jobs:
           make test/k3s
       - name: cleanup
         if: always()
-        run: make test/k3s/clean
+        run: |
+          sudo bin/k3s kubectl logs deployments/wasi-demo 
+          sudo bin/k3s kubectl get pods -o wide
+          make test/k3s/clean

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/out/img.tar
 !crates/wasmtime/src/bin/
 test/k8s/_out
 release/
+.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,7 @@ test/k3s: target/wasm32-wasi/$(TARGET)/img.tar bin/wasmedge bin/k3s
 	sudo bin/k3s kubectl apply -f test/k8s/deploy.yaml
 	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=90s && \
 	sudo bin/k3s kubectl get pods -o wide
+	sudo bin/k3s kubectl logs deployments/wasi-demo   
 
 .PHONY: test/k3s/clean
 test/k3s/clean: bin/wasmedge/clean bin/k3s/clean

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -36,6 +36,53 @@ pub fn get_args(spec: &Spec) -> &[String] {
     }
 }
 
+pub fn get_module_args(spec: &Spec) -> &[String] {
+    let args = get_args(spec);
+
+    match spec.annotations().clone() {
+        Some(annotations)
+            if annotations.contains_key("application/vnd.w3c.wasm.module.v1+wasm") =>
+        {
+            args
+        }
+        _ => {
+            if args.len() > 1 {
+                &args[1..]
+            } else {
+                &[]
+            }
+        }
+    }
+}
+
+pub fn get_module(spec: &Spec) -> (Option<String>, String) {
+    let args = get_args(spec);
+
+    match spec.annotations().clone() {
+        Some(annotations)
+            if annotations.contains_key("application/vnd.w3c.wasm.module.v1+wasm") =>
+        {
+            (None, "_start".to_string())
+        }
+        _ => {
+            if !args.is_empty() {
+                let start = args[0].clone();
+                let mut iterator = start.split('#');
+                let mut cmd = iterator.next().unwrap().to_string();
+
+                let stripped = cmd.strip_prefix(std::path::MAIN_SEPARATOR);
+                if let Some(strpd) = stripped {
+                    cmd = strpd.to_string();
+                }
+                let method = iterator.next().unwrap_or("_start");
+                (Some(cmd), method.to_string())
+            } else {
+                (None, "_start".to_string())
+            }
+        }
+    }
+}
+
 pub fn spec_from_file<P: AsRef<Path>>(path: P) -> Result<Spec> {
     let file = File::open(path)?;
     let cfg: Spec = json::from_reader(file)?;
@@ -159,4 +206,205 @@ pub fn setup_prestart_hooks(hooks: &Option<oci_spec::runtime::Hooks>) -> Result<
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod oci_tests {
+    use super::*;
+    use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder};
+
+    #[test]
+    fn test_get_args() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec!["hello.wat".to_string()])
+                    .build()?,
+            )
+            .build()?;
+
+        let args = get_args(&spec);
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0], "hello.wat");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_args_return_empty() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(ProcessBuilder::default().cwd("/").args(vec![]).build()?)
+            .build()?;
+
+        let args = get_args(&spec);
+        assert_eq!(args.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_args_returns_all() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec![
+                        "hello.wat".to_string(),
+                        "echo".to_string(),
+                        "hello".to_string(),
+                    ])
+                    .build()?,
+            )
+            .build()?;
+
+        let args = get_args(&spec);
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0], "hello.wat");
+        assert_eq!(args[1], "echo");
+        assert_eq!(args[2], "hello");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_module_args_returns_module_args_only() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec![
+                        "hello.wat".to_string(),
+                        "echo".to_string(),
+                        "hello".to_string(),
+                    ])
+                    .build()?,
+            )
+            .build()?;
+
+        let args = get_module_args(&spec);
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "echo");
+        assert_eq!(args[1], "hello");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_module_args_returns_empty_when_just_module() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec!["hello.wat".to_string()])
+                    .build()?,
+            )
+            .build()?;
+
+        let args = get_module_args(&spec);
+        assert_eq!(args.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_module_args_returns_module_args_only_when_oci_artifact() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec!["echo".to_string(), "hello".to_string()])
+                    .build()?,
+            )
+            .annotations(HashMap::from([(
+                "application/vnd.w3c.wasm.module.v1+wasm".to_string(),
+                "sha256:1234".to_string(),
+            )]))
+            .build()?;
+
+        let args = get_module_args(&spec);
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "echo");
+        assert_eq!(args[1], "hello");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_module_args_returns_empty_args_when_oci_artifact() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(ProcessBuilder::default().cwd("/").args(vec![]).build()?)
+            .annotations(HashMap::from([(
+                "application/vnd.w3c.wasm.module.v1+wasm".to_string(),
+                "sha256:1234".to_string(),
+            )]))
+            .build()?;
+
+        let args = get_module_args(&spec);
+        assert_eq!(args.len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_module_returns_empty_args_when_oci_artifact() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec!["echo".to_string(), "hello".to_string()])
+                    .build()?,
+            )
+            .annotations(HashMap::from([(
+                "application/vnd.w3c.wasm.module.v1+wasm".to_string(),
+                "sha256:1234".to_string(),
+            )]))
+            .build()?;
+
+        let (module, method) = get_module(&spec);
+        assert_eq!(module, None);
+        assert_eq!(method, "_start");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_module_returns_module() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(
+                ProcessBuilder::default()
+                    .cwd("/")
+                    .args(vec!["hello.wat".to_string()])
+                    .build()?,
+            )
+            .build()?;
+
+        let (module, method) = get_module(&spec);
+        assert_eq!(module.unwrap(), "hello.wat");
+        assert_eq!(method, "_start");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_module_returns_none_when_not_present() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(ProcessBuilder::default().cwd("/").args(vec![]).build()?)
+            .build()?;
+
+        let (module, _) = get_module(&spec);
+        assert_eq!(module, None);
+
+        Ok(())
+    }
 }

--- a/crates/wasi-demo-app/src/main.rs
+++ b/crates/wasi-demo-app/src/main.rs
@@ -4,7 +4,11 @@ fn main() {
     let args: Vec<_> = env::args().collect();
     let mut cmd = "daemon";
     if !args.is_empty() {
-        cmd = &args[0];
+        // temporary work around for wasmedge bug
+        // https://github.com/WasmEdge/wasmedge-rust-sdk/issues/10
+        if !(args.len() == 1 && args[0].is_empty()) {
+            cmd = &args[0];
+        }
     }
 
     match cmd {

--- a/crates/wasi-demo-app/src/main.rs
+++ b/crates/wasi-demo-app/src/main.rs
@@ -3,24 +3,24 @@ use std::{env, fs::File, io::prelude::*, process, thread::sleep, time::Duration}
 fn main() {
     let args: Vec<_> = env::args().collect();
     let mut cmd = "daemon";
-    if args.len() >= 2 {
-        cmd = &args[1];
+    if !args.is_empty() {
+        cmd = &args[0];
     }
 
     match cmd {
-        "echo" => println!("{}", &args[2..].join(" ")),
-        "sleep" => sleep(Duration::from_secs_f64(args[2].parse::<f64>().unwrap())),
-        "exit" => process::exit(args[2].parse::<i32>().unwrap()),
+        "echo" => println!("{}", &args[1..].join(" ")),
+        "sleep" => sleep(Duration::from_secs_f64(args[1].parse::<f64>().unwrap())),
+        "exit" => process::exit(args[1].parse::<i32>().unwrap()),
         "write" => {
-            let mut file = File::create(&args[2]).unwrap();
-            file.write_all(args[3..].join(" ").as_bytes()).unwrap();
+            let mut file = File::create(&args[1]).unwrap();
+            file.write_all(args[2..].join(" ").as_bytes()).unwrap();
         }
         "daemon" => loop {
             println!("This is a song that never ends.\nYes, it goes on and on my friends.\nSome people started singing it not knowing what it was,\nSo they'll continue singing it forever just because...\n");
             sleep(Duration::from_secs(1));
         },
         _ => {
-            eprintln!("unknown command: {0}", args[1]);
+            eprintln!("unknown command: {0}", args[0]);
             process::exit(1);
         }
     }


### PR DESCRIPTION
When working on adding OCI artifact support, I found two bugs:

1) the args to the program wasm program included the `module.wasm` artifact. This means the demo app was parsing the second arguement even though it was really the first.
2) the shim would hang (via an exception) if the module wasn't passed as the entrypoint or cmd.  This lead to the sim hanging.  Adding an addtional check lets the shim fail properly in scenarios where someone built the container without the correct entry point.  

I've included in the tests the checks for the OCI artifacts. I can drop those and add back when add oci artifact support in the next PR but I thought i'd include it initially.

work towards #108 

