### PR TITLE
Do not run clippy on auto-generated files

### DIFF
--- a/crates/containerd-shim-wasm/src/services.rs
+++ b/crates/containerd-shim-wasm/src/services.rs
@@ -1,4 +1,7 @@
 //! Generated service definitions from the protobuf definitions.
 
+// do not run clippy on generated files
+#![allow(clippy::all)]
+
 pub mod sandbox;
 pub mod sandbox_ttrpc;

--- a/crates/containerd-shim-wasm/src/services/sandbox_ttrpc.rs
+++ b/crates/containerd-shim-wasm/src/services/sandbox_ttrpc.rs
@@ -29,7 +29,7 @@ pub struct ManagerClient {
 impl ManagerClient {
     pub fn new(client: ::ttrpc::Client) -> Self {
         ManagerClient {
-            client,
+            client: client,
         }
     }
 


### PR DESCRIPTION
The files generated by the `ttrpc-compiler` do not pass some stylistic clippy's checks.
This means that we need to run `make fix` after running `make build` to prevent CI failures.

This PR prevents clippy from running on the auto-generated.
This means that `make check` won't fail on those files.
This also prevents `make fix` from modifying the auto-generated files.