### PR TITLE
Bump nix to 1.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
  "libc",
  "libcontainer",
  "log",
- "nix 0.26.4",
+ "nix 0.27.1",
  "oci-spec",
  "protobuf 3.2.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ env_logger = "0.10"
 libc = "0.2.147"
 libcontainer = { version = "0.2", default-features = false }
 log = "0.4"
-nix = "0.26"
+nix = "0.27"
 oci-spec = { version = "0.6.1", features = ["runtime"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -31,7 +31,7 @@ wat = { workspace = true }
 caps = "0.5"
 dbus = { version = "*", features = ["vendored"] }
 libcontainer = { workspace = true, features = ["libseccomp", "systemd", "v1", "v2"]}
-nix = { workspace = true }
+nix = { workspace = true, features = ["sched", "mount"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }

--- a/crates/containerd-shim-wasm/src/sys/unix/networking.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/networking.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::os::unix::io::AsRawFd;
 
 use anyhow::Result;
 use containerd_shim::error::Error as ShimError;
@@ -25,7 +24,7 @@ pub fn setup_namespaces(spec: &runtime::Spec) -> Result<()> {
                         err
                     ))
                 })?;
-                setns(f.as_raw_fd(), CloneFlags::CLONE_NEWNET).map_err(|err| {
+                setns(f, CloneFlags::CLONE_NEWNET).map_err(|err| {
                     ShimError::Other(format!("could not set network namespace: {0}", err))
                 })?;
             } else {


### PR DESCRIPTION
`nix 1.27` doesn't enable features by default, so we need to enable them manually.
Also, libcontainer uses Nix 1.26, and the `Pid` type had changed between the two versions. To work around this, we need to go through the raw `pid_t`.

This supersedes #294