### PR TITLE
remove wasmedge-sys dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,6 @@ dependencies = [
  "serial_test",
  "ttrpc",
  "wasmedge-sdk",
- "wasmedge-sys",
 ]
 
 [[package]]

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -12,7 +12,6 @@ oci-spec = { workspace = true, features = ["runtime"] }
 ttrpc = { workspace = true }
 
 wasmedge-sdk = { version = "0.12.2" }
-wasmedge-sys = "*"
 
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }

--- a/crates/containerd-shim-wasmedge/src/tests.rs
+++ b/crates/containerd-shim-wasmedge/src/tests.rs
@@ -108,9 +108,12 @@ fn test_has_default_devices() -> anyhow::Result<()> {
 fn get_wasmedge_binary_path() -> std::path::PathBuf {
     use std::os::unix::prelude::OsStrExt;
 
-    let f = wasmedge_sys::ffi::WasmEdge_VersionGet;
+    extern "C" {
+        pub fn WasmEdge_VersionGet() -> *const libc::c_char;
+    }
+
     let mut info = unsafe { std::mem::zeroed() };
-    if unsafe { libc::dladdr(f as *const libc::c_void, &mut info) } == 0 {
+    if unsafe { libc::dladdr(WasmEdge_VersionGet as *const libc::c_void, &mut info) } == 0 {
         // no dladdr support, must be a static binary
         std::env::current_exe().unwrap_or_default()
     } else {


### PR DESCRIPTION
This PR removes the dependency on `wasmedge-sys`.

This depdency was only used to test that a symbol is statically / dinamically linked in the binary.
This PR inlines the FFI symbol instead of using the crate dependency.

The risk of depending on `wasmedge-sys` is that the version could drifts from what `wasmedge-sdk` uses.
In that case, the test would be probing the wrong symbol, and it may silenly succeed when it should fail.

The selected symbol for the probe is expected to remain unchaged across different versions of wasmedge.
If it ever changes, then compilation should fail, indicating that the symbol needs to be updated.