### PR TITLE
Use reusable workflows to split linux and windows builds

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -1,0 +1,68 @@
+name: Build shims
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      runtime:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: insightsengineering/disk-space-reclaimer@v1
+        if: runner.os == 'Linux'
+        with:
+          tools-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+      - name: "check cgroup version"
+        run: "mount | grep cgroup"
+        if: runner.os == 'Linux'
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        env:
+          RUST_CACHE_KEY_OS: ${{ inputs.os }}
+        with:
+          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
+      - name: Setup build env
+        run: |
+          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+          ./scripts/setup-$os.sh
+        shell: bash
+      - name: Set environment variables for Windows
+        if: runner.os == 'Windows'
+        run: |
+          echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> $env:GITHUB_ENV
+          echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> $env:GITHUB_ENV
+      - name: Build
+        run: make build RUNTIMES=${{ inputs.runtime }}
+      - name: Validate docs
+        run: ./scripts/validate-docs.sh
+      - name: Run tests
+        run: |
+          make test
+      - name: Package artifacts
+        shell: bash
+        run: |
+          make dist RUNTIMES=${{ inputs.runtime }}
+          # Check if there's any files to archive as tar fails otherwise
+          if stat dist/bin/* >/dev/null 2>&1; then
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin .
+          else
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -T /dev/null
+          fi
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
+          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -20,30 +20,22 @@ jobs:
         with:
           tools-cache: true
           android: true
-          dotnet: true
-          haskell: true
+          dotnet: false
+          haskell: false
           large-packages: false
           swap-storage: false
-          docker-images: true
-      - name: "check cgroup version"
-        run: "mount | grep cgroup"
-        if: runner.os == 'Linux'
+          docker-images: false
       - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        env:
-          RUST_CACHE_KEY_OS: ${{ inputs.os }}
-        with:
-          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - name: Setup build env
         run: |
           os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
           ./scripts/setup-$os.sh
         shell: bash
-      - name: Set environment variables for Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> $env:GITHUB_ENV
-          echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> $env:GITHUB_ENV
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        env:
+          RUST_CACHE_KEY_OS: ${{ inputs.os }}
+        with:
+          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - name: Build
         run: make build RUNTIMES=${{ inputs.runtime }}
       - name: Validate docs

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    name: build on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -14,17 +14,6 @@ jobs:
   build:
     runs-on: ${{ inputs.os }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        if: runner.os == 'Linux'
-        with:
-          tools-cache: true
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          swap-storage: false
-          docker-images: false
       - uses: actions/checkout@v3
       - name: Setup build env
         run: |

--- a/.github/workflows/action-fmt.yml
+++ b/.github/workflows/action-fmt.yml
@@ -11,17 +11,6 @@ jobs:
   fmt:
     runs-on: ${{ inputs.os }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        if: runner.os == 'Linux'
-        with:
-          tools-cache: true
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          swap-storage: false
-          docker-images: false
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/action-fmt.yml
+++ b/.github/workflows/action-fmt.yml
@@ -1,0 +1,45 @@
+name: Run lint
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  fmt:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: insightsengineering/disk-space-reclaimer@v1
+        if: runner.os == 'Linux'
+        with:
+          tools-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
+      - name: Setup build env
+        run: |
+          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
+          ./scripts/setup-$os.sh
+        shell: bash
+      - run: 
+          # needed to run rustfmt in nightly toolchain
+          rustup toolchain install nightly --component rustfmt
+      - name: Set environment variables for Windows
+        if: runner.os == 'Windows'
+        run: |
+          # required until standalong is implemented for windows (https://github.com/WasmEdge/wasmedge-rust-sdk/issues/54)
+          echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> $env:GITHUB_ENV
+          echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> $env:GITHUB_ENV
+      - name: Run checks
+        run: make check

--- a/.github/workflows/action-fmt.yml
+++ b/.github/workflows/action-fmt.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   fmt:
+    name: lint on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/action-fmt.yml
+++ b/.github/workflows/action-fmt.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           tools-cache: true
           android: true
-          dotnet: true
-          haskell: true
+          dotnet: false
+          haskell: false
           large-packages: false
           swap-storage: false
-          docker-images: true
+          docker-images: false
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/action-test-image.yml
+++ b/.github/workflows/action-test-image.yml
@@ -1,0 +1,18 @@
+name: Run end to end tests on kind
+
+on:
+  workflow_call:
+
+jobs:
+  test-image:
+    name: build test image
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: build
+        run: make dist/img.tar
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: test-image
+          path: dist/img.tar

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -14,16 +14,6 @@ jobs:
   e2e-k3s:
     runs-on: ${{ inputs.os }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          swap-storage: false
-          docker-images: false
       - name: "check cgroup version"
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -1,0 +1,49 @@
+name: Run end to end tests on k3s
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      runtime:
+        required: true
+        type: string
+
+jobs:
+  e2e-k3s:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: insightsengineering/disk-space-reclaimer@v1
+        with:
+          tools-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+      - name: "check cgroup version"
+        run: "mount | grep cgroup"
+      - uses: actions/checkout@v3
+      - name: setup rust-wasm target
+        run: rustup target add wasm32-wasi
+      - name: Setup build env
+        run: ./scripts/setup-linux.sh
+        shell: bash
+      - name: Download artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
+          path: dist
+      - name: Unpack artifats
+        shell: bash
+        run: |
+          mkdir -p dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+      - name: run
+        run: make test/k3s
+      - name: cleanup
+        if: always()
+        run: make test/k3s/clean

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+      - name: Download test image
+        uses: actions/download-artifact@master
+        with:
+          name: test-image
+          path: dist
       - name: run
         run: make test/k3s
       - name: cleanup

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   e2e-k3s:
+    name: e2e k3s test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
       - name: "check cgroup version"

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           tools-cache: true
           android: true
-          dotnet: true
-          haskell: true
+          dotnet: false
+          haskell: false
           large-packages: false
           swap-storage: false
-          docker-images: true
+          docker-images: false
       - name: "check cgroup version"
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -1,0 +1,55 @@
+name: Run end to end tests on kind
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      runtime:
+        required: true
+        type: string
+
+jobs:
+  e2e-kind:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: insightsengineering/disk-space-reclaimer@v1
+        with:
+          tools-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
+          docker-images: true
+      - name: "check cgroup version"
+        run: "mount | grep cgroup"
+      - uses: actions/checkout@v3
+      - name: setup rust-wasm target
+        run: rustup target add wasm32-wasi
+      - name: Setup build env
+        run: ./scripts/setup-linux.sh
+        shell: bash
+      - name: Download artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
+          path: dist
+      - name: Unpack artifats
+        shell: bash
+        run: |
+          mkdir -p dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+      - name: run
+        run: make test/k8s
+      # only runs when the previous step fails
+      - name: inspect failed pods
+        if: failure()
+        run: |
+          kubectl get pods --all-namespaces
+          kubectl describe pods --all-namespaces
+      - name: cleanup
+        if: always()
+        run: make test/k8s/clean

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+      - name: Download test image
+        uses: actions/download-artifact@master
+        with:
+          name: test-image
+          path: dist
       - name: run
         run: make test/k8s
       # only runs when the previous step fails

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -14,16 +14,6 @@ jobs:
   e2e-kind:
     runs-on: ${{ inputs.os }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: false
-          haskell: false
-          large-packages: false
-          swap-storage: false
-          docker-images: false
       - name: "check cgroup version"
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   e2e-kind:
+    name: e2e kind test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
       - name: "check cgroup version"

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           tools-cache: true
           android: true
-          dotnet: true
-          haskell: true
+          dotnet: false
+          haskell: false
           large-packages: false
           swap-storage: false
-          docker-images: true
+          docker-images: false
       - name: "check cgroup version"
         run: "mount | grep cgroup"
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,184 +14,49 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        if: runner.os == 'Linux'
-        with:
-          tools-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          docker-images: true
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt, clippy
-          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup build env
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-        shell: bash
-      - run: 
-          # needed to run rustfmt in nightly toolchain
-          rustup toolchain install nightly --component rustfmt
-      - name: Set environment variables for Windows
-        if: runner.os == 'Windows'
-        run: |
-          # required until standalong is implemented for windows (https://github.com/WasmEdge/wasmedge-rust-sdk/issues/54)
-          echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> $env:GITHUB_ENV
-          echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> $env:GITHUB_ENV
-      - name: Run checks
-        run: make check
-  build:
+    uses: ./.github/workflows/action-fmt.yml
+    with:
+      os: ${{ matrix.os }}
+
+  build-ubuntu:
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04", "windows-latest"]
+        os: ["ubuntu-20.04", "ubuntu-22.04"]
         runtime: ["wasmtime", "wasmedge"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          docker-images: true
-      - name: "check cgroup version"
-        run: "mount | grep cgroup"
-        if: runner.os == 'Linux'
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        env:
-          RUST_CACHE_KEY_OS: ${{ matrix.os }}
-        with:
-           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup build env
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-        shell: bash
-      - name: Set environment variables for Windows
-        if: runner.os == 'Windows'
-        run: |
-          echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> $env:GITHUB_ENV
-          echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> $env:GITHUB_ENV
-      - name: Build
-        run: make build RUNTIMES=${{ matrix.runtime }}
-      - name: Validate docs
-        run: ./scripts/validate-docs.sh
-      - name: Run tests
-        run: |
-          make test
-      - name: Package artifacts
-        shell: bash
-        run: |
-          make dist RUNTIMES=${{ matrix.runtime }}
-          # Check if there's any files to archive as tar fails otherwise
-          if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}.tar.gz -C dist/bin .
-          else
-            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}.tar.gz -T /dev/null
-          fi
-      - name: Upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}
-          path: dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.os }}.tar.gz
+    uses: ./.github/workflows/action-build.yml
+    with:
+      os: ${{ matrix.os }}
+      runtime: ${{ matrix.runtime }}
+
+  build-windows:
+    strategy:
+      matrix:
+        os: ["windows-latest"]
+        runtime: ["wasmtime", "wasmedge"]
+    uses: ./.github/workflows/action-build.yml
+    with:
+      os: ${{ matrix.os }}
+      runtime: ${{ matrix.runtime }}
 
   e2e-wasmtime:
-    needs: [build]
+    needs: [build-ubuntu]
     strategy:
       matrix:
         # 20.04 uses cgroupv1, 22.04 uses cgroupv2
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          docker-images: true
-      - name: "check cgroup version"
-        run: "mount | grep cgroup"
-      - uses: actions/checkout@v3
-      - name: setup rust-wasm target
-        run: rustup target add wasm32-wasi
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-        shell: bash
-      - name: Download artifacts
-        uses: actions/download-artifact@master
-        with:
-          name: containerd-shim-wasmtime-${{ matrix.os }}
-          path: dist
-      - name: Unpack artifats
-        shell: bash
-        run: |
-          mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-wasmtime-${{ matrix.os }}.tar.gz -C dist/bin
-      - name: run
-        run: make test/k8s
-      # only runs when the previous step fails
-      - name: inspect failed pods
-        if: failure()
-        run: |
-          kubectl get pods --all-namespaces
-          kubectl describe pods --all-namespaces
-      - name: cleanup
-        if: always()
-        run: make test/k8s/clean
+        runtime:  ["wasmtime"]
+    uses: ./.github/workflows/action-test-kind.yml
+    with:
+      os: ${{ matrix.os }}
+      runtime: ${{ matrix.runtime }}
 
-  e2e-wasmedge:
-    needs: [build]
+  e2e-k3s:
+    needs: [build-ubuntu]
     strategy:
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          docker-images: true
-      - name: "check cgroup version"
-        run: "mount | grep cgroup"
-      - uses: actions/checkout@v3
-      - name: setup rust-wasm target
-        run: rustup target add wasm32-wasi
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-        shell: bash
-      - name: Download artifacts
-        uses: actions/download-artifact@master
-        with:
-          name: containerd-shim-wasmedge-${{ matrix.os }}
-          path: dist
-      - name: Unpack artifats
-        shell: bash
-        run: |
-          mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-wasmedge-${{ matrix.os }}.tar.gz -C dist/bin
-      - name: run
-        run: make test/k3s
-      - name: cleanup
-        if: always()
-        run: make test/k3s/clean
+        runtime: ["wasmedge"]
+    uses: ./.github/workflows/action-test-k3s.yml
+    with:
+      os: ${{ matrix.os }}
+      runtime: ${{ matrix.runtime }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,21 @@ env:
 
 jobs:
   fmt:
-    name: lint
+    name: ${{ matrix.runtime }}
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
+        runtime: ["common"] # not required, but groups jobs
     uses: ./.github/workflows/action-fmt.yml
     with:
       os: ${{ matrix.os }}
+  
+  test-image:
+    name: ${{ matrix.runtime }}
+    strategy:
+      matrix:
+        runtime: ["common"] # not required, but groups jobs
+    uses: ./.github/workflows/action-test-image.yml
 
   build-ubuntu:
     name: ${{ matrix.runtime }}
@@ -43,7 +51,7 @@ jobs:
 
   e2e-wasmtime:
     name: ${{ matrix.runtime }}
-    needs: [build-ubuntu]
+    needs: [build-ubuntu, test-image]
     strategy:
       matrix:
         # 20.04 uses cgroupv1, 22.04 uses cgroupv2
@@ -56,7 +64,7 @@ jobs:
 
   e2e-k3s:
     name: ${{ matrix.runtime }}
-    needs: [build-ubuntu]
+    needs: [build-ubuntu, test-image]
     strategy:
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       os: ${{ matrix.os }}
 
   build-ubuntu:
+    name: Build ${{ matrix.runtime }} on ${{ matrix.runtime }}
     strategy:
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
@@ -29,6 +30,7 @@ jobs:
       runtime: ${{ matrix.runtime }}
 
   build-windows:
+    name: Build ${{ matrix.runtime }} on ${{ matrix.runtime }}
     strategy:
       matrix:
         os: ["windows-latest"]
@@ -39,6 +41,7 @@ jobs:
       runtime: ${{ matrix.runtime }}
 
   e2e-wasmtime:
+    name: e2e test ${{ matrix.runtime }} with kind on ${{ matrix.os }}
     needs: [build-ubuntu]
     strategy:
       matrix:
@@ -51,6 +54,7 @@ jobs:
       runtime: ${{ matrix.runtime }}
 
   e2e-k3s:
+    name: e2e test ${{ matrix.runtime }} with k3s on ${{ matrix.os }}
     needs: [build-ubuntu]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   fmt:
+    name: lint
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
@@ -19,7 +20,7 @@ jobs:
       os: ${{ matrix.os }}
 
   build-ubuntu:
-    name: Build ${{ matrix.runtime }} on ${{ matrix.runtime }}
+    name: ${{ matrix.runtime }}
     strategy:
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
@@ -30,7 +31,7 @@ jobs:
       runtime: ${{ matrix.runtime }}
 
   build-windows:
-    name: Build ${{ matrix.runtime }} on ${{ matrix.runtime }}
+    name: ${{ matrix.runtime }}
     strategy:
       matrix:
         os: ["windows-latest"]
@@ -41,7 +42,7 @@ jobs:
       runtime: ${{ matrix.runtime }}
 
   e2e-wasmtime:
-    name: e2e test ${{ matrix.runtime }} with kind on ${{ matrix.os }}
+    name: ${{ matrix.runtime }}
     needs: [build-ubuntu]
     strategy:
       matrix:
@@ -54,7 +55,7 @@ jobs:
       runtime: ${{ matrix.runtime }}
 
   e2e-k3s:
-    name: e2e test ${{ matrix.runtime }} with k3s on ${{ matrix.os }}
+    name: ${{ matrix.runtime }}
     needs: [build-ubuntu]
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,16 +58,6 @@ jobs:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          docker-images: true
       - uses: Swatinem/rust-cache@v2
         with:
           key: release-${{ needs.generate.outputs.crate }}
@@ -94,16 +84,6 @@ jobs:
       - generate
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space (Ubuntu)
-        uses: insightsengineering/disk-space-reclaimer@v1
-        with:
-          tools-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          swap-storage: false
-          docker-images: true
       - uses: actions/checkout@v3
       - name: Setup buildx
         run: docker buildx create --use

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 sudo apt -y update
 sudo apt install -y pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev
+
+if [ ! -z "$CI" ] && ! mount | grep cgroup; then
+    echo "cgroup is not mounted" 1>&2
+    exit 1
+fi

--- a/scripts/setup-windows.sh
+++ b/scripts/setup-windows.sh
@@ -2,3 +2,8 @@
 choco install -y wasmedge --version 0.13.1
 # require clang for wasmedge for bindgen, which is used in the build script to generate the rust bindings to the c codebase 
 choco install -y llvm --version 16.0.6
+
+if [ ! -z "$CI" ]; then
+    echo "WASMEDGE_LIB_DIR=C:\Program Files\WasmEdge\lib" >> ${GITHUB_ENV}
+    echo "WASMEDGE_INCLUDE_DIR=C:\Program Files\WasmEdge\include" >> ${GITHUB_ENV}
+fi


### PR DESCRIPTION
This is a continuation of #267 and further reduces the PR runtime to \~8min