### PR TITLE
refactor: group imports 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,15 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v2
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
       - name: Setup build env
         run: ./scripts/setup.sh
         shell: bash
+      - run: 
+          # needed to run rustfmt in nightly toolchain
+          rustup toolchain install nightly --component rustfmt
       - name: Run checks
         run: make check
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
       - name: Setup build env

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ build:
 
 .PHONY: check
 check:
-	cargo fmt --all -- --check
+	cargo +nightly fmt --all -- --check
 	cargo clippy --all --all-targets -- -D warnings
 
 .PHONY: fix
 fix:
-	cargo fmt --all
+	cargo +nightly fmt --all
 	cargo clippy --fix --all --all-targets -- -D warnings
 
 .PHONY: test

--- a/crates/containerd-shim-wasm/src/libcontainer_instance/container_executor.rs
+++ b/crates/containerd-shim-wasm/src/libcontainer_instance/container_executor.rs
@@ -1,5 +1,7 @@
+use std::fs::OpenOptions;
 use std::io::Read;
-use std::{fs::OpenOptions, os::fd::RawFd, path::PathBuf};
+use std::os::fd::RawFd;
+use std::path::PathBuf;
 
 use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use libcontainer::workload::default::DefaultExecutor;

--- a/crates/containerd-shim-wasm/src/libcontainer_instance/container_executor.rs
+++ b/crates/containerd-shim-wasm/src/libcontainer_instance/container_executor.rs
@@ -1,12 +1,13 @@
-use crate::sandbox::oci;
+use std::io::Read;
+use std::{fs::OpenOptions, os::fd::RawFd, path::PathBuf};
+
+use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use libcontainer::workload::default::DefaultExecutor;
 use libcontainer::workload::{Executor, ExecutorError};
 use nix::unistd::{dup, dup2};
