### PR TITLE
chore: Use latest kind and k8s release

### DIFF
--- a/test/k8s/Dockerfile
+++ b/test/k8s/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 ARG KIND_VERSION=v0.20.0
-ARG KIND_NODE_VERSION=v1.27.3
+ARG KIND_NODE_VERSION=v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
 ARG RUNTIME=wasmtime
 
 FROM scratch AS kind
@@ -15,8 +15,7 @@ RUN apt-get update -y && \
 ADD dist/bin/* /usr/local/bin/
 
 ARG RUNTIME
-RUN sed -i 's,SystemdCgroup = true,,' /etc/containerd/config.toml && \
-    cat <<EOF >> /etc/containerd/config.toml
+RUN cat <<EOF >> /etc/containerd/config.toml
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
 runtime_type = "io.containerd.${RUNTIME}.v1"
 EOF

--- a/test/k8s/Dockerfile
+++ b/test/k8s/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
-ARG KIND_VERSION=v0.17.0
-ARG KIND_NODE_VERSION=v1.23.13
+ARG KIND_VERSION=v0.20.0
+ARG KIND_NODE_VERSION=v1.27.3
 ARG RUNTIME=wasmtime
 
 FROM scratch AS kind


### PR DESCRIPTION
Updating to use more recent versions of kubernetes and kind