### PR TITLE
[CI] Make Ubuntu 20.04 and 22.04 use different rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        env:
+          RUST_CACHE_KEY_OS: ${{ matrix.os }}
       - name: Setup OCI runtime build env
         run: ${GITHUB_WORKSPACE}/.github/scripts/build.sh
         shell: bash


### PR DESCRIPTION
Currently Ubuntu 20.04 and 22.04 are sharing the same cache.
This is a problem as 20.04 and 22.04 ship differente glibc versions.
This prevents the buil scripts compiled and cached in 22.04 from running in 20.04.

`actions-rust-lang/setup-rust-toolchain@v1` uses `Swatinem/rust-cache@v2`, which uses all environment variables matching `RUST*` as hash for the cache key. See the description of `env-vars` [here](https://github.com/marketplace/actions/rust-cache).

This PR adds an environment variable `RUST_CACHE_KEY_OS` so that different OS use different caches.

This fixes #193.