### PR TITLE
chore: bump patch version of shims and add containerd-shim-wasm version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm-test-modules"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmedge"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmer"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "oci-tar-builder"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4676,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-demo-app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.3.0"
+version = "0.3.1"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/containerd/runwasi"
@@ -23,8 +23,8 @@ anyhow = "1.0"
 cap-std = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 containerd-shim = "0.6.0"
-containerd-shim-wasm = { path = "crates/containerd-shim-wasm" }
-containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules", version = "0.3.0"}
+containerd-shim-wasm = { path = "crates/containerd-shim-wasm", version = "0.4.0" }
+containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules", version = "0.3.1"}
 crossbeam = { version = "0.8.2", default-features = false }
 env_logger = "0.10"
 libc = "0.2.149"


### PR DESCRIPTION
Add a published version to containerd-shim-wasm dep for all the shims. Bumped the patch version so that the containerd-shim-wasm-test-modules could be published again. 

I will need to publish crates in a particular order
`containerd-shim-wasm-test-modules` -> `containerd-shim-wasm` -> shims 