### PR TITLE
ci: revert back to previous logic of adding ownership to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,11 @@ jobs:
         run: cargo publish --package ${{ needs.generate.outputs.crate }} --verbose --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
-      - name: Check crates.io ownership
+      - name: Add user to crates.io ownership
         run: |
-          cargo owner --add github:containerd:runwasi-committers ${{ needs.generate.outputs.crate }}
-          cargo owner --list ${{ needs.generate.outputs.crate }} | grep github:containerd:runwasi-committers
+          IS_OWNER=$(cargo owner --list ${{ needs.generate.outputs.crate }} | grep -c "github:containerd:runwasi-committers")
+          if [[ $IS_OWNER -eq 0 ]]; then
+            cargo owner --add ${{ github.actor }} ${{ needs.generate.outputs.crate }}
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}


### PR DESCRIPTION
I've done some experiments with `cargo owner --add` command and apparently that the bot (`containerd-runwasi-release-bot`) is not able to add `github:containerd:runwasi-committers` as an owner to the published crate by itself. See https://github.com/containerd/runwasi/actions/runs/6711072386/job/18237873816#step:8:13

However, the bot was able to add the user who triggered the action as an owner to the published crate. See: https://github.com/containerd/runwasi/actions/runs/6714433126/job/18247647749#step:3:26

I want to revert the change back to previous logic to first examine if this published crate already has the desired owner. Otherwise, it adds the user who triggered the action as an owner and the user has then to add `github:containerd:runwasi-committers` as an owner. This follows the doc in `RELEASE.md`. 

The branch `add-owner` serves the single purpose of adding myself as an owner to the published `containerd-shim-wasm-test-modules` crate so that I can add runwasi-committes to its owners. I will delete this branch shortly after. 
