### PR TITLE
chore: add published version of wasm-test-modules dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cap-std = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 containerd-shim = "0.6.0"
 containerd-shim-wasm = { path = "crates/containerd-shim-wasm" }
-containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules" }
+containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules", version = "0.3.0"}
 crossbeam = { version = "0.8.2", default-features = false }
 env_logger = "0.10"
 libc = "0.2.149"


### PR DESCRIPTION
In cargo, it is possible to specify a local path and a register version for one dep (see https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations). 

What this means for us is that we can keep using local `containerd-shim-wasm-test-modules` for development. At the same time, when we do `cargo publish`, it will resolve to use the remote version of `containerd-shim-wasm-test-containers` from crates.io. 