### PR TITLE
Upload k3s/kind logs on failure

### DIFF
--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -43,6 +43,18 @@ jobs:
         run: |
           sudo bin/k3s kubectl get pods --all-namespaces
           sudo bin/k3s kubectl describe pods --all-namespaces
+      - name: tar logs
+        if: failure()
+        run: |
+          sudo journalctl -u k3s-runwasi > k3s.log
+          sudo tar czf k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C . k3s.log -C /var/log/pods . -C /var/lib/rancher/k3s/agent/containerd/ containerd.log
+          sudo chown ${USER}:${USER} k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz
+      - name: upload logs
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}
+          path: k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz
       - name: cleanup
         if: always()
         run: make test/k3s/clean

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -43,6 +43,17 @@ jobs:
         run: |
           kubectl get pods --all-namespaces
           kubectl describe pods --all-namespaces
+      - name: tar logs
+        if: failure()
+        run: |
+          bin/kind export logs ./kind-logs --name containerd-wasm
+          tar czf kind-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C ./kind-logs .
+      - name: upload logs
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: kind-logs-${{ inputs.runtime }}-${{ inputs.os }}
+          path: kind-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz
       - name: cleanup
         if: always()
         run: make test/k8s/clean

--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,11 @@ target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm:
 target/wasm32-wasi/$(OPT_PROFILE)/img.tar: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
 	cd crates/wasi-demo-app && cargo build $(RELEASE_FLAG) --features oci-v1-tar
 
-dist/img.tar: target/wasm32-wasi/$(OPT_PROFILE)/img.tar
+.PHONY: dist/img.tar
+dist/img.tar:
 	@mkdir -p "dist/"
-	cp "$<" "$@"
+	[ -f $(PWD)/dist/img.tar ] || $(MAKE) target/wasm32-wasi/$(OPT_PROFILE)/img.tar
+	[ -f $(PWD)/dist/img.tar ] || cp target/wasm32-wasi/$(OPT_PROFILE)/img.tar "$@"
 
 load: dist/img.tar
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import --all-platforms $<


### PR DESCRIPTION
This PR gathers the containerd and pod logs for k3s and kind whenever the e2e tests fails and uploads them as artifacts for further inspection.

This [CI run](https://github.com/containerd/runwasi/actions/runs/6385816342?pr=346) is an example of what said artifacts look like for both, k3s and kind.

I hope this will help us further debug the root cause of the sporadic e2e failures in CI.