### PR TITLE
Add alpine build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup buildx
         run: docker buildx create --use
       - name: build binaries
-        run: docker buildx bake --set *.cache-from=type=gha,scope=buildkit-release-${CRATE} --set *.cache-to=type=gha,scope=buildkit-release-${CRATE} release-tars
+        run: docker buildx bake --set *.cache-from=type=gha,scope=buildkit-release-${CRATE} --set *.cache-to=type=gha,scope=buildkit-release-${CRATE} tar-cross
         env:
           CRATE: ${{ needs.generate.outputs.crate }}
       - name: upload binary as GitHub artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "chrono",
  "containerd-shim",
  "containerd-shim-wasm",
+ "dbus",
  "libc",
  "libcontainer",
  "log",
@@ -567,6 +568,7 @@ dependencies = [
  "chrono",
  "containerd-shim",
  "containerd-shim-wasm",
+ "dbus",
  "env_logger",
  "libc",
  "libcontainer",
@@ -1656,6 +1658,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 nix = { workspace = true }
 libc = { workspace = true }
 libcontainer = { workspace = true }
+dbus = { version = "*", optional = true }
 
 [dev-dependencies]
 tempfile = "3.7"
@@ -31,6 +32,7 @@ default = ["standalone", "static"]
 standalone = ["wasmedge-sdk/standalone"]
 static = ["wasmedge-sdk/static"]
 wasi_nn = ["wasmedge-sdk/wasi_nn"]
+vendored_dbus = ["dbus/vendored"]
 
 [[bin]]
 name = "containerd-shim-wasmedge-v1"

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -34,6 +34,7 @@ thiserror = { workspace = true }
 serde_json = { workspace = true }
 nix = { workspace = true }
 libcontainer = { workspace = true }
+dbus = { version = "*", optional = true }
 serde = { workspace = true }
 libc = { workspace = true }
 
@@ -42,6 +43,9 @@ tempfile = "3.7"
 libc = { workspace = true }
 pretty_assertions = "1"
 env_logger = "0.10"
+
+[features]
+vendored_dbus = ["dbus/vendored"]
 
 [[bin]]
 name = "containerd-shim-wasmtime-v1"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "CRATE" {
-    default = ""
+    default = null
 }
 
 # special target: https://github.com/docker/metadata-action#bake-definition
@@ -19,10 +19,15 @@ target "image" {
 
 target "image-cross" {
     inherits = ["image"]
-    platforms = [
-        "linux/amd64",
-        "linux/arm64"
-    ]
+    platforms = ["linux/${arch}"]
+    name = "image-cross-${image}-${arch}"
+    matrix = {
+        image = ["bullseye", "alpine"]
+        arch = ["amd64", "arm64"]
+    }
+    args = {
+        "BASE_IMAGE" = "${image}"
+    }
 }
 
 target "bins" {
@@ -32,14 +37,33 @@ target "bins" {
 
 target "bins-cross" {
     inherits = ["bins"]
-    platforms = [
-        "linux/amd64",
-        "linux/arm64"
-    ]
+    output= ["type=local,dest=bin/${image}-${arch}"]
+    platforms = ["linux/${arch}"]
+    name = "bins-cross-${image}-${arch}"
+    matrix = {
+        image = ["bullseye", "alpine"]
+        arch = ["amd64", "arm64"]
+    }
+    args = {
+        "BASE_IMAGE" = "${image}"
+    }
 }
 
-target "release-tars" {
-    inherits = ["bins-cross"]
+target "tar" {
+    inherits = ["bins"]
     output = ["type=local,dest=release/"]
     target = "release-tar"
+}
+
+target "tar-cross" {
+    inherits = ["tar"]
+    platforms = ["linux/${arch}"]
+    name = "tar-cross-${image}-${arch}"
+    matrix = {
+        image = ["bullseye", "alpine"]
+        arch = ["amd64", "arm64"]
+    }
+    args = {
+        "BASE_IMAGE" = "${image}"
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
+# Make sure to this in sync with RUST_VERSION in the Dockerfile
+channel="1.71.1"
 profile="default"
-channel="1.71.0"

--- a/scripts/dockerfile-utils.sh
+++ b/scripts/dockerfile-utils.sh
@@ -1,0 +1,61 @@
+# Runs a recipe for a step in the Dockerfile.
+# Usage:
+#   dockerfile-utils <step>
+#
+# where step is one of `install_host`, `install_target` or `build_setup`.
+#  * install_host:   installs build tools and other host environment dependencies (things that run in the host).
+#  * install_target: installs build dependencies like libraries (things that will run in the target).
+#  * build_setup:    setup to customize the build process (mainly setting env-vars)
+#
+# This script choosses the correct recipe based on the linux distribution of the base image.
+# Supported distributions are `debian` and `alpine`.
+
+dockerfile_utils_alpine() {
+    # recipes for alpine
+
+    install_host() {
+        apk add g++ bash clang pkgconf git protoc jq
+        apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main rust-bindgen
+    }
+
+    install_target() {
+        xx-apk add \
+            gcc g++ musl-dev zlib-dev zlib-static \
+            ncurses-dev ncurses-static libffi-dev \
+            libseccomp-dev libseccomp-static
+    }
+
+    setup_build() {
+        export WASMEDGE_DEP_STDCXX_LINK_TYPE="static"
+        export WASMEDGE_DEP_STDCXX_LIB_PATH="$(xx-info sysroot)usr/lib"
+        export WASMEDGE_RUST_BINDGEN_PATH="$(which bindgen)"
+        export LIBSECCOMP_LINK_TYPE="static"
+        export LIBSECCOMP_LIB_PATH="$(xx-info sysroot)usr/lib"
+        export RUSTFLAGS="-Cstrip=symbols -Clink-arg=-lgcc"
+        export CARGO_FLAGS="--features=vendored_dbus"
+    }
+
+}
+
+dockerfile_utils_debian() {
+    # recipes for debian
+
+    install_host() {
+        apt-get update -y
+        apt-get install --no-install-recommends -y clang pkg-config dpkg-dev git jq
+    }
+
+    install_target() {
+        xx-apt-get install -y \
+            gcc g++ libc++6-dev zlib1g \
+            libsystemd-dev libdbus-1-dev libseccomp-dev
+    }
+
+    setup_build() {
+        export RUSTFLAGS="-Cstrip=symbols"
+    }
+
+}
+
+dockerfile_utils_$(xx-info vendor)
+$1


### PR DESCRIPTION
This PR adds support for building alpine binaries.

The main changes:
* Add a build argument to the Dockerfile to specify the base image.
* Update the bake file to account for the new argument
* Move some of the logic from the Dockerfile to a shell script that handles the different base images.
* The name of the tar archives now end with `-gnu`or `-musl` (for debian and alpine respectively).
* Bumped `wasmedge-sdk` to 0.11.2 (required for building with alpine https://github.com/WasmEdge/wasmedge-rust-sdk/pull/48).
* Add a feature to vendor the dbus crate (so that it links statically)

Result:
```bash
$ docker buildx bake bins-cross tar-cross
# ... 4 parallel builds, go get a coffee ...

$ ls bin
alpine-amd64  alpine-arm64  bullseye-amd64  bullseye-arm64

$ ls bin/alpine-amd64/
containerd-shim-wasmedged-v1  containerd-shim-wasmtimed-v1  containerd-wasmedged
containerd-shim-wasmedge-v1   containerd-shim-wasmtime-v1   containerd-wasmtimed
# same output for bin/alpine-arm64, bin/bullseye-amd64, and bin/bullseye-arm64

$ ls release/
containerd-shim-wasmedge-linux-amd64-gnu.tar.gz   containerd-shim-wasmtime-linux-amd64-gnu.tar.gz
containerd-shim-wasmedge-linux-amd64-musl.tar.gz  containerd-shim-wasmtime-linux-amd64-musl.tar.gz
containerd-shim-wasmedge-linux-arm64-gnu.tar.gz   containerd-shim-wasmtime-linux-arm64-gnu.tar.gz
containerd-shim-wasmedge-linux-arm64-musl.tar.gz  containerd-shim-wasmtime-linux-arm64-musl.tar.gz

$ ldd bin/alpine-amd64/containerd-shim-wasmedge-v1 
        statically linked

$ ldd bin/bullseye-amd64/containerd-shim-wasmedge-v1 
        linux-vdso.so.1 (0x00007ffe1e1b8000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f33f077d000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f33f0778000)
        # ... and more ...
```