### PR TITLE
Bump wasmedge-sdk with fixed musl issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sdk"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2069fe61f5dbbfbb3f518e473f301983f275cadb801fb9256737ce7b993804b7"
+checksum = "11bb38d73f5ce871a7a4c6da62b72ef80a948cbe66bc98051e303614abf6700f"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4526,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sys"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41df5edf19a81558c2e9d7ec95bf4adec7e81ba2d1ef3d57076e3177e6508023"
+checksum = "246cbb4772e75958ba2d3f016f5b46bf56c5911a99ecbad8ece79e6cf750b75c"
 dependencies = [
  "bindgen",
  "cfg-if 1.0.0",

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -11,7 +11,7 @@ log = { workspace = true }
 oci-spec = { workspace = true, features = ["runtime"] }
 ttrpc = { workspace = true }
 
-wasmedge-sdk = { version = "0.12.1" }
+wasmedge-sdk = { version = "0.12.2" }
 wasmedge-sys = "*"
 
 [dev-dependencies]


### PR DESCRIPTION
The new patch release of wasmedge-sdk fixes the issue where it fails to build with musl.