### PR TITLE
Link against wasmedge static library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,6 @@ jobs:
       - name: Setup OCI runtime build env
         run: ${GITHUB_WORKSPACE}/.github/scripts/build.sh
         shell: bash
-      - name: Setup WasmEdge build env
-        run: |
-          make bin/wasmedge
-          echo "LD_LIBRARY_PATH=$PWD/bin/wasmedge/lib" >> $GITHUB_ENV
-          echo "WASMEDGE_INCLUDE_DIR=$PWD/bin/wasmedge/include" >> $GITHUB_ENV
-          echo "WASMEDGE_LIB_DIR=$PWD/bin/wasmedge/lib" >> $GITHUB_ENV
       - name: Run checks
         run: make check
   build:
@@ -43,12 +37,6 @@ jobs:
       - name: Setup OCI runtime build env
         run: ${GITHUB_WORKSPACE}/.github/scripts/build.sh
         shell: bash
-      - name: Setup WasmEdge build env
-        run: |
-          make bin/wasmedge
-          echo "LD_LIBRARY_PATH=$PWD/bin/wasmedge/lib" >> $GITHUB_ENV
-          echo "WASMEDGE_INCLUDE_DIR=$PWD/bin/wasmedge/include" >> $GITHUB_ENV
-          echo "WASMEDGE_LIB_DIR=$PWD/bin/wasmedge/lib" >> $GITHUB_ENV
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -104,11 +92,7 @@ jobs:
         run: ${GITHUB_WORKSPACE}/.github/scripts/build.sh
         shell: bash
       - name: run
-        run: |
-          echo "LD_LIBRARY_PATH=$PWD/bin/wasmedge/lib" >> $GITHUB_ENV
-          echo "WASMEDGE_INCLUDE_DIR=$PWD/bin/wasmedge/include" >> $GITHUB_ENV
-          echo "WASMEDGE_LIB_DIR=$PWD/bin/wasmedge/lib" >> $GITHUB_ENV
-          make test/k3s
+        run: make test/k3s
       - name: cleanup
         if: always()
         run: make test/k3s/clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,6 @@ jobs:
       - name: Setup build env
         run: ${GITHUB_WORKSPACE}/.github/scripts/build.sh
         shell: bash
