### PR TITLE
chore: bump rust version to 1.71

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.71.0
 
 jobs:
   fmt:
@@ -17,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.69.0
+          toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy
       - name: Setup OCI runtime build env
         run: |
@@ -44,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.69.0
+          toolchain: ${{ env.RUST_VERSION }}
       - name: Setup OCI runtime build env
         run: |
           sudo apt -y update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG RUST_VERSION=1.69
+ARG RUST_VERSION=1.71
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx


### PR DESCRIPTION
This bumps the CI rust version and the Docker image rust version to `1.71`. Am I missing anything? 