### PR TITLE
oci-tar-builder: ensure the output directory exists

### DIFF
--- a/crates/oci-tar-builder/src/bin.rs
+++ b/crates/oci-tar-builder/src/bin.rs
@@ -11,6 +11,7 @@ pub fn main() {
     let out_dir;
     if let Some(out_path) = args.out_path.as_deref() {
         out_dir = PathBuf::from(out_path);
+        fs::create_dir_all(&out_dir).unwrap();
     } else {
         out_dir = env::current_dir().unwrap();
     }


### PR DESCRIPTION
When specifying an uncreated output directory, the command will fail
```sh
 cargo run --bin oci-tar-builder -- --name wasi-demo-app --repo localhost:5000 --module ./target/wasm32-wasi/debug/wasi-demo-app.wasm -o ./bin                                                          130 ↵
   Compiling oci-tar-builder v0.1.0 (/Users/icebergu/workspace/wasm/runwasi/crates/oci-tar-builder)
    Finished dev [unoptimized + debuginfo] target(s) in 1.48s
     Running `target/debug/oci-tar-builder --name wasi-demo-app --repo 'localhost:5000' --module ./target/wasm32-wasi/debug/wasi-demo-app.wasm -o ./bin`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', crates/oci-tar-builder/src/bin.rs:75:37
```