### PR TITLE
MAINTAINERS: Add James Sturtevant(jsturtevant) as a REVIEWER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,3 +15,4 @@
 "ipuustin","Ismo Puustinen","ismo.puustinen@intel.com"
 "rumpl","Djordje Lukic","djordje.lukic@docker.com"
 "utam0k","Toru Komatsu","k0ma@utam0k.jp"
+"jsturtevant","James Sturtevant","jstur@microsoft.com"


### PR DESCRIPTION
I'd like to invite @jsturtevant as a reviewer. He had made sustained commits to runwasi, including his work on enabling OCI artifacts for Wasm, demonstrated his technical depth and knowledge on this project.

Needs explicit LGTM from @rumpl and 1/3 of the runwasi Committers according to https://github.com/containerd/project/blob/main/GOVERNANCE.md.

- [ ] @devigned
- [ ] @cpuguy83
- [ ] @danbugs

This PR will remain open for 7 days.