### PR TITLE
Check for existence of args otherwise fail in wasmtime

### DIFF
--- a/crates/containerd-shim-wasmtime/src/executor.rs
+++ b/crates/containerd-shim-wasmtime/src/executor.rs
@@ -24,7 +24,7 @@ pub struct WasmtimeExecutor {
 impl Executor for WasmtimeExecutor {
     fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
         let args = oci::get_args(spec);
-        if args.len() != 1 {
+        if args.is_empty() {
             return Err(ExecutorError::InvalidArg);
         }
 


### PR DESCRIPTION
After #131, only a single arg was allowed to pass causing the shim to fail.  An example is:

```
sudo ctr run --rm --runtime=/home/jstur/.local/bin/containerd-shim-wasmtime-v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm /wasi-demo-app.wasm echo 'hello'
```

With this change something this works:

```
sudo ctr run --rm --runtime=/home/jstur/.local/bin/containerd-shim-wasmtime-v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm /wasi-demo-app.wasm echo 'hello'            
hello
 exiting  
```

TODO:
- add unit test 
- look into why the shim fails silently in this case (there is a log message if you are following containerd logs:

```
[ERROR] failed to execute workload err=InvalidArg name="wasmtime"
Jul 25 17:56:37 jjs15338 containerd[697]: [ERROR] failed to execute payload err=ExecutionFailed { source: InvalidArg, name: "wasmtime" }
```