### PR TITLE
fix(Cargo.toml): restrict wildcard version to major versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = "1.0"
 ttrpc = "0.8.0"
 wat = "1.0"
 windows-sys = "0.48"
+serial_test = "2"
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ tar = "0.4"
 tempfile = "3.8"
 thiserror = "1.0"
 ttrpc = "0.8.0"
-wat = "*" # Use whatever version wasmtime will make us pull
-windows-sys = { version = "0.48" }
+wat = "1.0"
+windows-sys = "0.48"
 
 [profile.release]
 panic = "abort"

--- a/crates/containerd-shim-wasm-test-modules/Cargo.toml
+++ b/crates/containerd-shim-wasm-test-modules/Cargo.toml
@@ -7,14 +7,14 @@ license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-env_logger = "0.10"
+env_logger = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 oci-spec = { workspace = true }
 serde_json = { workspace = true }
-tempfile = "3.8"
+tempfile = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }
-lazy_static = { version = "1.4.0" }
-wat = { version = "1.0.46" }
+lazy_static = "1.4.0"
+wat = { workspace = true }

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3.29" }
 
 [target.'cfg(unix)'.dependencies]
 caps = "0.5"
-dbus = { version = "*", features = ["vendored"] }
+dbus = { version = "0", features = ["vendored"] }
 libcontainer = { workspace = true, features = ["libseccomp", "systemd", "v1", "v2"]}
 nix = { workspace = true, features = ["sched", "mount"] }
 containerd-client = "0.4.0"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -34,6 +34,7 @@ futures = { version = "0.3.29" }
 
 [target.'cfg(unix)'.dependencies]
 caps = "0.5"
+# this must match the version pulled by libcontainer
 dbus = { version = "0", features = ["vendored"] }
 libcontainer = { workspace = true, features = ["libseccomp", "systemd", "v1", "v2"]}
 nix = { workspace = true, features = ["sched", "mount"] }

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -16,7 +16,7 @@ wasmedge-sdk = { version = "0.12.2" }
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }
 libc = { workspace = true }
-serial_test = "*"
+serial_test = "2"
 
 [features]
 default = ["standalone", "static"]

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -16,7 +16,7 @@ wasmedge-sdk = { version = "0.12.2" }
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }
 libc = { workspace = true }
-serial_test = "2"
+serial_test = { workspace = true }
 
 [features]
 default = ["standalone", "static"]

--- a/crates/containerd-shim-wasmer/Cargo.toml
+++ b/crates/containerd-shim-wasmer/Cargo.toml
@@ -18,7 +18,7 @@ wasmer-wasix = { version = "0.12.0" }
 
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }
-serial_test = "*"
+serial_test = "2"
 
 [[bin]]
 name = "containerd-shim-wasmer-v1"

--- a/crates/containerd-shim-wasmer/Cargo.toml
+++ b/crates/containerd-shim-wasmer/Cargo.toml
@@ -18,7 +18,7 @@ wasmer-wasix = { version = "0.12.0" }
 
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }
-serial_test = "2"
+serial_test = { workspace = true }
 
 [[bin]]
 name = "containerd-shim-wasmer-v1"

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -30,7 +30,7 @@ wasi-common = "11.0"
 
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }
-serial_test = "2"
+serial_test = { workspace = true }
 
 [[bin]]
 name = "containerd-shim-wasmtime-v1"

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -30,7 +30,7 @@ wasi-common = "11.0"
 
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }
-serial_test = "*"
+serial_test = "2"
 
 [[bin]]
 name = "containerd-shim-wasmtime-v1"


### PR DESCRIPTION
This PR aims to use more restrictive dependency versions in our `Cargo.toml` file.

## Motivation

**Policy Compliance**: To adhere to the "no wildcard version" policy enforced by crates.io, making our package more compliant and easier to publish. See https://github.com/containerd/runwasi/actions/runs/6715767237/job/18251185616#step:7:794

**Reduced Risks**: By pinning our dependencies to major versions, we reduce the risks associated with unexpected breaking changes in newer versions.

## Follow ups

I will give another try to release `containerd-shim-wasm` at `v0.4.0`