-      - name: Setup WasmEdge build env
-        if: ${{ contains(needs.generate.outputs.crate, 'wasmedge' ) }}
-        run: |
-          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --version=0.13.1
-          echo "LD_LIBRARY_PATH=$HOME/.wasmedge/lib" >> $GITHUB_ENV
       - name: Build
         run: cargo build --verbose --package ${{ needs.generate.outputs.crate }}
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-macro"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372985c17ffd2705e0cc14aa85e96c546d04823aec07ec1e0da0a2983c9eb655"
+checksum = "ad17cbd3b8a8ed1cba44755e616495e13baf3f7e7f9576df7d7a357b928c070a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3065,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sdk"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30b3d1a423ee62c0016bbfd07bdca4669a30cd167d7ff528caff559b467c17b"
+checksum = "4ab1a3beab101c87a51692630a7b29d71cdc061ac06bf31c089b16f094952c3d"
 dependencies = [
  "anyhow",
  "num-derive",
@@ -3076,19 +3076,21 @@ dependencies = [
  "wasmedge-macro",
  "wasmedge-sys",
  "wasmedge-types",
- "wat",
 ]
 
 [[package]]
 name = "wasmedge-sys"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db99e2ef8cf618f832f1ecf32c3b86e8ce0fb2f31013426040ae514a981312c"
+checksum = "157f13aa077203259d7771f606f0206feb7cb6bb2b0894f93439a8af1bda4ab9"
 dependencies = [
  "bindgen",
  "cmake",
+ "lazy_static",
  "libc",
+ "parking_lot",
  "paste",
+ "rand",
  "scoped-tls",
  "thiserror",
  "wasmedge-macro",

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,22 +9,14 @@ FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION} AS base
 COPY --from=xx / /
-RUN apt-get update -y && apt-get install --no-install-recommends -y clang jq
+RUN apt-get update -y && apt-get install --no-install-recommends -y clang jq wget
 
 FROM base AS build
 SHELL ["/bin/bash", "-c"]
 ARG BUILD_TAGS TARGETPLATFORM
-ENV WASMEDGE_INCLUDE_DIR=/root/.wasmedge/include
-ENV WASMEDGE_LIB_DIR=/root/.wasmedge/lib
-ENV LD_LIBRARY_PATH=/root/.wasmedge/lib
 RUN xx-apt-get install -y gcc g++ libc++6-dev zlib1g
 RUN xx-apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev
 RUN rustup target add $(xx-info march)-unknown-$(xx-info os)-$(xx-info libc)
-RUN <<EOT
-    set -ex
-    os=$(xx-info os)
-    curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --version=0.13.1 --platform=${os^} --machine=$(xx-info march)
-EOT
 
 WORKDIR /build/src
 COPY --link crates ./crates

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@ INSTALL ?= install
 TEST_IMG_NAME ?= wasmtest:latest
 RUNTIMES ?= wasmedge wasmtime
 export CONTAINERD_NAMESPACE ?= default
-export WASMEDGE_INCLUDE_DIR ?=$(PWD)/bin/wasmedge/include
-export WASMEDGE_LIB_DIR ?=$(PWD)/bin/wasmedge/lib
 
 TARGET ?= debug
 RELEASE_FLAG :=
@@ -83,17 +81,6 @@ test/k8s: test/k8s/cluster
 test/k8s/clean: bin/kind
 	bin/kind delete cluster --name $(KIND_CLUSTER_NAME)
 
-.PHONY: bin/wasmedge
-bin/wasmedge:
-	mkdir -p ${CURDIR}/bin
-	curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --version=0.13.1 -p $(PWD)/bin/wasmedge && \
-	sudo -E sh -c 'echo "$(PWD)/bin/wasmedge/lib" > /etc/ld.so.conf.d/libwasmedge.conf' && sudo ldconfig
-
-.PHONY: bin/wasmedge/clean
-bin/wasmedge/clean:
-	sudo rm /etc/ld.so.conf.d/libwasmedge.conf && sudo ldconfig
-	curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/uninstall.sh | bash -s -- -p $(PWD)/bin/wasmedge -q
-
 .PHONY: bin/k3s
 bin/k3s:
 	mkdir -p bin && \
@@ -104,16 +91,12 @@ bin/k3s/clean:
 	bin/k3s-runwasi-uninstall.sh
 
 .PHONY: test/k3s
-test/k3s: target/wasm32-wasi/$(TARGET)/img.tar bin/wasmedge bin/k3s
-	export WASMEDGE_INCLUDE_DIR=$(PWD)/bin/wasmedge/include && \
-	export WASMEDGE_LIB_DIR=$(PWD)/bin/wasmedge/lib && \
+test/k3s: target/wasm32-wasi/$(TARGET)/img.tar bin/k3s
 	cargo build $(RELEASE_FLAG) && \
 	cp target/$(TARGET)/containerd-shim-wasmedge-v1 $(PWD)/bin/ && \
 	sudo cp /var/lib/rancher/k3s/agent/etc/containerd/config.toml /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
 	echo '[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
 	echo '  runtime_type = "$(PWD)/bin/containerd-shim-wasmedge-v1"' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
-	echo '  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm.options]' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
-	echo '    BinaryName = "$(PWD)/bin/wasmedge/bin/wasmedge"' | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl && \
 	echo "CONTAINERD_NAMESPACE='default'" | sudo tee /etc/systemd/system/k3s-runwasi.service.env && \
 	echo "NO_PROXY=192.168.0.0/16" | sudo tee -a /etc/systemd/system/k3s-runwasi.service.env && \
 	sudo systemctl daemon-reload && \
@@ -125,7 +108,6 @@ test/k3s: target/wasm32-wasi/$(TARGET)/img.tar bin/wasmedge bin/k3s
 	sudo bin/k3s kubectl get pods -o wide
 
 .PHONY: test/k3s/clean
-test/k3s/clean: bin/wasmedge/clean bin/k3s/clean
+test/k3s/clean: bin/k3s/clean
 	cargo clean
-	unset WASMEDGE_INCLUDE_DIR WASMEDGE_LIB_DIR
 	rm $(PWD)/bin/containerd-shim-wasmedge-v1

--- a/README.md
+++ b/README.md
@@ -146,14 +146,7 @@ You will need to make sure the `containerd-[ wasmedge | wasmtime ]d` daemon has 
 
 #### Building
 
-1. Install Wasm Edge dependencies
-
-```terminal
-make bin/wasmedge/clean
-make bin/wasmedge
-```
-
-2. Install [youki dependencies](https://github.com/containers/youki#dependencies)
+1. Install [youki dependencies](https://github.com/containers/youki#dependencies)
 
 ```
 sudo apt-get install    \
@@ -167,7 +160,7 @@ sudo apt-get install    \
       libssl-dev
 ```
 
-3. Build
+2. Build
 
 ```
 make build

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -8,7 +8,7 @@ containerd-shim = { workspace = true }
 containerd-shim-wasm = { workspace = true }
 log = { workspace = true }
 ttrpc = { workspace = true }
-wasmedge-sdk = "0.9.0"
+wasmedge-sdk = { version = "0.10.0", features = [ "standalone", "static" ] }
 chrono = { workspace = true }
 anyhow = { workspace = true }
 cap-std = { workspace = true }

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
@@ -3,8 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmedge::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance, wasmedge_sdk::Vm<wasmedge_sdk::NeverType>>>(
-        "io.containerd.wasmedge.v1",
-        None,
-    );
+    shim::run::<ShimCli<WasiInstance, wasmedge_sdk::Vm>>("io.containerd.wasmedge.v1", None);
 }

--- a/crates/containerd-shim-wasmedge/src/executor.rs
+++ b/crates/containerd-shim-wasmedge/src/executor.rs
@@ -9,7 +9,7 @@ use std::os::unix::io::RawFd;
 
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
-    params, NeverType, VmBuilder,
+    params, VmBuilder,
 };
 
 const EXECUTOR_NAME: &str = "wasmedge";
@@ -50,7 +50,7 @@ impl Executor for WasmEdgeExecutor {
 }
 
 impl WasmEdgeExecutor {
-    fn prepare(&self, args: &[String], spec: &Spec) -> anyhow::Result<wasmedge_sdk::Vm<NeverType>> {
+    fn prepare(&self, args: &[String], spec: &Spec) -> anyhow::Result<wasmedge_sdk::Vm> {
         let mut cmd = args[0].clone();
         if let Some(stripped) = args[0].strip_prefix(std::path::MAIN_SEPARATOR) {
             cmd = stripped.to_string();
@@ -62,7 +62,7 @@ impl WasmEdgeExecutor {
             .map_err(|err| ExecutorError::Execution(err))?;
         let mut vm = VmBuilder::new()
             .with_config(config)
-            .build::<NeverType>()
+            .build()
             .map_err(|err| ExecutorError::Execution(err))?;
         let wasi_module = vm
             .wasi_module_mut()

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
     plugin::PluginManager,
-    NeverType, Vm, VmBuilder,
+    Vm, VmBuilder,
 };
 
 use std::{
@@ -98,7 +98,7 @@ fn determine_rootdir<P: AsRef<Path>>(bundle: P, namespace: String) -> Result<Pat
 }
 
 impl Instance for Wasi {
-    type E = Vm<NeverType>;
+    type E = Vm;
     fn new(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self {
         let cfg = cfg.unwrap(); // TODO: handle error
         let bundle = cfg.get_bundle().unwrap_or_default();
@@ -250,8 +250,8 @@ impl Wasi {
 }
 
 impl EngineGetter for Wasi {
-    type E = Vm<NeverType>;
-    fn new_engine() -> Result<Vm<NeverType>, Error> {
+    type E = Vm;
+    fn new_engine() -> Result<Vm, Error> {
         PluginManager::load(None).unwrap();
         let mut host_options = HostRegistrationConfigOptions::default();
         host_options = host_options.wasi(true);

--- a/test/k8s/Dockerfile
+++ b/test/k8s/Dockerfile
@@ -12,8 +12,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustup install stable
 WORKDIR /shim
 COPY . .
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential git clang pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev
-RUN curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --version=0.13.1
+RUN apt-get update && apt-get install --no-install-recommends -y build-essential git clang wget pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev
 RUN \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/shim/target \


### PR DESCRIPTION
This PR links the wasmedge shims agains the wasmedge static library:
* This simplifies distribution of the shims.

It uses the (new) combination of `standalone` and `static` features of the `wasmedge-sys` crate, which automatically downloads the static library as part of the build process:
* This removes the need to manually install wasmedge.
* Simplifies dependency management: the wasmedge version is now set by the upstream `wasmedge-sdk` crate.
* This requires switching to a git commit for `wasmedge-sdk` until tag `0.10.0` is released.

