### PR TITLE
chore: bump wasmedge to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,6 +3568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "setjmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a4a1d465f5de0833aed8a7c76b1c01606bc8160c5a7d2c0108867dfffdfef3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4678,9 +4687,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sdk"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dd469c97571a49a836041dca83b28e44246bd54c108dfeae2475fcc7f2f267"
+checksum = "2069fe61f5dbbfbb3f518e473f301983f275cadb801fb9256737ce7b993804b7"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4694,9 +4703,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sys"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080c608ca53ff7d76613d9918c62d9f5a411c7f568ccb7ca067de06eb64bdc88"
+checksum = "41df5edf19a81558c2e9d7ec95bf4adec7e81ba2d1ef3d57076e3177e6508023"
 dependencies = [
  "bindgen",
  "cfg-if 1.0.0",
@@ -4710,6 +4719,7 @@ dependencies = [
  "rand",
  "reqwest",
  "scoped-tls",
+ "setjmp",
  "sha256",
  "tar",
  "thiserror",

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -11,7 +11,7 @@ log = { workspace = true }
 oci-spec = { workspace = true, features = ["runtime"] }
 ttrpc = { workspace = true }
 
-wasmedge-sdk = { version = "0.11.2" }
+wasmedge-sdk = { version = "0.12.1" }
 wasmedge-sys = "*"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This PR supersedes https://github.com/containerd/runwasi/pull/309