### PR TITLE
chore: bump containerd-shim-wasm to `v0.3.0` and other crates to `v0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "caps",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm-test"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "containerd-shim-wasm",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmedge"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmer"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmtime"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "oci-tar-builder"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-demo-app"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1"
+version = "0.2.0"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/containerd/runwasi"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd-shim-wasm"
 description = "Library for building containerd shims for wasm"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"


### PR DESCRIPTION
After the PR is merged, I will tag a release for `containerd-shim-wasm` and the shims

Could you please take a look? @cpuguy83 