### PR TITLE
Run e2e test with both kind and k3s for all runtimes

### DIFF
--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -36,7 +36,7 @@ jobs:
           path: dist
       - name: run
         timeout-minutes: 5
-        run: make test/k8s
+        run: make test/k8s-${{ inputs.runtime }}
       # only runs when the previous step fails
       - name: inspect failed pods
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         # 20.04 uses cgroupv1, 22.04 uses cgroupv2
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-        runtime:  ["wasmtime"]
+        runtime: ["wasmtime", "wasmedge", "wasmer"]
     uses: ./.github/workflows/action-test-kind.yml
     with:
       os: ${{ matrix.os }}
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-        runtime: ["wasmedge", "wasmer"]
+        runtime: ["wasmtime", "wasmedge", "wasmer"]
     uses: ./.github/workflows/action-test-k3s.yml
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds k3s e2e tests to wasmtime and kind e2e tests to wasmedge and wasmer.
It does it by adding a parameter to the e2e test in the Makefile, which indicates the runtime to use.