### PR TITLE
Remove EngineGetter

### DIFF
--- a/benches/containerd-shim-benchmarks/benches/webassembly-benchmarks.rs
+++ b/benches/containerd-shim-benchmarks/benches/webassembly-benchmarks.rs
@@ -14,7 +14,7 @@ use chrono::{DateTime, Utc};
 
 use containerd_shim_wasm::sandbox::exec::has_cap_sys_admin;
 use containerd_shim_wasm::sandbox::instance::Wait;
-use containerd_shim_wasm::sandbox::{EngineGetter, Error, Instance, InstanceConfig};
+use containerd_shim_wasm::sandbox::{Error, Instance, InstanceConfig};
 
 use containerd_shim_wasmedge::instance::{reset_stdio, Wasi as WasmEdgeWasi};
 use containerd_shim_wasmtime::instance::Wasi as WasmtimeWasi;

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -279,10 +279,3 @@ mod noptests {
         nop.delete().unwrap();
     }
 }
-
-/// Abstraction that allows for different wasi engines to be used.
-/// The containerd shim setup by this library will use this trait to get an engine and pass that along to instances.
-pub trait EngineGetter {
-    type Engine: Send + Sync + Clone;
-    fn new_engine() -> Result<Self::Engine, Error>;
-}

--- a/crates/containerd-shim-wasm/src/sandbox/manager.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/manager.rs
@@ -62,6 +62,15 @@ impl<T: Sandbox> Service<T> {
     }
 }
 
+impl<T: Sandbox> Default for Service<T>
+where
+    <T::Instance as Instance>::Engine: Default,
+{
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 impl<T: Sandbox + 'static> Manager for Service<T> {
     fn create(
         &self,

--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -9,7 +9,7 @@ pub mod manager;
 pub mod shim;
 
 pub use error::{Error, Result};
-pub use instance::{EngineGetter, Instance, InstanceConfig};
+pub use instance::{Instance, InstanceConfig};
 pub use manager::{Sandbox as SandboxService, Service as ManagerService};
 pub use shim::{Cli as ShimCli, Local};
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -13,7 +13,7 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread;
 
-use super::instance::{EngineGetter, Instance, InstanceConfig, Nop, Wait};
+use super::instance::{Instance, InstanceConfig, Nop, Wait};
 use super::{oci, Error, SandboxService};
 use cgroups_rs::cgroup::get_cgroups_relative_paths_by_pid;
 use cgroups_rs::hierarchies::{self};
@@ -1472,13 +1472,14 @@ pub struct Cli<T: Instance + Sync + Send> {
 
 impl<I> shim::Shim for Cli<I>
 where
-    I: Instance + Sync + Send + EngineGetter<Engine = <I as Instance>::Engine>,
+    I: Instance + Sync + Send,
+    <I as Instance>::Engine: Default,
 {
     type T = Local<I>;
 
     fn new(_runtime_id: &str, args: &Flags, _config: &mut shim::Config) -> Self {
         Cli {
-            engine: I::new_engine().unwrap(),
+            engine: Default::default(),
             phantom: std::marker::PhantomData,
             namespace: args.namespace.to_string(),
             containerd_address: args.address.clone(),

--- a/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
+++ b/crates/containerd-shim-wasmedge/src/bin/containerd-wasmedged/main.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use containerd_shim_wasm::sandbox::EngineGetter;
 use containerd_shim_wasm::sandbox::{Local, ManagerService};
 use containerd_shim_wasm::services::sandbox_ttrpc::{create_manager, Manager};
 use containerd_shim_wasmedge::instance::Wasi as WasiInstance;
@@ -9,8 +8,7 @@ use ttrpc::{self, Server};
 
 fn main() {
     info!("starting up!");
-    let s: ManagerService<Local<WasiInstance>> =
-        ManagerService::new(WasiInstance::new_engine().unwrap());
+    let s: ManagerService<Local<WasiInstance>> = Default::default();
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
+++ b/crates/containerd-shim-wasmtime/src/bin/containerd-wasmtimed/main.rs
@@ -5,12 +5,10 @@ use containerd_shim_wasm::services::sandbox_ttrpc::{create_manager, Manager};
 use containerd_shim_wasmtime::instance::Wasi as WasiInstance;
 use log::info;
 use ttrpc::{self, Server};
-use wasmtime::Engine;
 
 fn main() {
     info!("starting up!");
-    let engine = Engine::default();
-    let s: ManagerService<Local<WasiInstance>> = ManagerService::new(engine);
+    let s: ManagerService<Local<WasiInstance>> = ManagerService::default();
     let s = Arc::new(Box::new(s) as Box<dyn Manager + Send + Sync>);
     let service = create_manager(s);
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -13,11 +13,9 @@ use containerd_shim_wasm::libcontainer_instance::{LibcontainerInstance, LinuxCon
 use containerd_shim_wasm::sandbox::error::Error;
 use containerd_shim_wasm::sandbox::instance::ExitCode;
 use containerd_shim_wasm::sandbox::instance_utils::maybe_open_stdio;
-use containerd_shim_wasm::sandbox::{EngineGetter, InstanceConfig};
+use containerd_shim_wasm::sandbox::InstanceConfig;
 use libcontainer::syscall::syscall::create_syscall;
 use std::os::fd::IntoRawFd;
-
-use wasmtime::Engine;
 
 use crate::executor::WasmtimeExecutor;
 
@@ -135,13 +133,6 @@ impl LibcontainerInstance for Wasi {
     }
 }
 
-impl EngineGetter for Wasi {
-    type Engine = wasmtime::Engine;
-    fn new_engine() -> Result<Engine, Error> {
-        Ok(Engine::default())
-    }
-}
-
 #[cfg(test)]
 mod wasitest {
     use std::borrow::Cow;
@@ -219,7 +210,7 @@ mod wasitest {
     #[test]
     fn test_delete_after_create() -> Result<()> {
         let cfg = InstanceConfig::new(
-            Wasi::new_engine()?,
+            Default::default(),
             "test_namespace".into(),
             "/containerd/address".into(),
         );
@@ -330,7 +321,7 @@ mod wasitest {
         spec.save(dir.path().join("config.json"))?;
 
         let mut cfg = InstanceConfig::new(
-            Wasi::new_engine()?,
+            Default::default(),
             "test_namespace".into(),
             "/containerd/address".into(),
         );


### PR DESCRIPTION
This PR removes the `EngineGetter` trait and replaces it with the use of `Default::default()`.
In the case where an instance would have implemented a non-trivial `EngineGetter`, there are two options:
* If the associated `Engine` type is local to the crate, implement a suitable `Default`.
* Otherwise, use a wrapper struct for the associated `Engine` type and implement a suitable `Default` for the wrapper (and optionally also `Deref`)