### PR TITLE
ci: add runwasi-committee to owner of the crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,6 @@ jobs:
       - name: Check crates.io ownership
         run: |
           cargo owner --add github:containerd:runwasi-committers ${{ needs.generate.outputs.crate }}
-          cargo owner --add ${{ github.actor }} ${{ needs.generate.outputs.crate }}
-          
           cargo owner --list ${{ needs.generate.outputs.crate }} | grep github:containerd:runwasi-committers
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,9 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
       - name: Check crates.io ownership
         run: |
+          cargo owner --add github:containerd:runwasi-committers ${{ needs.generate.outputs.crate }}
+          cargo owner --add ${{ github.actor }} ${{ needs.generate.outputs.crate }}
+          
           cargo owner --list ${{ needs.generate.outputs.crate }} | grep github:containerd:runwasi-committers
-          if [ $? -ne 0 ]; then
-            cargo owner --add ${{ github.actor }} ${{ needs.generate.outputs.crate }}
-          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}


### PR DESCRIPTION
Instead of checking if the `github:containerd:runwasi-committers` is an owner of the crate, we always add it as an owner. 

This may help to resolve the error we encountered at this run: https://github.com/containerd/runwasi/actions/runs/6699464559/job/18203943248#step:7:12