### PR TITLE
Make wasmedge preopen the container root

### DIFF
--- a/crates/containerd-shim-wasmedge/src/executor.rs
+++ b/crates/containerd-shim-wasmedge/src/executor.rs
@@ -91,7 +91,7 @@ impl WasmEdgeExecutor {
         wasi_module.initialize(
             Some(args.iter().map(|s| s as &str).collect()),
             Some(envs.iter().map(|s| s as &str).collect()),
-            None,
+            Some(vec!["/:."]),
         );
 
         let (module_name, _) = oci::get_module(spec);


### PR DESCRIPTION
With #78 we inadvertedly stopped preopening the container root.
This means that the wasmedge shim doesn't have access to the container filesystem.
This PR reintroduces preopening the container root with wasmedge.