### PR TITLE
Remove redundant generics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-bin/
-test/out/img.tar
+/bin/
+/test/out/img.tar
+/test/k8s/_out
 **/target/
-!crates/wasmedge/src/bin/
-!crates/wasmtime/src/bin/
-test/k8s/_out
-release/
-.vscode/
+/release/
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use containerd_shim as shim;
 use containerd_shim_wasm::sandbox::{ShimCli, Instance}
 
 struct MyInstance {
- // ...
+    // ...
 }
 
 impl Instance for MyInstance {

--- a/crates/containerd-shim-wasm/src/libcontainer_instance/instance.rs
+++ b/crates/containerd-shim-wasm/src/libcontainer_instance/instance.rs
@@ -35,10 +35,10 @@ use crate::sandbox::{error::Error, instance::Wait, Instance};
 /// methods.
 pub trait LibcontainerInstance {
     /// The WASI engine type
-    type E: Send + Sync + Clone;
+    type Engine: Send + Sync + Clone;
 
     /// Create a new instance
-    fn new_libcontainer(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self;
+    fn new_libcontainer(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Self;
 
     /// Get the exit code of the instance
     fn get_exit_code(&self) -> ExitCode;
@@ -57,9 +57,9 @@ pub trait LibcontainerInstance {
 /// This implementation uses the libcontainer library to create and start
 /// the container.
 impl<T: LibcontainerInstance> Instance for T {
-    type E = T::E;
+    type Engine = T::Engine;
 
-    fn new(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self {
+    fn new(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Self {
         Self::new_libcontainer(id, cfg)
     }
 

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -15,13 +15,10 @@ pub type ExitCode = Arc<(Mutex<Option<(u32, DateTime<Utc>)>>, Condvar)>;
 /// Generic options builder for creating a wasm instance.
 /// This is passed to the `Instance::new` method.
 #[derive(Clone)]
-pub struct InstanceConfig<E>
-where
-    E: Send + Sync + Clone,
-{
+pub struct InstanceConfig<Engine: Send + Sync + Clone> {
     /// The WASI engine to use.
     /// This should be cheap to clone.
-    engine: E,
+    engine: Engine,
     /// Optional stdin named pipe path.
     stdin: Option<String>,
     /// Optional stdout named pipe path.
@@ -36,11 +33,8 @@ where
     containerd_address: String,
 }
 
-impl<E> InstanceConfig<E>
-where
-    E: Send + Sync + Clone,
-{
-    pub fn new(engine: E, namespace: String, containerd_address: String) -> Self {
+impl<Engine: Send + Sync + Clone> InstanceConfig<Engine> {
+    pub fn new(engine: Engine, namespace: String, containerd_address: String) -> Self {
         Self {
             engine,
             namespace,
@@ -97,7 +91,7 @@ where
     }
 
     /// get the wasm engine for the instance
-    pub fn get_engine(&self) -> E {
+    pub fn get_engine(&self) -> Engine {
         self.engine.clone()
     }
 
@@ -116,10 +110,10 @@ where
 /// Instance is a trait that gets implemented by consumers of this library.
 pub trait Instance {
     /// The WASI engine type
-    type E: Send + Sync + Clone;
+    type Engine: Send + Sync + Clone;
 
     /// Create a new instance
-    fn new(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self;
+    fn new(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Self;
 
     /// Start the instance
     /// The returned value should be a unique ID (such as a PID) for the instance.
@@ -184,8 +178,8 @@ pub struct Nop {
 }
 
 impl Instance for Nop {
-    type E = ();
-    fn new(_id: String, _cfg: Option<&InstanceConfig<Self::E>>) -> Self {
+    type Engine = ();
+    fn new(_id: String, _cfg: Option<&InstanceConfig<Self::Engine>>) -> Self {
         Nop {
             exit_code: Arc::new((Mutex::new(None), Condvar::new())),
         }
@@ -289,6 +283,6 @@ mod noptests {
 /// Abstraction that allows for different wasi engines to be used.
 /// The containerd shim setup by this library will use this trait to get an engine and pass that along to instances.
 pub trait EngineGetter {
-    type E: Send + Sync + Clone;
-    fn new_engine() -> Result<Self::E, Error>;
+    type Engine: Send + Sync + Clone;
+    fn new_engine() -> Result<Self::Engine, Error>;
 }

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-shim-wasmedge-v1/main.rs
@@ -3,5 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmedge::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance, wasmedge_sdk::Vm>>("io.containerd.wasmedge.v1", None);
+    shim::run::<ShimCli<WasiInstance>>("io.containerd.wasmedge.v1", None);
 }

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
@@ -9,7 +9,7 @@ use ttrpc::{self, Server};
 
 fn main() {
     info!("starting up!");
-    let s: ManagerService<_, Local<WasiInstance, _>> =
+    let s: ManagerService<Local<WasiInstance>> =
         ManagerService::new(WasiInstance::new_engine().unwrap());
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -70,9 +70,9 @@ fn determine_rootdir<P: AsRef<Path>>(bundle: P, namespace: String) -> Result<Pat
 }
 
 impl LibcontainerInstance for Wasi {
-    type E = Vm;
+    type Engine = Vm;
 
-    fn new_libcontainer(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self {
+    fn new_libcontainer(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Self {
         let cfg = cfg.unwrap(); // TODO: handle error
         let bundle = cfg.get_bundle().unwrap_or_default();
         let namespace = cfg.get_namespace();
@@ -137,7 +137,7 @@ impl LibcontainerInstance for Wasi {
 }
 
 impl EngineGetter for Wasi {
-    type E = Vm;
+    type Engine = Vm;
     fn new_engine() -> Result<Vm, Error> {
         PluginManager::load(None).unwrap();
         let mut host_options = HostRegistrationConfigOptions::default();

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-shim-wasmtime-v1/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-shim-wasmtime-v1/main.rs
@@ -3,5 +3,5 @@ use containerd_shim_wasm::sandbox::ShimCli;
 use containerd_shim_wasmtime::instance::Wasi as WasiInstance;
 
 fn main() {
-    shim::run::<ShimCli<WasiInstance, wasmtime::Engine>>("io.containerd.wasmtime.v1", None);
+    shim::run::<ShimCli<WasiInstance>>("io.containerd.wasmtime.v1", None);
 }

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
@@ -10,7 +10,7 @@ use wasmtime::Engine;
 fn main() {
     info!("starting up!");
     let engine = Engine::default();
-    let s: ManagerService<_, Local<WasiInstance, _>> = ManagerService::new(engine);
+    let s: ManagerService<Local<WasiInstance>> = ManagerService::new(engine);
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -65,9 +65,9 @@ fn determine_rootdir<P: AsRef<Path>>(bundle: P, namespace: String) -> Result<Pat
 }
 
 impl LibcontainerInstance for Wasi {
-    type E = wasmtime::Engine;
+    type Engine = wasmtime::Engine;
 
-    fn new_libcontainer(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self {
+    fn new_libcontainer(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Self {
         // TODO: there are failure cases e.x. parsing cfg, loading spec, etc.
         // thus should make `new` return `Result<Self, Error>` instead of `Self`
         log::info!("creating new instance: {}", id);
@@ -136,7 +136,7 @@ impl LibcontainerInstance for Wasi {
 }
 
 impl EngineGetter for Wasi {
-    type E = wasmtime::Engine;
+    type Engine = wasmtime::Engine;
     fn new_engine() -> Result<Engine, Error> {
         Ok(Engine::default())
     }


### PR DESCRIPTION
This PR removes the generics that can be inferred derived from others.
It also makes the actual code more closely match the example in `README.md`, which was missing many `_` generics.