### PR TITLE
ci: double the timeout duration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
         run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
       - name: Build
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: make build-${{ needs.generate.outputs.runtime }}
       - name: Test
         if: ${{ matrix.arch == 'x86_64' }}


### PR DESCRIPTION
I triggered release CI for all three shims (wasmtime, wasmedge and wasmer). Two out of three encountered a timeout issue so I am doubling the timeout duration for the build action

See failed runs:

- https://github.com/containerd/runwasi/actions/runs/6699073525/job/18202498689#step:7:650
- https://github.com/containerd/runwasi/actions/runs/6699079435/job/18202521220#step:7:638