### PR TITLE
refactor: remove engine getter and the generic type `E`

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -11,7 +11,7 @@ pub mod manager;
 pub mod shim;
 
 pub use error::{Error, Result};
-pub use instance::{EngineGetter, Instance, InstanceConfig};
+pub use instance::{Instance, InstanceConfig};
 pub use manager::{Sandbox as SandboxService, Service as ManagerService};
 pub use shim::{Cli as ShimCli, Local};
 

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
@@ -3,5 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmedge::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance, wasmedge_sdk::Vm>>("io.containerd.wasmedge.v1", None);
+    shim::run::<ShimCli<WasiInstance>>("io.containerd.wasmedge.v1", None);
 }

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
@@ -3,5 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmedge::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance>>("io.containerd.wasmedge.v1", None);
+    shim::run::<ShimCli<WasiInstance, _>>("io.containerd.wasmedge.v1", None);
 }

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use containerd_shim_wasm::sandbox::EngineGetter;
 use containerd_shim_wasm::sandbox::{Local, ManagerService};
 use containerd_shim_wasm::services::sandbox_ttrpc::{create_manager, Manager};
 use containerd_shim_wasmedge::instance::Wasi as WasiInstance;
@@ -9,8 +8,7 @@ use ttrpc::{self, Server};
 
 fn main() {
     info!("starting up!");
-    let s: ManagerService<_, Local<WasiInstance, _>> =
-        ManagerService::new(WasiInstance::new_engine().unwrap());
+    let s: ManagerService<Local<WasiInstance>> = ManagerService::new();
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
@@ -8,7 +8,7 @@ use ttrpc::{self, Server};
 
 fn main() {
     info!("starting up!");
-    let s: ManagerService<Local<WasiInstance>> = ManagerService::new();
+    let s: ManagerService<Local<WasiInstance, _>, _> = ManagerService::default();
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmedge/src/engine.rs
+++ b/crates/containerd-shim-wasmedge/src/engine.rs
@@ -1,0 +1,40 @@
+use containerd_shim_wasm::sandbox::instance::Engine;
+use wasmedge_sdk::config::CommonConfigOptions;
+use wasmedge_sdk::config::ConfigBuilder;
+use wasmedge_sdk::config::HostRegistrationConfigOptions;
+use wasmedge_sdk::Vm;
+use wasmedge_sdk::VmBuilder;
+
+#[derive(Debug, Clone)]
+pub struct WasmEdgeEngine {
+    vm: Vm,
+}
+
+impl From<WasmEdgeEngine> for Vm {
+    fn from(val: WasmEdgeEngine) -> Self {
+        val.vm
+    }
+}
+
+impl From<Vm> for WasmEdgeEngine {
+    fn from(vm: Vm) -> Self {
+        Self { vm }
+    }
+}
+
+impl Default for WasmEdgeEngine {
+    fn default() -> Self {
+        let config = ConfigBuilder::new(CommonConfigOptions::default())
+            .with_host_registration_config(HostRegistrationConfigOptions::default().wasi(true))
+            .build()
+            .unwrap();
+        let vm = VmBuilder::new().with_config(config).build().unwrap();
+        Self { vm }
+    }
+}
+
+impl Engine for WasmEdgeEngine {
+    fn new() -> Self {
+        WasmEdgeEngine::default()
+    }
+}

--- a/crates/containerd-shim-wasmedge/src/lib.rs
+++ b/crates/containerd-shim-wasmedge/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod engine;
 pub mod error;
 pub mod executor;
 pub mod instance;

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-shim-wasmtime-v1/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-shim-wasmtime-v1/main.rs
@@ -3,5 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmtime::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance>>("io.containerd.wasmtime.v1", None);
+    shim::run::<ShimCli<WasiInstance, _>>("io.containerd.wasmtime.v1", None);
 }

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-shim-wasmtime-v1/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-shim-wasmtime-v1/main.rs
@@ -3,5 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmtime::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance, wasmtime::Engine>>("io.containerd.wasmtime.v1", None);
+    shim::run::<ShimCli<WasiInstance>>("io.containerd.wasmtime.v1", None);
 }

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
@@ -8,7 +8,7 @@ use ttrpc::{self, Server};
 
 fn main() {
     info!("starting up!");
-    let s: ManagerService<Local<WasiInstance>> = ManagerService::new();
+    let s: ManagerService<Local<WasiInstance, _>, _> = ManagerService::default();
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
@@ -5,12 +5,10 @@ use containerd_shim_wasm::services::sandbox_ttrpc::{create_manager, Manager};
 use containerd_shim_wasmtime::instance::Wasi as WasiInstance;
 use log::info;
 use ttrpc::{self, Server};
-use wasmtime::Engine;
 
 fn main() {
     info!("starting up!");
-    let engine = Engine::default();
-    let s: ManagerService<_, Local<WasiInstance, _>> = ManagerService::new(engine);
+    let s: ManagerService<Local<WasiInstance>> = ManagerService::new();
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmtime/src/engine.rs
+++ b/crates/containerd-shim-wasmtime/src/engine.rs
@@ -1,0 +1,27 @@
+use containerd_shim_wasm::sandbox::instance::Engine as InstanceEngine;
+use wasmtime::Engine;
+
+#[derive(Default, Clone)]
+pub struct WasmtimeEngine {
+    engine: Engine,
+}
+
+impl From<Engine> for WasmtimeEngine {
+    fn from(engine: Engine) -> Self {
+        Self { engine }
+    }
+}
+
+impl From<WasmtimeEngine> for Engine {
+    fn from(val: WasmtimeEngine) -> Self {
+        val.engine
+    }
+}
+
+impl InstanceEngine for WasmtimeEngine {
+    fn new() -> Self {
+        Self {
+            engine: Engine::default(),
+        }
+    }
+}

--- a/crates/containerd-shim-wasmtime/src/lib.rs
+++ b/crates/containerd-shim-wasmtime/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod engine;
 pub mod error;
 pub mod executor;
 pub mod instance;


### PR DESCRIPTION
There is no practical use of `get_engine()` function from the `EngineGetter` trait, so I decided to remove it entirely. 

It looks like youki's Executor is all we need