### PR TITLE
feat: Support wasmedge plugins

### DIFF
--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -15,13 +15,8 @@ pub struct WasmEdgeEngine {
 
 impl Default for WasmEdgeEngine {
     fn default() -> Self {
-        PluginManager::load(None).unwrap();
-
         let host_options = HostRegistrationConfigOptions::default();
         let host_options = host_options.wasi(true);
-        #[cfg(all(target_os = "linux", feature = "wasi_nn", target_arch = "x86_64"))]
-        let host_options = host_options.wasi_nn(true);
-
         let config = ConfigBuilder::default()
             .with_host_registration_config(host_options)
             .build()
@@ -59,6 +54,8 @@ impl Engine for WasmEdgeEngine {
             None => "main".to_string(),
         };
 
+        PluginManager::load(None)?;
+        let vm = vm.auto_detect_plugins()?;
         let vm = vm
             .register_module_from_file(&mod_name, &path)
             .context("registering module")?;


### PR DESCRIPTION
It's a feature PR

By the way, please note that this feature currently only functions when dynamically linking the WasmEdge library to the WasmEdge shim.

For building this, you can use the following command:
`cargo build --package containerd-shim-wasmedge --no-default-features`

In addition, I have provided all the WasmEdge runtime demo cases via containerd ([here](https://github.com/CaptainVincent/runwasi/actions/runs/6150982952)), including the `wasinn plugin` demo related to this feature. Considering that these demos may only be supported with the WasmEdge shim, I plan to relocate and maintain them under the WasmEdge or Second State Org's repository. At the same time, I will ensure that they run demos daily in CI and guarantee that these demos are always executed based on the latest upstream code.