### PR TITLE
MAINTAINERS: Add Jorge Prendes(jprendes) as a REVIEWER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16,3 +16,4 @@
 "rumpl","Djordje Lukic","djordje.lukic@docker.com"
 "utam0k","Toru Komatsu","k0ma@utam0k.jp"
 "jsturtevant","James Sturtevant","jstur@microsoft.com"
+"jprendes","Jorge Prendes","jorge.prendes@gmail.com"


### PR DESCRIPTION
I'd like to invite @jprendes as a reviewer. He had made sustained commits to runwasi, including his work on linking against WasmEdge static library. He has demonstrated his technical depth and knowledge on this project.

Needs explicit LGTM from @jprendes  and 1/3 of the runwasi Committers according to https://github.com/containerd/project/blob/main/GOVERNANCE.md.

- [x] @devigned
- [x] @cpuguy83
- [ ] @danbugs

This PR will remain open for 7 days.