### PR TITLE
Pass the containerd address into shim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim"
 version = "0.3.0"
-source = "git+https://github.com/containerd/rust-extensions?rev=8500b4c665e0d0911b9546c00bd0bd4670cf5533#8500b4c665e0d0911b9546c00bd0bd4670cf5533"
+source = "git+https://github.com/containerd/rust-extensions?rev=7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93#7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93"
 dependencies = [
  "cgroups-rs",
  "command-fds",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "containerd-shim-protos"
 version = "0.3.0"
-source = "git+https://github.com/containerd/rust-extensions?rev=8500b4c665e0d0911b9546c00bd0bd4670cf5533#8500b4c665e0d0911b9546c00bd0bd4670cf5533"
+source = "git+https://github.com/containerd/rust-extensions?rev=7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93#7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93"
 dependencies = [
  "protobuf 3.2.0",
  "ttrpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 env_logger = "0.10"
 log = "0.4"
 tar = "0.4"
-containerd-shim = {git = "https://github.com/containerd/rust-extensions", rev = "8500b4c665e0d0911b9546c00bd0bd4670cf5533" }
+containerd-shim = {git = "https://github.com/containerd/rust-extensions", rev = "7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93" }
 ttrpc = "0.8.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 nix = "0.26"

--- a/crates/containerd-shim-wasm/protos/sandbox.proto
+++ b/crates/containerd-shim-wasm/protos/sandbox.proto
@@ -14,6 +14,7 @@ message CreateRequest {
     string id = 2;
     string ttrpc_address = 3;
     string working_directory = 4;
+    string containerd_address = 5;
 }
 
 message CreateResponse {

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -32,13 +32,15 @@ where
     bundle: Option<String>,
     /// Namespace for containerd
     namespace: String,
+    // /// GRPC address back to main containerd
+    containerd_address: String,
 }
 
 impl<E> InstanceConfig<E>
 where
     E: Send + Sync + Clone,
 {
-    pub fn new(engine: E, namespace: String) -> Self {
+    pub fn new(engine: E, namespace: String, containerd_address: String) -> Self {
         Self {
             engine,
             namespace,
@@ -46,6 +48,7 @@ where
             stdout: None,
             stderr: None,
             bundle: None,
+            containerd_address,
         }
     }
 
@@ -101,6 +104,11 @@ where
     /// get the namespace for the instance
     pub fn get_namespace(&self) -> String {
         self.namespace.clone()
+    }
+
+    /// get the containerd address for the instance
+    pub fn get_containerd_address(&self) -> String {
+        self.containerd_address.clone()
     }
 }
 

--- a/crates/containerd-shim-wasm/src/sandbox/manager.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/manager.rs
@@ -23,6 +23,7 @@ use containerd_shim::{
 };
 use nix::sched::{setns, unshare, CloneFlags};
 use oci_spec::runtime;
+use shim::Flags;
 use ttrpc::context;
 
 use super::error::Error;
@@ -38,7 +39,13 @@ where
 {
     type Instance: Instance<E = E>;
 
-    fn new(namespace: String, id: String, engine: E, publisher: RemotePublisher) -> Self;
+    fn new(
+        namespace: String,
+        containerd_address: String,
+        id: String,
+        engine: E,
+        publisher: RemotePublisher,
+    ) -> Self;
 }
 
 /// Service is a manager service which can be used to manage multiple instances of a sandbox in-process.
@@ -88,6 +95,7 @@ where
 
         let sb = T::new(
             req.namespace.clone(),
+            req.containerd_address.clone(),
             req.id.clone(),
             self.engine.clone(),
             publisher,
@@ -189,10 +197,10 @@ impl Task for Shim {}
 impl shim::Shim for Shim {
     type T = Self;
 
-    fn new(_runtime_id: &str, id: &str, namespace: &str, _config: &mut shim::Config) -> Self {
+    fn new(_runtime_id: &str, args: &Flags, _config: &mut shim::Config) -> Self {
         Shim {
-            id: id.to_string(),
-            namespace: namespace.to_string(),
+            id: args.id.to_string(),
+            namespace: args.namespace.to_string(),
         }
     }
 

--- a/crates/containerd-shim-wasm/src/services/sandbox.rs
+++ b/crates/containerd-shim-wasm/src/services/sandbox.rs
@@ -37,6 +37,8 @@ pub struct CreateRequest {
     pub ttrpc_address: ::std::string::String,
     // @@protoc_insertion_point(field:runwasi.services.sandbox.v1.CreateRequest.working_directory)
     pub working_directory: ::std::string::String,
+    // @@protoc_insertion_point(field:runwasi.services.sandbox.v1.CreateRequest.containerd_address)
+    pub containerd_address: ::std::string::String,
     // special fields
     // @@protoc_insertion_point(special_field:runwasi.services.sandbox.v1.CreateRequest.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -54,7 +56,7 @@ impl CreateRequest {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(4);
+        let mut fields = ::std::vec::Vec::with_capacity(5);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "namespace",
@@ -75,6 +77,11 @@ impl CreateRequest {
             "working_directory",
             |m: &CreateRequest| { &m.working_directory },
             |m: &mut CreateRequest| { &mut m.working_directory },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "containerd_address",
+            |m: &CreateRequest| { &m.containerd_address },
+            |m: &mut CreateRequest| { &mut m.containerd_address },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<CreateRequest>(
             "CreateRequest",
@@ -106,6 +113,9 @@ impl ::protobuf::Message for CreateRequest {
                 34 => {
                     self.working_directory = is.read_string()?;
                 },
+                42 => {
+                    self.containerd_address = is.read_string()?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -130,6 +140,9 @@ impl ::protobuf::Message for CreateRequest {
         if !self.working_directory.is_empty() {
             my_size += ::protobuf::rt::string_size(4, &self.working_directory);
         }
+        if !self.containerd_address.is_empty() {
+            my_size += ::protobuf::rt::string_size(5, &self.containerd_address);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -147,6 +160,9 @@ impl ::protobuf::Message for CreateRequest {
         }
         if !self.working_directory.is_empty() {
             os.write_string(4, &self.working_directory)?;
+        }
+        if !self.containerd_address.is_empty() {
+            os.write_string(5, &self.containerd_address)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -169,6 +185,7 @@ impl ::protobuf::Message for CreateRequest {
         self.id.clear();
         self.ttrpc_address.clear();
         self.working_directory.clear();
+        self.containerd_address.clear();
         self.special_fields.clear();
     }
 
@@ -178,6 +195,7 @@ impl ::protobuf::Message for CreateRequest {
             id: ::std::string::String::new(),
             ttrpc_address: ::std::string::String::new(),
             working_directory: ::std::string::String::new(),
+            containerd_address: ::std::string::String::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -847,11 +865,12 @@ impl ::protobuf::reflect::ProtobufValue for DeleteResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\rsandbox.proto\x12\x1brunwasi.services.sandbox.v1\"\x8f\x01\n\rCreate\
+    \n\rsandbox.proto\x12\x1brunwasi.services.sandbox.v1\"\xbe\x01\n\rCreate\
     Request\x12\x1c\n\tnamespace\x18\x01\x20\x01(\tR\tnamespace\x12\x0e\n\
     \x02id\x18\x02\x20\x01(\tR\x02id\x12#\n\rttrpc_address\x18\x03\x20\x01(\
     \tR\x0cttrpcAddress\x12+\n\x11working_directory\x18\x04\x20\x01(\tR\x10w\
-    orkingDirectory\"1\n\x0eCreateResponse\x12\x1f\n\x0bsocket_path\x18\x01\
+    orkingDirectory\x12-\n\x12containerd_address\x18\x05\x20\x01(\tR\x11cont\
+    ainerdAddress\"1\n\x0eCreateResponse\x12\x1f\n\x0bsocket_path\x18\x01\
     \x20\x01(\tR\nsocketPath\"E\n\x0eConnectRequest\x12\x0e\n\x02id\x18\x01\
     \x20\x01(\tR\x02id\x12#\n\rttrpc_address\x18\x02\x20\x01(\tR\x0cttrpcAdd\
     ress\"2\n\x0fConnectResponse\x12\x1f\n\x0bsocket_path\x18\x01\x20\x01(\t\

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -371,7 +371,11 @@ mod wasitest {
 
         spec.save(dir.path().join("config.json"))?;
 
-        let mut cfg = InstanceConfig::new(Wasi::new_engine()?, "test_namespace".into());
+        let mut cfg = InstanceConfig::new(
+            Wasi::new_engine()?,
+            "test_namespace".into(),
+            "/containerd/address".into(),
+        );
         let cfg = cfg
             .set_bundle(dir.path().to_str().unwrap().to_string())
             .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string());
@@ -407,7 +411,11 @@ mod wasitest {
         let vm = VmBuilder::new().with_config(config).build().unwrap();
         let i = Wasi::new(
             "".to_string(),
-            Some(&InstanceConfig::new(vm, "test_namespace".into())),
+            Some(&InstanceConfig::new(
+                vm,
+                "test_namespace".into(),
+                "/containerd/address".into(),
+            )),
         );
         i.delete().unwrap();
     }

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -40,14 +40,11 @@ static mut STDERR_FD: Option<RawFd> = None;
 pub struct Wasi {
     exit_code: ExitCode,
     engine: wasmtime::Engine,
-
     stdin: String,
     stdout: String,
     stderr: String,
     bundle: String,
-
     rootdir: PathBuf,
-
     id: String,
 }
 
@@ -401,7 +398,11 @@ mod wasitest {
             )
             .build()?;
         spec.save(dir.path().join("config.json"))?;
-        let mut cfg = InstanceConfig::new(Engine::default(), "test_namespace".into());
+        let mut cfg = InstanceConfig::new(
+            Engine::default(),
+            "test_namespace".into(),
+            "/containerd/address".into(),
+        );
         let cfg = cfg
             .set_bundle(dir.path().to_str().unwrap().to_string())
             .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string())


### PR DESCRIPTION
This updates Rust-extensions dep to include https://github.com/containerd/rust-extensions/pull/150 which enables using containerd from within the shim.  This is in perp for handling oci artifacts that will be stored in the containerd content store in which we need the containerd address.