### PR TITLE
feat: resolve a name clash of the libcontainer features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ KIND_CLUSTER_NAME ?= containerd-wasm
 .PHONY: build
 build:
 	cargo build -p containerd-shim-wasm --features generate_bindings $(RELEASE_FLAG)
-	cargo build -p containerd-shim-wasm --features libcontainer $(RELEASE_FLAG)
+	# compiling against libcontainer's default features (dependency on libseccomp)
+	cargo build -p containerd-shim-wasm --features libcontainer_default $(RELEASE_FLAG)
 	cargo build $(RELEASE_FLAG)
 
 .PHONY: check

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -43,7 +43,7 @@ rand = "0.8"
 
 [features]
 default = []
-libcontainer = ["libcontainer/default"]
+libcontainer_default = ["libcontainer/default"]
 generate_bindings = ["ttrpc-codegen"]
 generate_doc = []
 libseccomp = ["libcontainer/libseccomp"]

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 containerd-shim = { workspace = true }
-containerd-shim-wasm = { workspace = true, features = ["libcontainer"]}
+containerd-shim-wasm = { workspace = true, features = ["libcontainer_default"]}
 log = { workspace = true }
 ttrpc = { workspace = true }
 wasmedge-sdk = { version = "0.11.2" }

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 containerd-shim = { workspace = true }
-containerd-shim-wasm = { workspace = true, features = ["libcontainer"]}
+containerd-shim-wasm = { workspace = true, features = ["libcontainer_default"]}
 log = { workspace = true }
 ttrpc = { workspace = true }
 


### PR DESCRIPTION
This commit resolves a name clash of the `libcontainer` feature from the containerd-shim-wasm, which undesirably forces all other features to bring in libseccomp and systemd dependencies. By renaming `libcontainer` to `libcontainer_default`, the consumer of the crate can specify `cgroupsv2` to directly access libcontainer's v2 feature without bringing in libseccomp and systemd dependencies. 

This will resolve this concerns @0xE282B0 raised https://github.com/deislabs/containerd-wasm-shims/pull/122#issuecomment-1682388913

FYI @jsturtevant 