### PR TITLE
Add the shim to to the network NS specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,10 @@ test/k8s/cluster-oci-%: dist/img-oci.tar bin/kind test/k8s/_out/img-oci-%
 test/k8s-%: test/k8s/clean test/k8s/cluster-%
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) apply -f test/k8s/deploy.yaml
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=90s
+	# verify that we are still running after some time	
+	sleep 5s
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
+
 
 .PHONY: test/k8s/clean
 test/k8s/clean: bin/kind
@@ -251,6 +255,9 @@ test/k3s-%: dist/img.tar bin/k3s dist-%
 	sudo bin/k3s kubectl apply -f test/k8s/deploy.yaml
 	sudo bin/k3s kubectl get pods --all-namespaces
 	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=120s
+	# verify that we are still running after some time	
+	sleep 5s
+	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=5s
 	sudo bin/k3s kubectl get pods -o wide
 
 .PHONY: test/k3s/clean

--- a/crates/containerd-shim-wasm/src/sandbox/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim.rs
@@ -39,6 +39,7 @@ use ttrpc::context::Context;
 use super::instance::{Instance, InstanceConfig, Nop};
 use super::{oci, Error, SandboxService};
 use crate::sys::metrics::get_metrics;
+use crate::sys::networking::setup_namespaces;
 
 enum InstanceOption<I: Instance> {
     Instance(I),
@@ -1209,6 +1210,9 @@ where
             .get("io.kubernetes.cri.sandbox-id")
             .unwrap_or(&id)
             .to_string();
+
+        setup_namespaces(&spec)
+            .map_err(|e| shim::Error::Other(format!("failed to setup namespaces: {}", e)))?;
 
         #[cfg(unix)]
         mount::<str, Path, str, str>(


### PR DESCRIPTION
When removing the mounting code we also removed the network setup: https://github.com/containerd/runwasi/pull/327#issuecomment-1730071090

Ends up this is required as youki is only setting the Pid and User namespaces: https://github.com/containers/youki/blob/ba4a10f4a09b0360eeb38ab70a95adc986b2b9da/crates/libcontainer/src/process/container_intermediate_process.rs#L70