### PR TITLE
Use `cross-rs`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@ rustflags = [
 
 [target.'cfg(unix)']
 runner = 'scripts/test-runner.sh'
+
+[profile.release]
+strip = "symbols"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,14 @@
+[build]
+default-target = "x86_64-unknown-linux-musl"
+
+[target.aarch64-unknown-linux-musl]
+dockerfile = "cross/Dockerfile.musl"
+
+[target.x86_64-unknown-linux-musl]
+dockerfile = "cross/Dockerfile.musl"
+
+[target.aarch64-unknown-linux-gnu]
+dockerfile = "cross/Dockerfile.gnu"
+
+[target.x86_64-unknown-linux-gnu]
+dockerfile = "cross/Dockerfile.gnu"

--- a/cross/Dockerfile.gnu
+++ b/cross/Dockerfile.gnu
@@ -1,0 +1,8 @@
+ARG CROSS_BASE_IMAGE
+ARG CROSS_DEB_ARCH
+FROM $CROSS_BASE_IMAGE
+
+ARG CROSS_DEB_ARCH
+RUN dpkg --add-architecture ${CROSS_DEB_ARCH} && \
+    apt-get -y update && \
+    apt-get install -y pkg-config libseccomp-dev:${CROSS_DEB_ARCH}

--- a/cross/Dockerfile.musl
+++ b/cross/Dockerfile.musl
@@ -1,0 +1,25 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+COPY --from=jorgeprendes420/apk-anywhere / /
+ENV MARCH=${CROSS_CMAKE_SYSTEM_PROCESSOR}
+RUN apk-init ${MARCH} ${CROSS_SYSROOT}
+
+# configure libsecccomp-rs to use static linking
+RUN apk-${MARCH} add libseccomp-static libseccomp-dev
+ENV LIBSECCOMP_LINK_TYPE="static"
+ENV LIBSECCOMP_LIB_PATH="${CROSS_SYSROOT}/lib"
+
+# configure wasmedge to link stdc++ statically
+RUN apk-${MARCH} add g++
+ENV WASMEDGE_DEP_STDCXX_LINK_TYPE="static"
+ENV WASMEDGE_DEP_STDCXX_LIB_PATH="${CROSS_SYSROOT}/lib"
+
+# wasmedge (through llvm) needs some symbols defined in libgcc
+RUN mkdir /.cargo && cat <<'EOF' > /.cargo/config.toml
+[target.'cfg(target_env = "musl")']
+rustflags = ["-Clink-arg=-lgcc"]
+EOF
+
+RUN apt-get -y update && \
+    apt-get install -y pkg-config


### PR DESCRIPTION
This PR enables the use of `cross-rs` for building and testing.
```sh
make build-wasmedge CARGO=cross TARGET=x86_64-unknown-linux-musl
```

It also works as an example on how to set up the cross containers for building `runwasi` with `libseccomp`

This PR depends on #331 as otherwise wasmedge wouldn't build on `musl` targets.

Note that the release workflows are not using `cross-rs` which can be done in a follow up PR.