### PR TITLE
Centralize running wasi test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror",
  "ttrpc",

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -28,12 +28,12 @@ clone3 = "0.2"
 libc = { workspace = true }
 caps = "0.5"
 proc-mounts = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 ttrpc-codegen = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
-tempfile = "3"
 pretty_assertions = "1"
 signal-hook = "0.3"
 env_logger = { workspace = true }

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -42,6 +42,7 @@ tempfile = "3.7"
 libc = { workspace = true }
 pretty_assertions = "1"
 env_logger = "0.10"
+serial_test = "*"
 
 [[bin]]
 name = "containerd-shim-wasmtime-v1"

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -264,55 +264,55 @@ impl EngineGetter for Wasi {
 
 #[cfg(test)]
 mod wasitest {
-    use std::fs::{create_dir, read_to_string, File, OpenOptions};
-    use std::io::prelude::*;
-    use std::os::unix::prelude::OpenOptionsExt;
-    use std::sync::mpsc::channel;
-    use std::time::Duration;
-
     use containerd_shim_wasm::function;
     use containerd_shim_wasm::sandbox::exec::has_cap_sys_admin;
-    use containerd_shim_wasm::sandbox::instance::Wait;
-    use containerd_shim_wasm::sandbox::testutil::run_test_with_sudo;
-    use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder};
-    use tempfile::{tempdir, TempDir};
+    use containerd_shim_wasm::sandbox::testutil::{run_test_with_sudo, run_wasi_test};
+    use serial_test::serial;
+    use std::fs::read_to_string;
+    use tempfile::tempdir;
 
     use super::*;
 
     // This is taken from https://github.com/bytecodealliance/wasmtime/blob/6a60e8363f50b936e4c4fc958cb9742314ff09f3/docs/WASI-tutorial.md?plain=1#L270-L298
-    const WASI_HELLO_WAT: &[u8]= r#"(module
-        ;; Import the required fd_write WASI function which will write the given io vectors to stdout
-        ;; The function signature for fd_write is:
-        ;; (File Descriptor, *iovs, iovs_len, nwritten) -> Returns number of bytes written
-        (import "wasi_unstable" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
-
-        (memory 1)
-        (export "memory" (memory 0))
-
-        ;; Write 'hello world\n' to memory at an offset of 8 bytes
-        ;; Note the trailing newline which is required for the text to appear
-        (data (i32.const 8) "hello world\n")
-
-        (func $main (export "_start")
-            ;; Creating a new io vector within linear memory
-            (i32.store (i32.const 0) (i32.const 8))  ;; iov.iov_base - This is a pointer to the start of the 'hello world\n' string
-            (i32.store (i32.const 4) (i32.const 12))  ;; iov.iov_len - The length of the 'hello world\n' string
-
-            (call $fd_write
-                (i32.const 1) ;; file_descriptor - 1 for stdout
-                (i32.const 0) ;; *iovs - The pointer to the iov array, which is stored at memory location 0
-                (i32.const 1) ;; iovs_len - We're printing 1 string stored in an iov - so one.
-                (i32.const 20) ;; nwritten - A place in memory to store the number of bytes written
+    fn hello_world_module(start_fn: Option<&str>) -> Vec<u8> {
+        let start_fn = start_fn.unwrap_or("_start");
+        format!(r#"(module
+            ;; Import the required fd_write WASI function which will write the given io vectors to stdout
+            ;; The function signature for fd_write is:
+            ;; (File Descriptor, *iovs, iovs_len, nwritten) -> Returns number of bytes written
+            (import "wasi_unstable" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+    
+            (memory 1)
+            (export "memory" (memory 0))
+    
+            ;; Write 'hello world\n' to memory at an offset of 8 bytes
+            ;; Note the trailing newline which is required for the text to appear
+            (data (i32.const 8) "hello world\n")
+    
+            (func $main (export "{start_fn}")
+                ;; Creating a new io vector within linear memory
+                (i32.store (i32.const 0) (i32.const 8))  ;; iov.iov_base - This is a pointer to the start of the 'hello world\n' string
+                (i32.store (i32.const 4) (i32.const 12))  ;; iov.iov_len - The length of the 'hello world\n' string
+    
+                (call $fd_write
+                    (i32.const 1) ;; file_descriptor - 1 for stdout
+                    (i32.const 0) ;; *iovs - The pointer to the iov array, which is stored at memory location 0
+                    (i32.const 1) ;; iovs_len - We're printing 1 string stored in an iov - so one.
+                    (i32.const 20) ;; nwritten - A place in memory to store the number of bytes written
+                )
+                drop ;; Discard the number of bytes written from the top of the stack
             )
-            drop ;; Discard the number of bytes written from the top of the stack
         )
-    )
-    "#.as_bytes();
+        "#).as_bytes().to_vec()
+    }
 
     #[test]
     fn test_delete_after_create() -> Result<()> {
-        let dir = tempdir()?;
-        let cfg = prepare_cfg(&dir)?;
+        let cfg = InstanceConfig::new(
+            Wasi::new_engine()?,
+            "test_namespace".into(),
+            "/containerd/address".into(),
+        );
 
         let i = Wasi::new("".to_string(), Some(&cfg));
         i.delete()?;
@@ -321,92 +321,30 @@ mod wasitest {
     }
 
     #[test]
-    fn test_wasi() -> Result<(), Error> {
+    #[serial]
+    fn test_wasi_entrypoint() -> Result<(), Error> {
         if !has_cap_sys_admin() {
             println!("running test with sudo: {}", function!());
             return run_test_with_sudo(function!());
         }
         // start logging
+        // to enable logging run `export RUST_LOG=trace` and append cargo command with --show-output
+        // before running test
         let _ = env_logger::try_init();
 
         let dir = tempdir()?;
-        let cfg = prepare_cfg(&dir)?;
+        let path = dir.path();
 
-        let wasi = Wasi::new("test".to_string(), Some(&cfg));
+        let module = hello_world_module(None);
 
-        wasi.start()?;
+        let res = run_wasi_test::<Wasi, wasmtime::Engine>(&dir, module.into(), None)?;
 
-        let (tx, rx) = channel();
-        let waiter = Wait::new(tx);
-        wasi.wait(&waiter).unwrap();
-
-        let res = match rx.recv_timeout(Duration::from_secs(10)) {
-            Ok(res) => res,
-            Err(e) => {
-                wasi.kill(SIGKILL as u32).unwrap();
-                return Err(Error::Others(format!(
-                    "error waiting for module to finish: {0}",
-                    e
-                )));
-            }
-        };
         assert_eq!(res.0, 0);
 
-        let output = read_to_string(dir.path().join("stdout"))?;
+        let output = read_to_string(path.join("stdout"))?;
         assert_eq!(output, "hello world\n");
-
-        wasi.delete()?;
 
         reset_stdio();
         Ok(())
-    }
-
-    fn prepare_cfg(dir: &TempDir) -> Result<InstanceConfig<Engine>> {
-        create_dir(dir.path().join("rootfs"))?;
-
-        let opts = Options {
-            root: Some(dir.path().join("runwasi")),
-        };
-        let opts_file = OpenOptions::new()
-            .read(true)
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(dir.path().join("options.json"))?;
-        write!(&opts_file, "{}", serde_json::to_string(&opts)?)?;
-
-        let wasm_path = dir.path().join("rootfs/hello.wat");
-        let mut f = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o755)
-            .open(wasm_path)?;
-        f.write_all(WASI_HELLO_WAT)?;
-
-        let stdout = File::create(dir.path().join("stdout"))?;
-        let stderr = File::create(dir.path().join("stderr"))?;
-        drop(stdout);
-        drop(stderr);
-        let spec = SpecBuilder::default()
-            .root(RootBuilder::default().path("rootfs").build()?)
-            .process(
-                ProcessBuilder::default()
-                    .cwd("/")
-                    .args(vec!["./hello.wat".to_string()])
-                    .build()?,
-            )
-            .build()?;
-        spec.save(dir.path().join("config.json"))?;
-        let mut cfg = InstanceConfig::new(
-            Engine::default(),
-            "test_namespace".into(),
-            "/containerd/address".into(),
-        );
-        let cfg = cfg
-            .set_bundle(dir.path().to_str().unwrap().to_string())
-            .set_stdout(dir.path().join("stdout").to_str().unwrap().to_string())
-            .set_stderr(dir.path().join("stderr").to_str().unwrap().to_string());
-        Ok(cfg.to_owned())
     }
 }


### PR DESCRIPTION
When working on #219, I noticed the testing logic is all the same and I was adding functionality in two places.  

This is just an example of an idea to re-use some of it.  I would like to get others thoughts on if this makes sense of not.   I am on the fence... but thought I would share as it similar to https://github.com/containerd/runwasi/pull/111#pullrequestreview-1496058596

If so we could clean it up, move it somewhere else and maybe improve the function `run_wasi_test<I, E>` as it needs instance and the associated item.