### PR TITLE
Support passing named pipes in stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "thiserror",
  "ttrpc",
  "ttrpc-codegen",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2.147"
 oci-spec = { version = "0.6.1", features = ["runtime"] }
 sha256 = "1.3.0"
 libcontainer = { version = "0.1", default-features = false }
+windows-sys = { version = "0.48" }
 
 [profile.release]
 panic = "abort"

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ target/wasm32-wasi/$(TARGET)/img.tar: target/wasm32-wasi/$(TARGET)/wasi-demo-app
 	cd crates/wasi-demo-app && cargo build $(RELEASE_FLAG) --features oci-v1-tar
 
 dist/img.tar: target/wasm32-wasi/$(TARGET)/img.tar
-	@mkdir -p dist/
-	cp $< $@
+	@mkdir -p "dist/"
+	cp "$<" "$@"
 
 load: dist/img.tar
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import --all-platforms $<

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -31,6 +31,9 @@ command-fds = "0.2"
 libcontainer = { workspace = true, optional = true, default-features = false }
 nix = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+
 [build-dependencies]
 ttrpc-codegen = { version = "0.4.2", optional = true }
 

--- a/crates/containerd-shim-wasm/src/sandbox/stdio.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/stdio.rs
@@ -1,4 +1,4 @@
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::ErrorKind::NotFound;
 use std::io::{Error, Result};
 use std::path::Path;
@@ -34,13 +34,11 @@ macro_rules! stdio_impl {
                     path if path.as_os_str().is_empty() => None,
                     path => Some(path.to_owned()),
                 })
-                .map(
-                    |path| match OpenOptions::new().read(true).write(true).open(path) {
-                        Err(err) if err.kind() == NotFound => Ok(None),
-                        Ok(f) => Ok(Some(f)),
-                        Err(err) => Err(err),
-                    },
-                )
+                .map(|path| match open_file(path) {
+                    Err(err) if err.kind() == NotFound => Ok(None),
+                    Ok(f) => Ok(Some(f)),
+                    Err(err) => Err(err),
+                })
                 .transpose()
                 .map(|opt| Self(Arc::new(Mutex::new(opt.flatten()))))
             }

--- a/crates/containerd-shim-wasm/src/sys/unix/stdio.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/stdio.rs
@@ -1,9 +1,15 @@
+use std::fs::{File, OpenOptions};
 use std::io::Result;
 pub use std::os::fd::AsRawFd as StdioAsRawFd;
 use std::os::fd::OwnedFd;
+use std::path::Path;
 
 pub use libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 
 pub fn try_into_fd(f: impl Into<OwnedFd>) -> Result<impl StdioAsRawFd> {
     Ok(f.into())
+}
+
+pub fn open_file<P: AsRef<Path>>(path: P) -> Result<File> {
+    OpenOptions::new().read(true).write(true).open(path)
 }

--- a/crates/wasi-demo-app/Cargo.toml
+++ b/crates/wasi-demo-app/Cargo.toml
@@ -12,8 +12,6 @@ oci-spec = { workspace = true, optional = true }
 oci-tar-builder = { optional = true, path = "../oci-tar-builder" }
 anyhow = { workspace = true, optional = true }
 
-
-
 [features]
 default = []
 oci-v1-tar = ["default", "tar", "sha256", "log", "env_logger", "oci-spec", "oci-tar-builder", "anyhow"]


### PR DESCRIPTION
Containerd passes STDIO as named pipes on windows. The stdio implementation with `libc::dup2([f.as](http://f.as/)_raw_fd(), $fd) }` would error with `invalid handle was specified`.

This checks if it starts with the standard named_pipe path and adds the appropriate `openoptions`. 