### PR TITLE
feat: add stats function to task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cgroups-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b098e7c3a70d03c288fa0a96ccf13e770eb3d78c4cc0e1549b3c13215d5f965"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,7 +468,7 @@ name = "containerd-shim"
 version = "0.3.0"
 source = "git+https://github.com/containerd/rust-extensions?rev=7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93#7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93"
 dependencies = [
- "cgroups-rs",
+ "cgroups-rs 0.2.11",
  "command-fds",
  "containerd-shim-protos",
  "go-flag",
@@ -494,6 +507,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "caps",
+ "cgroups-rs 0.3.2",
  "chrono",
  "clone3",
  "command-fds",
@@ -1721,6 +1735,18 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -28,6 +28,7 @@ clone3 = "0.2"
 libc = { workspace = true }
 caps = "0.5"
 proc-mounts = "0.3"
+cgroups-rs = "0.3.2"
 
 [build-dependencies]
 ttrpc-codegen = { version = "0.4.2", optional = true }

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -17,7 +17,7 @@ use super::instance::{EngineGetter, Instance, InstanceConfig, Nop, Wait};
 use super::{oci, Error, SandboxService};
 use cgroups_rs::cgroup::get_cgroups_relative_paths_by_pid;
 use cgroups_rs::hierarchies::{self};
-use cgroups_rs::{Cgroup, Hierarchy, Subsystem};
+use cgroups_rs::{Cgroup, Subsystem};
 use chrono::{DateTime, Utc};
 use containerd_shim::{
     self as shim, api,

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -16,7 +16,7 @@ use std::thread;
 use super::instance::{EngineGetter, Instance, InstanceConfig, Nop, Wait};
 use super::{oci, Error, SandboxService};
 use cgroups_rs::cgroup::get_cgroups_relative_paths_by_pid;
-use cgroups_rs::hierarchies::{self, V2};
+use cgroups_rs::hierarchies::{self};
 use cgroups_rs::{Cgroup, Hierarchy, Subsystem};
 use chrono::{DateTime, Utc};
 use containerd_shim::{
@@ -41,8 +41,8 @@ use nix::sys::stat::Mode;
 use nix::unistd::mkdir;
 use oci_spec::runtime;
 use shim::api::{StatsRequest, StatsResponse};
-use shim::cgroup::collect_metrics;
-use shim::protos::cgroups::metrics::{CPUStat, CPUUsage, MemoryEntry, MemoryStat, Metrics};
+
+use shim::protos::cgroups::metrics::{MemoryEntry, MemoryStat, Metrics};
 use shim::util::convert_to_any;
 use shim::Flags;
 use ttrpc::context::Context;
@@ -1383,10 +1383,10 @@ where
     fn stats(
         &self,
         _ctx: &::ttrpc::TtrpcContext,
-        _req: StatsRequest,
+        req: StatsRequest,
     ) -> ::ttrpc::Result<StatsResponse> {
-        log::info!("stats: {:?}", _req);
-        let resp = self.task_stats(_req)?;
+        log::info!("stats: {:?}", req);
+        let resp = self.task_stats(req)?;
         Ok(resp)
     }
 }

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -548,6 +548,12 @@ mod localtests {
         })?;
         assert_eq!(state.status(), Status::RUNNING);
 
+        let stats = local.task_stats(api::StatsRequest {
+            id: "testinstance".to_string(),
+            ..Default::default()
+        })?;
+        assert!(stats.has_stats());
+
         let ll = local.clone();
         let (instance_tx, instance_rx) = channel();
         std::thread::spawn(move || {
@@ -703,6 +709,12 @@ mod localtests {
         });
 
         rx.try_recv().unwrap_err();
+
+        let res = local.task_stats(api::StatsRequest {
+            id: "test".to_string(),
+            ..Default::default()
+        })?;
+        assert!(res.has_stats());
 
         local.task_kill(api::KillRequest {
             id: "test".to_string(),


### PR DESCRIPTION
This PR adds a new `stats` function to the implementation of a Task. It uses `cgroups_rs` crate to get the memory stats from cgroup subsystems, which is largely inspired by how containerd runc shim is implemented in rust-extensions repo. 

This is currently work-in-process but I want to get it out there so to collect some early feedback. 

If you want to test it, you can use `ctr task metric <task-name>` to print out the memory usage of the task

```bash
➜  runwasi git:(stats) ✗ sudo ctr task metric testwasm
ID          TIMESTAMP                              
testwasm    seconds:1690930464  nanos:407172844    

METRIC                   VALUE       
memory.usage_in_bytes    18649088    
memory.limit_in_bytes    0           
memory.stat.cache        0           
cpuacct.usage            3545445     
cpuacct.usage_percpu     []          
pids.current             9           
pids.limit               0     
```

TODO:
- [x] unit tests the stats function in cgroup v1
- [x] unit tests the stats function in cgroup v2

Closes #208 
