### PR TITLE
Preopen the container root instead of cwd

### DIFF
--- a/crates/containerd-shim-wasmedge/src/executor.rs
+++ b/crates/containerd-shim-wasmedge/src/executor.rs
@@ -88,7 +88,7 @@ impl WasmEdgeExecutor {
         wasi_module.initialize(
             Some(args.iter().map(|s| s as &str).collect()),
             Some(envs.iter().map(|s| s as &str).collect()),
-            Some(vec!["/:."]),
+            Some(vec!["/:/"]),
         );
 
         let (module_name, _) = oci::get_module(spec);

--- a/crates/containerd-shim-wasmtime/src/executor.rs
+++ b/crates/containerd-shim-wasmtime/src/executor.rs
@@ -80,7 +80,7 @@ impl WasmtimeExecutor {
         let env = oci_wasmtime::env_to_wasi(spec);
         log::info!("setting up wasi");
 
-        let path = wasi_dir(".", OpenOptions::new().read(true))?;
+        let path = wasi_dir("/", OpenOptions::new().read(true))?;
         let wasi_builder = WasiCtxBuilder::new()
             .args(args)?
             .envs(env.as_slice())?


### PR DESCRIPTION
Currently `wasmedge` and `wasmtime` are mounting the container _cwd_ into the wasi _root_.
This PR changes that so that we mount he container _root_ into the wasi _root_ 