### PR TITLE
Use `cross-rs` for building in CI

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -9,10 +9,16 @@ on:
       runtime:
         required: true
         type: string
+      target:
+        required: false
+        type: string
+      slug:
+        required: true
+        type: string
 
 jobs:
   build:
-    name: build on ${{ inputs.os }}
+    name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3
@@ -23,12 +29,16 @@ jobs:
         shell: bash
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         env:
-          RUST_CACHE_KEY_OS: ${{ inputs.os }}
+          RUST_CACHE_KEY_OS: rust-cache-${{ inputs.os }}-${{ inputs.slug }}
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
+      - name: Setup cross-rs
+        if: runner.os == 'Linux'
+        run: ./scripts/setup-cross.sh ${{ inputs.target }}
       - name: Build
         run: make build-${{ inputs.runtime }}
       - name: Validate docs
+        if: ${{ inputs.runtime == 'common' }}
         run: ./scripts/validate-docs.sh
       - name: Run tests
         timeout-minutes: 5
@@ -41,13 +51,13 @@ jobs:
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin .
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -C dist/bin .
           else
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -T /dev/null
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
         uses: actions/upload-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
-          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}
+          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
+          name: containerd-shim-${{ inputs.runtime }}-linux-musl
           path: dist
       - name: Unpack artifats
         shell: bash
         run: |
           mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-linux-musl.tar.gz -C dist/bin
       - name: Download test image
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
+          name: containerd-shim-${{ inputs.runtime }}-linux-musl
           path: dist
       - name: Unpack artifats
         shell: bash
         run: |
           mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-linux-musl.tar.gz -C dist/bin
       - name: Download test image
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}
+          name: containerd-shim-${{ inputs.runtime }}-linux-musl
           path: dist
       - name: Unpack artifats
         shell: bash
         run: |
           mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-linux-musl.tar.gz -C dist/bin
       - name: Download test image
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,15 @@ jobs:
     name: ${{ matrix.runtime }}
     strategy:
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-22.04"]
         runtime: ["common", "wasmtime", "wasmedge", "wasmer"]
+        libc: ["musl", "gnu"]
     uses: ./.github/workflows/action-build.yml
     with:
       os: ${{ matrix.os }}
       runtime: ${{ matrix.runtime }}
+      target: "x86_64-unknown-linux-${{ matrix.libc }}"
+      slug: "linux-${{ matrix.libc }}"
 
   build-windows:
     name: ${{ matrix.runtime }}
@@ -49,6 +52,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       runtime: ${{ matrix.runtime }}
+      slug: "windows"
 
   smoke-tests:
     name: ${{ matrix.runtime }}

--- a/scripts/setup-cross.sh
+++ b/scripts/setup-cross.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cargo install cross --git https://github.com/cross-rs/cross
+echo "CARGO=cross" >> ${GITHUB_ENV}
+
+if [ ! -z "$1" ]; then
+    echo "TARGET=$1" >> ${GITHUB_ENV}
+fi

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-sudo -E env LD_LIBRARY_PATH=${LD_LIBRARY_PATH} "$@"
+echo $@
+TARGET_DIR="$(dirname $0)/.."
+WASMEDGE_PATH=$(dirname $(find "$TARGET_DIR" -name libwasmedge.so | head -n 1) 2>/dev/null || echo "")
+sudo -E env LD_LIBRARY_PATH="${WASMEDGE_PATH}" "$@"

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -7,7 +7,8 @@ if [[ $RUNNER_OS == "Windows" ]]; then
     CARGO_FLAGS="--no-default-features"
 fi
 
-cargo build --all --verbose --features generate_doc $CARGO_FLAGS
+# Only containerd-shim-wasm has the generate_doc feature
+${CARGO:-cargo} build -p containerd-shim-wasm --verbose --features generate_doc $CARGO_FLAGS
 git status --porcelain | grep README.md || exit 0
 
 echo "README.md is not up to date. Please run 'cargo build --all --features generate_doc' and commit the changes." >&2


### PR DESCRIPTION
This PR switches CI to use the `cross-rs` support introduced in #332.
This should unblock #356.

This PR uses `cross-rs` for the linux builds of the shims. It generates a `linux-musl` and a `linux-gnu` artifacts using `musl` and `glibc` respectively.

It also stops building the shims on `ubuntu-20.04`. Since the `cross-rs` build happens in a container it is not necessary to build on different OS versions. However, we keep running e2e tests in `ubuntu-20.04` to maintain test coverage on an OS running `cgroups-v1`.

The e2e tests are switched to use the `musl` build of the shims, as this would unblock #356.
Since `cross-rs` uses an older `glibc` version, it might be possible to also enable e2e tests using `glibc`, but I suggest we defer that to another PR after #356 is merged.

There are some complications around running the unit tests with `cross-rs`. This PR works around those issues by building the tests with `cross-rs`, but running them in the host. See https://github.com/containerd/runwasi/pull/359#discussion_r1364078589 for more details.