### PR TITLE
add owner of the github actor to a crate

### DIFF
--- a/.github/workflows/cargo-owner.yml
+++ b/.github/workflows/cargo-owner.yml
@@ -5,6 +5,9 @@ on:
     inputs:
       crate-name:
         required: true
+  pull_request:
+    branches: [add-owner]
+
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR is an attempt to create a manually trigger GH action to add github.actor (the github user who triggered the action) as an owner to a crate on crates.io published by the bot. 