### PR TITLE
chore: bump rust to 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/containerd-shim-wasmedge",
     "crates/containerd-shim-wasmtime",
 ]
+resolver = "2"
 
 [workspace.package]
 edition = "2021"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Make sure to keep RUST_VERSION in sync with the version in rust-toolchain.toml
 ARG BASE_IMAGE="bullseye"
-ARG RUST_VERSION=1.71.1
+ARG RUST_VERSION=1.72.0
 ARG XX_VERSION=1.2.1
 ARG CRATE="containerd-shim-wasmtime,containerd-shim-wasmedge"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Make sure to this in sync with RUST_VERSION in the Dockerfile
-channel="1.71.1"
+channel="1.72.0"
 profile="default"


### PR DESCRIPTION
There is an addition for `resolver=2` applies to the workspace, and the reason for that is to resolve this build warning message


```bash
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```