### PR TITLE
chore: bump containerd-shim to 0.4.0 and bump crates patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,8 +452,9 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim"
-version = "0.3.0"
-source = "git+https://github.com/containerd/rust-extensions?rev=7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93#7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b838538bbc58599a085b1d9e525eb15eae53c48c756f3339dc61524f77891a"
 dependencies = [
  "cgroups-rs",
  "command-fds",
@@ -480,8 +481,9 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-protos"
-version = "0.3.0"
-source = "git+https://github.com/containerd/rust-extensions?rev=7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93#7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbbd1b58f3aa972bb5218a0a79c9e96939113f5db5cacbd15be5022e02ba2d5"
 dependencies = [
  "protobuf 3.2.0",
  "ttrpc",
@@ -490,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "caps",
@@ -518,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmedge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -542,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -1816,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "oci-tar-builder"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2950,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-demo-app"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/containerd/runwasi"
@@ -23,7 +23,7 @@ serde_json = "1.0"
 env_logger = "0.10"
 log = "0.4"
 tar = "0.4"
-containerd-shim = {git = "https://github.com/containerd/rust-extensions", rev = "7f7e3117a6ecb49e5e3b48b4f457a4914d2f2b93" }
+containerd-shim = "0.4.0"
 ttrpc = "0.8.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 nix = "0.26"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd-shim-wasm"
 description = "Library for building containerd shims for wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"


### PR DESCRIPTION
This commit bumps the containerd-shim to 0.4.0 version and all the shims crates and containerd-shim-wasm crate to a new patch version as a preparation for a new release

Closes #162