### PR TITLE
Share artifacts between jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04", "windows-latest"]
+        runtime: ["wasmtime", "wasmedge"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -83,12 +84,21 @@ jobs:
           echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> $env:GITHUB_ENV
           echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> $env:GITHUB_ENV
       - name: Build
-        run: make build
+        run: make build RUNTIMES=${{ matrix.runtime }}
       - name: Validate docs
         run: ./scripts/validate-docs.sh
       - name: Run tests
         run: |
           make test
+      - name: Package artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          make install PREFIX=${{ github.workspace }} RUNTIMES=${{ matrix.runtime }}
+      - uses: actions/upload-artifact@master
+        with:
+          name: containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}
+          path: ${{ github.workspace }}/bin
 
   e2e-wasmtime:
     needs: [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: insightsengineering/disk-space-reclaimer@v1
+        if: runner.os == 'Linux'
         with:
           tools-cache: true
           android: true
@@ -93,12 +94,18 @@ jobs:
       - name: Package artifacts
         shell: bash
         run: |
-          mkdir -p artifacts
-          make install PREFIX=${{ github.workspace }} RUNTIMES=${{ matrix.runtime }}
-      - uses: actions/upload-artifact@master
+          make dist RUNTIMES=${{ matrix.runtime }}
+          # Check if there's any files to archive as tar fails otherwise
+          if stat dist/bin/* >/dev/null 2>&1; then
+            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}.tar.gz -C dist/bin .
+          else
+            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}.tar.gz -T /dev/null
+          fi
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
         with:
           name: containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}
-          path: ${{ github.workspace }}/bin
+          path: dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}.tar.gz
 
   e2e-wasmtime:
     needs: [build]
@@ -126,6 +133,16 @@ jobs:
       - name: Setup build env
         run: ./scripts/setup-linux.sh
         shell: bash
+      - name: Download artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: containerd-shim-wasmtime-${{ matrix.os }}
+          path: dist
+      - name: Unpack artifats
+        shell: bash
+        run: |
+          mkdir -p dist/bin
+          tar -xzf dist/containerd-shim-wasmtime-${{ matrix.os }}.tar.gz -C dist/bin
       - name: run
         run: make test/k8s
       # only runs when the previous step fails
@@ -163,6 +180,16 @@ jobs:
       - name: Setup build env
         run: ./scripts/setup-linux.sh
         shell: bash
+      - name: Download artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: containerd-shim-wasmedge-${{ matrix.os }}
+          path: dist
+      - name: Unpack artifats
+        shell: bash
+        run: |
+          mkdir -p dist/bin
+          tar -xzf dist/containerd-shim-wasmedge-${{ matrix.os }}.tar.gz -C dist/bin
       - name: run
         run: make test/k3s
       - name: cleanup

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+/dist/
 /test/out/img.tar
 /test/k8s/_out
 **/target/

--- a/test/k8s/Dockerfile
+++ b/test/k8s/Dockerfile
@@ -1,43 +1,22 @@
 # syntax=docker/dockerfile:1.4
 
-ARG KIND_NODE_VERSION=v1.23.13
-
-FROM kindest/node:${KIND_NODE_VERSION} AS kind-base
-
-# We need the build to link using against same system libs as the kind image otherwise the shim won't work.
-# So use the node image here as a base and install rust on top of it.
-FROM kind-base AS shim-build
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && sh /tmp/rustup.sh -y --profile=minimal
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup install stable
-WORKDIR /shim
-COPY . .
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential git clang wget pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev
-RUN \
-    --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/shim/target \
-    mkdir -p /opt/shim; make build install PREFIX=/opt/shim
-
-FROM scratch AS shim
-COPY --from=shim-build /opt/shim/bin/* /
-
-
-# Reuse kind-base so we don't have to download other images...
-FROM kind-base AS kind-fetch
-ARG TARGETARCH
 ARG KIND_VERSION=v0.17.0
-RUN curl -sSLf https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${TARGETARCH} > /root/kind && chmod +x /root/kind
+ARG KIND_NODE_VERSION=v1.23.13
+ARG RUNTIME=wasmtime
 
 FROM scratch AS kind
-COPY --from=kind-fetch /root/kind /kind
+ARG TARGETARCH KIND_VERSION
+ADD --chmod=755 https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${TARGETARCH} /kind
 
-FROM kind-base
-RUN apt-get update && apt-get install --no-install-recommends -y build-essential git clang pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev
-RUN <<EOF
-set -e
-echo '[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]' >> /etc/containerd/config.toml
-echo 'runtime_type = "io.containerd.wasmtime.v1"' >> /etc/containerd/config.toml
-sed -i 's,SystemdCgroup = true,,' /etc/containerd/config.toml
+FROM kindest/node:${KIND_NODE_VERSION}
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y libdbus-1-3
+
+ADD dist/bin/* /usr/local/bin/
+
+ARG RUNTIME
+RUN sed -i 's,SystemdCgroup = true,,' /etc/containerd/config.toml && \
+    cat <<EOF >> /etc/containerd/config.toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
+runtime_type = "io.containerd.${RUNTIME}.v1"
 EOF
-COPY --link --from=shim /* /usr/local/bin/
-


### PR DESCRIPTION
This PR shares the artifacts created during the build jobs with the e2e test jobs.
It cuts checks times from 20\~25 min to 13\~16 min.

Further improvements can be made by splitting the Ubuntu based jobs and Windows base jobs, since currently Windows builds are in the critical path. 