### PR TITLE
fix: add a stat condition check for uploading release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,15 @@ jobs:
       - name: Create release
         run: |
           gh release create ${{ github.ref }} --generate-notes --prerelease
-          for i in release/*/*; do
-            gh release upload ${RELEASE_NAME} $i
-          done
+          # skip upload if there are no files
+          if stat release/*/* >/dev/null 2>&1; then
+            for i in release/*/*; do
+              gh release upload ${RELEASE_NAME} $i
+            done
+          else
+            echo "No files to upload"
+            exit 0
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NAME: ${{ needs.generate.outputs.crate }}/${{ needs.generate.outputs.version }}


### PR DESCRIPTION
This commits adds a check to confirm the existance of files in the release subdirectories before attempting to upload to GitHub release. This change helps avoid unnecessary errors in the case where the release subdirectories are empty.

An instance of the failed run this commits tries to resolve is found [here](https://github.com/containerd/runwasi/actions/runs/5718307257). 