### PR TITLE
chore: bump containerd-wasm-shim to version v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "caps",

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd-shim-wasm"
 description = "Library for building containerd shims for wasm"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"


### PR DESCRIPTION
This bumps the version of the shim to `v0.2.0`. After this PR merged, I will tag a new release. 

Could you please take a look? @cpuguy83 