### PR TITLE
Moved determine_rootdir to containerd-shim-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,16 +543,12 @@ dependencies = [
  "clone3",
  "command-fds",
  "containerd-shim",
- "env_logger",
  "libc",
  "libcontainer",
  "log",
  "nix 0.26.2",
  "oci-spec",
- "pretty_assertions",
- "proc-mounts",
  "protobuf 3.2.0",
- "rand",
  "serde",
  "serde_json",
  "signal-hook",
@@ -567,7 +563,6 @@ name = "containerd-shim-wasmedge"
 version = "0.1.1"
 dependencies = [
  "anyhow",
- "cap-std",
  "chrono",
  "containerd-shim",
  "containerd-shim-wasm",
@@ -577,8 +572,6 @@ dependencies = [
  "log",
  "nix 0.26.2",
  "oci-spec",
- "pretty_assertions",
- "serde",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -604,7 +597,6 @@ dependencies = [
  "log",
  "nix 0.26.2",
  "oci-spec",
- "pretty_assertions",
  "serde",
  "serde_json",
  "tempfile",
@@ -927,12 +919,6 @@ dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2010,7 +1996,6 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
- "env_logger",
  "log",
  "oci-spec",
  "serde",
@@ -2066,15 +2051,6 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.1",
-]
-
-[[package]]
-name = "partition-identity"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa925f9becb532d758b0014b472c576869910929cf4c3f8054b386f19ab9e21"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -2182,16 +2158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,15 +2204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-mounts"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d652f8435d0ab70bf4f3590a6a851d59604831a458086541b95238cc51ffcf2"
-dependencies = [
- "partition-identity",
 ]
 
 [[package]]
@@ -4379,12 +4336,6 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zstd"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -28,7 +28,6 @@ libc = { workspace = true }
 clone3 = "0.2"
 caps = "0.5"
 command-fds = "0.2"
-proc-mounts = "0.3"
 libcontainer = { workspace = true, optional = true, default-features = false }
 cgroups-rs = "0.3.3"
 nix = { workspace = true }
@@ -38,10 +37,7 @@ ttrpc-codegen = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
-pretty_assertions = "1"
 signal-hook = "0.3"
-env_logger = { workspace = true }
-rand = "0.8"
 
 [features]
 default = []

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -4,8 +4,9 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
 
-use crate::sandbox::error::Error;
+use super::Error;
 
 /// Return the root path for the instance.
 ///
@@ -45,6 +46,29 @@ pub fn maybe_open_stdio(path: &str) -> Result<Option<File>, Error> {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+struct Options {
+    root: Option<PathBuf>,
+}
+
+pub fn determine_rootdir<P: AsRef<Path>>(
+    bundle: P,
+    namespace: &str,
+    rootdir: P,
+) -> Result<PathBuf, Error> {
+    let file = match File::open(bundle.as_ref().join("options.json")) {
+        Ok(f) => f,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(rootdir.as_ref().join(namespace)),
+        Err(e) => return Err(e.into()),
+    };
+    let path = serde_json::from_reader::<_, Options>(file)?
+        .root
+        .unwrap_or_else(|| rootdir.as_ref().to_owned())
+        .join(namespace);
+    log::info!("container runtime root path is {path:?}");
+    Ok(path)
+}
+
 fn construct_instance_root<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<PathBuf> {
     let root_path = fs::canonicalize(&root_path).with_context(|| {
         format!(
@@ -56,9 +80,11 @@ fn construct_instance_root<P: AsRef<Path>>(root_path: P, container_id: &str) -> 
     Ok(root_path.join(container_id))
 }
 
+#[cfg(unix)]
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
+    use std::fs::{File, OpenOptions};
+    use std::io::Write;
 
     use tempfile::tempdir;
 
@@ -79,4 +105,48 @@ mod tests {
         assert!(f.is_some());
         Ok(())
     }
+
+    #[test]
+    fn test_determine_rootdir_with_options_file() -> Result<(), Error> {
+        let namespace = "test_namespace";
+        let dir = tempdir()?;
+        let rootdir = dir.path().join("runwasi");
+        let opts = Options {
+            root: Some(rootdir.clone()),
+        };
+        let opts_file = OpenOptions::new()
+            .read(true)
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(dir.path().join("options.json"))?;
+        write!(&opts_file, "{}", serde_json::to_string(&opts)?)?;
+        let root = determine_rootdir(
+            dir.path(),
+            namespace,
+            &PathBuf::from("/run/containerd/runtime"),
+        )?;
+        assert_eq!(root, rootdir.join(namespace));
+        Ok(())
+    }
+
+    #[test]
+    fn test_determine_rootdir_without_options_file() -> Result<(), Error> {
+        let dir = tempdir()?;
+        let namespace = "test_namespace";
+        let root = determine_rootdir(
+            dir.path(),
+            namespace,
+            &PathBuf::from("/run/containerd/runtime"),
+        )?;
+        assert!(root.is_absolute());
+        assert_eq!(
+            root,
+            PathBuf::from("/run/containerd/runtime").join(namespace)
+        );
+        Ok(())
+    }
 }
+
+#[cfg(test)]
+mod rootdirtest {}

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -12,10 +12,8 @@ wasmedge-sdk = { version = "0.11.2" }
 wasmedge-sys = "*"
 chrono = { workspace = true }
 anyhow = { workspace = true }
-cap-std = { workspace = true }
 oci-spec = { workspace = true, features = ["runtime"] }
 thiserror = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 libc = { workspace = true }
 
@@ -25,8 +23,7 @@ dbus = { version = "*", optional = true }
 nix = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.8"
-pretty_assertions = "1"
+tempfile = "3.7"
 serial_test = "*"
 
 [features]

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -43,7 +43,6 @@ dbus = { version = "*", optional = true }
 [dev-dependencies]
 tempfile = "3.8"
 libc = { workspace = true }
-pretty_assertions = "1"
 env_logger = "0.10"
 
 [features]

--- a/crates/oci-tar-builder/Cargo.toml
+++ b/crates/oci-tar-builder/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 tar = { workspace = true }
 sha256 = { workspace = true }
 log = { workspace = true }
-env_logger = { workspace = true }
 oci-spec =  { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
This PR moves determine_rootdir to containerd-shim-wasm for sharing. It also removes unused dependencies in the repo. 