### PR TITLE
Retry bootstrapping k3s on failure

### DIFF
--- a/test/k3s/bootstrap.sh
+++ b/test/k3s/bootstrap.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+rm -f /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+cp -f /var/lib/rancher/k3s/agent/etc/containerd/config.toml /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+cat <<EOF >> /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
+  runtime_type = "$PWD/dist/bin/containerd-shim-$1-v1"
+EOF
+
+cat <<EOF > /etc/systemd/system/k3s-runwasi.service.env
+CONTAINERD_NAMESPACE='${CONTAINERD_NAMESPACE:-default}'
+NO_PROXY=192.168.0.0/16
+EOF
+
+systemctl daemon-reload
+systemctl restart k3s-runwasi
+while ! bin/k3s ctr version; do sleep 1; done
+bin/k3s ctr image import --all-platforms dist/img.tar
+while [ "$(bin/k3s kubectl get pods --all-namespaces --no-headers | wc -l)" == "0" ]; do sleep 1; done
+while [ "$(bin/k3s kubectl get pods --all-namespaces --no-headers | grep -vE "Completed|Running" | wc -l)" != "0" ]; do sleep 1; done


### PR DESCRIPTION
Sporadically k3s would fail to bootstrap, see
* missing file from install: https://github.com/containerd/runwasi/issues/322#issuecomment-1751267331
* kube-sys pods never start: https://github.com/containerd/runwasi/actions/runs/6455790697/job/17524166280

This PR tries to mitigate this by re-bootstrapping k3s when that happens.
This change uses a timeout of 40s for k3s bootstrapping. If that fails, it uninstalls k3s, reinstalls it, and tries again.
This would continue until it succeeds or the CI timeout of 5min is hit.

Note that in the case where the kube-sys pods never show up, simply restarting the systemd service is not enough (I tired this in one of the many many attempts), which indicates that a complete reinstall is a better option.