### PR TITLE
Add crate feature to disable libwasmedge static linking

### DIFF
--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -26,6 +26,9 @@ pretty_assertions = "1"
 serial_test = "*"
 
 [features]
+default = ["standalone", "static"]
+standalone = ["wasmedge-sdk/standalone"]
+static = ["wasmedge-sdk/static"]
 wasi_nn = ["wasmedge-sdk/wasi_nn"]
 
 [[bin]]


### PR DESCRIPTION
Fixes #206 