### PR TITLE
feat: auto merge dependabot PRs for patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     ignore:
       - dependency-name: "wasmtime"
       - dependency-name: "wasi-common"

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,36 @@
+# This action will automatically merge dependabot PRs on patch updates
+#
+# See more: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+name: Dependabot automation
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot-automation:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs on patch updates
+        # Only enable auto-merge for patch updates
+        if: |  
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr edit "$PR_URL" -t "(auto merged) $PR_TITLE"
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new action called "Dependabot automation" which will automatically merge dependabot PRs for patch updates. According to this [doc](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request), 

> If you enable auto-merge for a pull request, the pull request will merge automatically when all required reviews are met and all required status checks have passed.

which means the PRs won't be auto-merged if the tests gate fails or it doesn't have the required number of reviews. 

Hence I've also added `gh pr review --approve "$PR_URL` to automatically approve the dependabot PRs. 

Since this automates the process of merging dependabot PRs, I've set the schedule interval for depdnabot to "daily". 

Close #150 

Could you please take a look? @utam0k 