### PR TITLE
ci: add build env to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup build env
+        run: ./scripts/setup-linux.sh
       - name: Download artifacts
         if: ${{ needs.generate.outputs.runtime != 'wasm' }}
         uses: actions/download-artifact@master


### PR DESCRIPTION
The release of `containerd-shim-wasm` crate failed at the cargo publish step saying that `protoc` was not found. Thus I am adding build env to the release job. 