### PR TITLE
fix: remove redundent cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
   fmt:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -35,7 +34,6 @@ jobs:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: Swatinem/rust-cache@v2
       - name: "check cgroup version"
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
       - name: Setup build env
         run: ${GITHUB_WORKSPACE}/.github/scripts/build.sh
         shell: bash


### PR DESCRIPTION
PR #185 changes action from [actions-rs/toolchain@v1](https://github.com/actions-rs/toolchain) to [actions-rust-lang/setup-rust-toolchain@v1](https://github.com/actions-rust-lang/setup-rust-toolchain)

There is a key difference between these two actions and that is cache. [actions-rust-lang/setup-rust-toolchain@v1](https://github.com/actions-rust-lang/setup-rust-toolchain) defaults to use "Swatinem/rust-cache", but we already have used this in the CI. 

So this PR removes the redundent cache steps, and disables the rust-cache action in the release CI. 