-
-use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use oci_spec::runtime::Spec;
-use std::io::Read;
-use std::{fs::OpenOptions, os::fd::RawFd, path::PathBuf};
+
+use crate::sandbox::oci;
 
 #[derive(Default)]
 pub struct LinuxContainerExecutor {

--- a/crates/containerd-shim-wasm/src/libcontainer_instance/instance.rs
+++ b/crates/containerd-shim-wasm/src/libcontainer_instance/instance.rs
@@ -1,26 +1,21 @@
 //! Abstractions for running/managing a wasm/wasi instance that uses youki's libcontainer library.
 
-use std::{path::PathBuf, thread};
+use std::path::PathBuf;
+use std::thread;
 
 use anyhow::Context;
 use chrono::Utc;
 use libc::{SIGINT, SIGKILL};
-use libcontainer::{
-    container::{Container, ContainerStatus},
-    signal::Signal,
-};
+use libcontainer::container::{Container, ContainerStatus};
+use libcontainer::signal::Signal;
 use log::error;
-use nix::{
-    errno::Errno,
-    sys::wait::{waitid, Id as WaitID, WaitPidFlag, WaitStatus},
-};
+use nix::errno::Errno;
+use nix::sys::wait::{waitid, Id as WaitID, WaitPidFlag, WaitStatus};
 
-use crate::sandbox::InstanceConfig;
-use crate::sandbox::{error::Error, instance::Wait, Instance};
-use crate::sandbox::{
-    instance::ExitCode,
-    instance_utils::{get_instance_root, instance_exists},
-};
+use crate::sandbox::error::Error;
+use crate::sandbox::instance::{ExitCode, Wait};
+use crate::sandbox::instance_utils::{get_instance_root, instance_exists};
+use crate::sandbox::{Instance, InstanceConfig};
 
 /// LibcontainerInstance is a trait that gets implemented by a WASI runtime that
 /// uses youki's libcontainer library as the container runtime.

--- a/crates/containerd-shim-wasm/src/libcontainer_instance/instance.rs
+++ b/crates/containerd-shim-wasm/src/libcontainer_instance/instance.rs
@@ -1,5 +1,7 @@
 //! Abstractions for running/managing a wasm/wasi instance that uses youki's libcontainer library.
 
+use std::{path::PathBuf, thread};
+
 use anyhow::Context;
 use chrono::Utc;
 use libc::{SIGINT, SIGKILL};
@@ -13,15 +15,12 @@ use nix::{
     sys::wait::{waitid, Id as WaitID, WaitPidFlag, WaitStatus},
 };
 
+use crate::sandbox::InstanceConfig;
+use crate::sandbox::{error::Error, instance::Wait, Instance};
 use crate::sandbox::{
     instance::ExitCode,
     instance_utils::{get_instance_root, instance_exists},
 };
-
-use crate::sandbox::InstanceConfig;
-use std::{path::PathBuf, thread};
-
-use crate::sandbox::{error::Error, instance::Wait, Instance};
 
 /// LibcontainerInstance is a trait that gets implemented by a WASI runtime that
 /// uses youki's libcontainer library as the container runtime.

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -4,9 +4,8 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 
-use libc::{SIGINT, SIGKILL, SIGTERM};
-
 use chrono::{DateTime, Utc};
+use libc::{SIGINT, SIGKILL, SIGTERM};
 
 use super::error::Error;
 

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -1,9 +1,7 @@
 //! Common utilities for the containerd shims.
-use std::{
-    fs::{self, File, OpenOptions},
-    io::ErrorKind,
-    path::{Path, PathBuf},
-};
+use std::fs::{self, File, OpenOptions};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -1,11 +1,13 @@
 //! Common utilities for the containerd shims.
-use crate::sandbox::error::Error;
-use anyhow::{bail, Context, Result};
 use std::{
     fs::{self, File, OpenOptions},
     io::ErrorKind,
     path::{Path, PathBuf},
 };
+
+use anyhow::{bail, Context, Result};
+
+use crate::sandbox::error::Error;
 
 /// Return the root path for the instance.
 ///

--- a/crates/containerd-shim-wasm/src/sandbox/manager.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/manager.rs
@@ -7,20 +7,16 @@ use std::env::current_dir;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::thread;
 
 use anyhow::Context;
-use containerd_shim::{
-    self as shim, api,
-    error::Error as ShimError,
-    protos::shim::shim_ttrpc::{create_task, Task},
-    protos::ttrpc::{Client, Server},
-    protos::TaskClient,
-    publisher::RemotePublisher,
-    TtrpcContext, TtrpcResult,
-};
+use containerd_shim::error::Error as ShimError;
+use containerd_shim::protos::shim::shim_ttrpc::{create_task, Task};
+use containerd_shim::protos::ttrpc::{Client, Server};
+use containerd_shim::protos::TaskClient;
+use containerd_shim::publisher::RemotePublisher;
+use containerd_shim::{self as shim, api, TtrpcContext, TtrpcResult};
 use nix::sched::{setns, unshare, CloneFlags};
 use oci_spec::runtime;
 use shim::Flags;
@@ -28,8 +24,7 @@ use ttrpc::context;
 
 use super::error::Error;
 use super::instance::Instance;
-use super::oci;
-use super::sandbox;
+use super::{oci, sandbox};
 use crate::services::sandbox_ttrpc::{Manager, ManagerClient};
 
 /// Sandbox wraps an Instance and is used with the `Service` to manage multiple instances.

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -1,17 +1,18 @@
 //! Generic helpers for working with OCI specs that can be consumed by any runtime.
 
+use std::collections::HashMap;
 use std::fs::File;
+use std::io::{ErrorKind, Write};
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::process;
 
-use super::error::Result;
 use anyhow::Context;
 use nix::{sys::signal, unistd::Pid};
 pub use oci_spec::runtime::Spec;
 use serde_json as json;
-use std::collections::HashMap;
-use std::io::{ErrorKind, Write};
-use std::os::unix::process::CommandExt;
-use std::process;
+
+use super::error::Result;
 
 pub fn load(path: &str) -> Result<Spec> {
     let spec = Spec::load(path)?;
@@ -145,8 +146,9 @@ pub fn setup_prestart_hooks(hooks: &Option<oci_spec::runtime::Hooks>) -> Result<
 
 #[cfg(test)]
 mod oci_tests {
-    use super::*;
     use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder};
+
+    use super::*;
 
     #[test]
     fn test_get_args() -> Result<()> {

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use std::process;
 
 use anyhow::Context;
-use nix::{sys::signal, unistd::Pid};
+use nix::sys::signal;
+use nix::unistd::Pid;
 pub use oci_spec::runtime::Spec;
 use serde_json as json;
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -4,8 +4,7 @@
 
 use std::collections::HashMap;
 use std::env::current_dir;
-use std::fs::{self, File};
-use std::fs::{canonicalize, create_dir_all, OpenOptions};
+use std::fs::{self, canonicalize, create_dir_all, File, OpenOptions};
 use std::ops::Not;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
@@ -17,21 +16,17 @@ use cgroups_rs::cgroup::get_cgroups_relative_paths_by_pid;
 use cgroups_rs::hierarchies::{self};
 use cgroups_rs::{Cgroup, Subsystem};
 use chrono::{DateTime, Utc};
-use containerd_shim::{
-    self as shim, api,
-    error::Error as ShimError,
-    event::Event,
-    mount::mount_rootfs,
-    protos::events::task::{TaskCreate, TaskDelete, TaskExit, TaskIO, TaskStart},
-    protos::protobuf::well_known_types::timestamp::Timestamp,
-    protos::protobuf::{MessageDyn, MessageField},
-    protos::shim::shim_ttrpc::Task,
-    protos::types::task::Status,
-    publisher::RemotePublisher,
-    util::IntoOption,
-    util::{timestamp as new_timestamp, write_address},
-    warn, ExitSignal, TtrpcContext, TtrpcResult,
-};
+use containerd_shim::error::Error as ShimError;
+use containerd_shim::event::Event;
+use containerd_shim::mount::mount_rootfs;
+use containerd_shim::protos::events::task::{TaskCreate, TaskDelete, TaskExit, TaskIO, TaskStart};
+use containerd_shim::protos::protobuf::well_known_types::timestamp::Timestamp;
+use containerd_shim::protos::protobuf::{MessageDyn, MessageField};
+use containerd_shim::protos::shim::shim_ttrpc::Task;
+use containerd_shim::protos::types::task::Status;
+use containerd_shim::publisher::RemotePublisher;
+use containerd_shim::util::{timestamp as new_timestamp, write_address, IntoOption};
+use containerd_shim::{self as shim, api, warn, ExitSignal, TtrpcContext, TtrpcResult};
 use log::{debug, error};
 use nix::mount::{mount, MsFlags};
 use nix::sched::{setns, unshare, CloneFlags};

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -13,8 +13,6 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread;
 
-use super::instance::{Instance, InstanceConfig, Nop, Wait};
-use super::{oci, Error, SandboxService};
 use cgroups_rs::cgroup::get_cgroups_relative_paths_by_pid;
 use cgroups_rs::hierarchies::{self};
 use cgroups_rs::{Cgroup, Subsystem};
@@ -41,13 +39,15 @@ use nix::sys::stat::Mode;
 use nix::unistd::mkdir;
 use oci_spec::runtime;
 use shim::api::{StatsRequest, StatsResponse};
-
 use shim::protos::cgroups::metrics::{
     CPUStat, CPUUsage, MemoryEntry, MemoryStat, Metrics, PidsStat, Throttle,
 };
 use shim::util::convert_to_any;
 use shim::Flags;
 use ttrpc::context::Context;
+
+use super::instance::{Instance, InstanceConfig, Nop, Wait};
+use super::{oci, Error, SandboxService};
 
 type InstanceDataStatus = (Mutex<Option<(u32, DateTime<Utc>)>>, Condvar);
 

--- a/crates/containerd-shim-wasm/src/sandbox/testutil.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/testutil.rs
@@ -1,7 +1,8 @@
 //! Testing utilities used across different modules
 
-use super::{Error, Result};
 use std::process::{Command, Stdio};
+
+use super::{Error, Result};
 
 fn normalize_test_name(test: &str) -> Result<&str> {
     let closure_removed = test.trim_end_matches("::{{closure}}");

--- a/crates/containerd-shim-wasmedge/src/executor.rs
+++ b/crates/containerd-shim-wasmedge/src/executor.rs
@@ -1,13 +1,12 @@
+use std::{os::unix::io::RawFd, path::PathBuf};
+
 use anyhow::Result;
 use containerd_shim_wasm::sandbox::oci;
-use nix::unistd::{dup, dup2};
-use oci_spec::runtime::Spec;
-
 use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use libcontainer::workload::{Executor, ExecutorError};
 use log::debug;
-use std::{os::unix::io::RawFd, path::PathBuf};
-
+use nix::unistd::{dup, dup2};
+use oci_spec::runtime::Spec;
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
     params, VmBuilder,

--- a/crates/containerd-shim-wasmedge/src/executor.rs
+++ b/crates/containerd-shim-wasmedge/src/executor.rs
@@ -1,4 +1,5 @@
-use std::{os::unix::io::RawFd, path::PathBuf};
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use containerd_shim_wasm::sandbox::oci;
@@ -7,10 +8,8 @@ use libcontainer::workload::{Executor, ExecutorError};
 use log::debug;
 use nix::unistd::{dup, dup2};
 use oci_spec::runtime::Spec;
-use wasmedge_sdk::{
-    config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
-    params, VmBuilder,
-};
+use wasmedge_sdk::config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions};
+use wasmedge_sdk::{params, VmBuilder};
 
 const EXECUTOR_NAME: &str = "wasmedge";
 

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -1,17 +1,13 @@
+use std::fs;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::ErrorKind;
 use std::os::fd::IntoRawFd;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
 
-use anyhow::Context;
-use anyhow::Result;
-use containerd_shim_wasm::libcontainer_instance::LibcontainerInstance;
-use containerd_shim_wasm::libcontainer_instance::LinuxContainerExecutor;
+use anyhow::{Context, Result};
+use containerd_shim_wasm::libcontainer_instance::{LibcontainerInstance, LinuxContainerExecutor};
 use containerd_shim_wasm::sandbox::error::Error;
 use containerd_shim_wasm::sandbox::instance::ExitCode;
 use containerd_shim_wasm::sandbox::instance_utils::maybe_open_stdio;

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -1,3 +1,13 @@
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::ErrorKind;
+use std::os::fd::IntoRawFd;
+use std::sync::{Arc, Condvar, Mutex};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
 use anyhow::Context;
 use anyhow::Result;
 use containerd_shim_wasm::libcontainer_instance::LibcontainerInstance;
@@ -6,22 +16,11 @@ use containerd_shim_wasm::sandbox::error::Error;
 use containerd_shim_wasm::sandbox::instance::ExitCode;
 use containerd_shim_wasm::sandbox::instance_utils::maybe_open_stdio;
 use containerd_shim_wasm::sandbox::InstanceConfig;
-use nix::unistd::close;
-use serde::{Deserialize, Serialize};
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::ErrorKind;
-use std::os::fd::IntoRawFd;
-use std::sync::{Arc, Condvar, Mutex};
-
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::container::Container;
 use libcontainer::syscall::syscall::create_syscall;
+use nix::unistd::close;
+use serde::{Deserialize, Serialize};
 
 use crate::executor::WasmEdgeExecutor;
 
@@ -147,13 +146,11 @@ mod wasitest {
     use containerd_shim_wasm::sandbox::Instance;
     use libc::{dup2, SIGKILL, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
     use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder};
-    use tempfile::{tempdir, TempDir};
-
     use serial_test::serial;
+    use tempfile::{tempdir, TempDir};
+    use wasmedge_sdk::wat2wasm;
 
     use super::*;
-
-    use wasmedge_sdk::wat2wasm;
 
     static mut STDIN_FD: Option<RawFd> = None;
     static mut STDOUT_FD: Option<RawFd> = None;
@@ -340,8 +337,9 @@ mod wasitest {
 mod rootdirtest {
     use std::fs::OpenOptions;
 
-    use super::*;
     use tempfile::tempdir;
+
+    use super::*;
 
     #[test]
     fn test_determine_rootdir_with_options_file() -> Result<(), Error> {

--- a/crates/containerd-shim-wasmtime/src/executor.rs
+++ b/crates/containerd-shim-wasmtime/src/executor.rs
@@ -1,12 +1,11 @@
-use nix::unistd::{dup, dup2};
 use std::{fs::OpenOptions, os::fd::RawFd, path::PathBuf};
 
 use anyhow::{anyhow, Result};
 use containerd_shim_wasm::sandbox::oci;
 use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use libcontainer::workload::{Executor, ExecutorError};
+use nix::unistd::{dup, dup2};
 use oci_spec::runtime::Spec;
-
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::WasiCtxBuilder;
 

--- a/crates/containerd-shim-wasmtime/src/executor.rs
+++ b/crates/containerd-shim-wasmtime/src/executor.rs
@@ -1,4 +1,6 @@
-use std::{fs::OpenOptions, os::fd::RawFd, path::PathBuf};
+use std::fs::OpenOptions;
+use std::os::fd::RawFd;
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use containerd_shim_wasm::sandbox::oci;

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -1,21 +1,21 @@
-use anyhow::Result;
-use libcontainer::container::builder::ContainerBuilder;
-use libcontainer::container::Container;
-use nix::unistd::close;
-use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{ErrorKind, Read};
+use std::os::fd::IntoRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 
 use anyhow::Context;
+use anyhow::Result;
 use containerd_shim_wasm::libcontainer_instance::{LibcontainerInstance, LinuxContainerExecutor};
 use containerd_shim_wasm::sandbox::error::Error;
 use containerd_shim_wasm::sandbox::instance::ExitCode;
 use containerd_shim_wasm::sandbox::instance_utils::maybe_open_stdio;
 use containerd_shim_wasm::sandbox::InstanceConfig;
+use libcontainer::container::builder::ContainerBuilder;
+use libcontainer::container::Container;
 use libcontainer::syscall::syscall::create_syscall;
-use std::os::fd::IntoRawFd;
+use nix::unistd::close;
+use serde::{Deserialize, Serialize};
 
 use crate::executor::WasmtimeExecutor;
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -4,8 +4,7 @@ use std::os::fd::IntoRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use containerd_shim_wasm::libcontainer_instance::{LibcontainerInstance, LinuxContainerExecutor};
 use containerd_shim_wasm::sandbox::error::Error;
 use containerd_shim_wasm::sandbox::instance::ExitCode;
@@ -148,8 +147,7 @@ mod wasitest {
     use containerd_shim_wasm::sandbox::instance::Wait;
     use containerd_shim_wasm::sandbox::testutil::{has_cap_sys_admin, run_test_with_sudo};
     use containerd_shim_wasm::sandbox::Instance;
-    use libc::SIGKILL;
-    use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
+    use libc::{SIGKILL, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
     use nix::unistd::dup2;
     use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder};
     use tempfile::{tempdir, TempDir};

--- a/crates/containerd-shim-wasmtime/src/oci_wasmtime.rs
+++ b/crates/containerd-shim-wasmtime/src/oci_wasmtime.rs
@@ -2,7 +2,8 @@ use std::fs::OpenOptions;
 use std::path::Path;
 
 use anyhow::Context;
-use containerd_shim_wasm::sandbox::{error::Error, oci};
+use containerd_shim_wasm::sandbox::error::Error;
+use containerd_shim_wasm::sandbox::oci;
 use oci_spec::runtime::Spec;
 use wasmtime_wasi::{Dir as WasiDir, WasiCtxBuilder};
 

--- a/crates/containerd-shim-wasmtime/src/oci_wasmtime.rs
+++ b/crates/containerd-shim-wasmtime/src/oci_wasmtime.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use anyhow::Context;
 use containerd_shim_wasm::sandbox::{error::Error, oci};
 use oci_spec::runtime::Spec;
-
 use wasmtime_wasi::{Dir as WasiDir, WasiCtxBuilder};
 
 pub fn get_rootfs(spec: &Spec) -> Result<WasiDir, Error> {

--- a/crates/oci-tar-builder/src/bin.rs
+++ b/crates/oci-tar-builder/src/bin.rs
@@ -1,9 +1,11 @@
+use std::fs::File;
+use std::path::PathBuf;
 use std::{env, fs};
 
-use {
-    anyhow::Context, clap::Parser, oci_spec::image as spec, oci_tar_builder::Builder,
-    std::fs::File, std::path::PathBuf,
-};
+use anyhow::Context;
+use clap::Parser;
+use oci_spec::image as spec;
+use oci_tar_builder::Builder;
 
 pub fn main() {
     let args = Args::parse();

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+use std::fs::metadata;
+use std::io::Write;
+use std::path::PathBuf;
+
 use anyhow::{Context, Error, Result};
 use log::{debug, warn};
 use oci_spec::image::{
@@ -6,10 +11,6 @@ use oci_spec::image::{
 };
 use serde::Serialize;
 use sha256::{digest, try_digest};
-use std::collections::HashMap;
-use std::fs::metadata;
-use std::io::Write;
-use std::path::PathBuf;
 
 #[derive(Debug, Default)]
 pub struct Builder {

--- a/crates/wasi-demo-app/src/main.rs
+++ b/crates/wasi-demo-app/src/main.rs
@@ -20,7 +20,11 @@ fn main() {
             file.write_all(args[3..].join(" ").as_bytes()).unwrap();
         }
         "daemon" => loop {
-            println!("This is a song that never ends.\nYes, it goes on and on my friends.\nSome people started singing it not knowing what it was,\nSo they'll continue singing it forever just because...\n");
+            println!(
+                "This is a song that never ends.\nYes, it goes on and on my friends.\nSome people \
+                 started singing it not knowing what it was,\nSo they'll continue singing it \
+                 forever just because...\n"
+            );
             sleep(Duration::from_secs(1));
         },
         _ => {

--- a/crates/wasi-demo-app/src/main.rs
+++ b/crates/wasi-demo-app/src/main.rs
@@ -1,4 +1,8 @@
-use std::{env, fs::File, io::prelude::*, process, thread::sleep, time::Duration};
+use std::fs::File;
+use std::io::prelude::*;
+use std::thread::sleep;
+use std::time::Duration;
+use std::{env, process};
 
 fn main() {
     let args: Vec<_> = env::args().collect();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,6 @@
-# create three groups for std, external and local crates
-group_imports = "StdExternalCrate"
-
-# https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity
+newline_style = "Unix"
+unstable_features = true # Cargo fmt now needs to be called with `cargo +nightly fmt`
+group_imports = "StdExternalCrate" # create three groups for std, external and local crates
+# Merge imports from the same module
+# See: https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity
 imports_granularity = "Module"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,5 @@
 # create three groups for std, external and local crates
 group_imports = "StdExternalCrate"
+
+# https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity
+imports_granularity = "Module"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# create three groups for std, external and local crates
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
This commits adds a rustfmt configuration to create three import groups:
1. std, core
2. external
3. local crates

and group all the imports based on these three groups. 

Changed `cargo fmt --all` to `cargo +nightly fmt --all` as this feature isn't stable
