### PR TITLE
[CI] Move parse ref from yaml to a script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,50 +13,25 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  generate:
+  parse:
     runs-on: ubuntu-latest
-    name: Generate
+    name: Parse ref
     outputs:
-      crate: ${{ steps.parse-ref.outputs.crate }}
-      version: ${{ steps.parse-ref.outputs.version }}
-      runtime: ${{ steps.parse-ref.outputs.runtime }}
+      crate: ${{ steps.parse.outputs.crate }}
+      version: ${{ steps.parse.outputs.version }}
+      runtime: ${{ steps.parse.outputs.runtime }}
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-      - id: parse-ref
+      - id: parse
         name: Parse ref
-        run: |
-          set -e
-
-          CRATE="$(cut -d/ -f1 <<<"${GITHUB_REF#refs/*/}")"
-          VERSION="$(cut -d/ -f2 <<<"${GITHUB_REF#refs/*/}")"
-
-          if [ -z "${CRATE}" ]; then
-            echo "::error::Could not determine crate name from ref '${GITHUB_REF}'"
-            exit 1
-          fi
-
-          if [ -z "${VERSION}" ]; then
-            echo "::error::Could not determine version from ref '${GITHUB_REF}'"
-            exit 1
-          fi
-
-          RUNTIME="$(cut -d- -f3 <<<"${CRATE}")"
-
-          echo "CRATE=${CRATE}" >> $GITHUB_OUTPUT
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-          echo "RUNTIME=${RUNTIME}" >> $GITHUB_OUTPUT
-
-          setVersion="$(./scripts/version.sh "${CRATE}")"
-          if [ ! "${VERSION#v}" = "${setVersion}" ]; then
-            echo "::error::Version mismatch: tag version ${VERSION#v} != crate version ${setVersion}"
-            exit 1
-          fi
+        shell: bash
+        run: ./scripts/parse_ref.sh ${{ github.ref }} >> ${GITHUB_OUTPUT}
 
   build:
     needs:
-      - generate
+      - parse
     strategy:
       matrix:
         arch: ["x86_64", "aarch64"]
@@ -67,7 +42,7 @@ jobs:
         run: ./scripts/setup-linux.sh
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         env:
-          RUST_CACHE_KEY_OS: rust-release-cache-${{ needs.generate.outputs.crate }}-${{ matrix.arch }}
+          RUST_CACHE_KEY_OS: rust-release-cache-${{ needs.parse.outputs.crate }}-${{ matrix.arch }}
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - name: Setup cross-rs
@@ -77,42 +52,42 @@ jobs:
         run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
       - name: Build
         timeout-minutes: 20
-        run: make build-${{ needs.generate.outputs.runtime }}
+        run: make build-${{ needs.parse.outputs.runtime }}
       - name: Test
         if: ${{ matrix.arch == 'x86_64' }}
         timeout-minutes: 10
-        run: make test-${{ needs.generate.outputs.runtime }}
+        run: make test-${{ needs.parse.outputs.runtime }}
       - name: Package artifacts
-        if: ${{ needs.generate.outputs.runtime != 'wasm' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' }}
         shell: bash
         run: |
-          make dist-${{ needs.generate.outputs.runtime }}
+          make dist-${{ needs.parse.outputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ needs.generate.outputs.runtime }}-${{ matrix.arch }}.tar.gz -C dist/bin .
+            tar -czf dist/containerd-shim-${{ needs.parse.outputs.runtime }}-${{ matrix.arch }}.tar.gz -C dist/bin .
           else
-            tar -czf dist/containerd-shim-${{ needs.generate.outputs.runtime }}-${{ matrix.arch }}.tar.gz -T /dev/null
+            tar -czf dist/containerd-shim-${{ needs.parse.outputs.runtime }}-${{ matrix.arch }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
-        if: ${{ needs.generate.outputs.runtime != 'wasm' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' }}
         uses: actions/upload-artifact@master
         with:
-          name: containerd-shim-${{ needs.generate.outputs.runtime }}-${{ matrix.arch }}
-          path: dist/containerd-shim-${{ needs.generate.outputs.runtime }}-${{ matrix.arch }}.tar.gz
+          name: containerd-shim-${{ needs.parse.outputs.runtime }}-${{ matrix.arch }}
+          path: dist/containerd-shim-${{ needs.parse.outputs.runtime }}-${{ matrix.arch }}.tar.gz
 
   release:
     permissions:
       contents: write
     needs:
       - build
-      - generate
+      - parse
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup build env
         run: ./scripts/setup-linux.sh
       - name: Download artifacts
-        if: ${{ needs.generate.outputs.runtime != 'wasm' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' }}
         uses: actions/download-artifact@master
         with:
           path: release
@@ -121,23 +96,23 @@ jobs:
           gh release create ${{ github.ref }} --generate-notes --prerelease
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_NAME: ${{ needs.generate.outputs.crate }}/${{ needs.generate.outputs.version }}
+          RELEASE_NAME: ${{ needs.parse.outputs.crate }}/${{ needs.parse.outputs.version }}
       - name: Upload release artifacts
-        if: ${{ needs.generate.outputs.runtime != 'wasm' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' }}
         run: |
           for i in release/*/*; do
             gh release upload ${RELEASE_NAME} $i
           done
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_NAME: ${{ needs.generate.outputs.crate }}/${{ needs.generate.outputs.version }}
+          RELEASE_NAME: ${{ needs.parse.outputs.crate }}/${{ needs.parse.outputs.version }}
       - name: Cargo publish
-        run: cargo publish --package ${{ needs.generate.outputs.crate }} --verbose --locked
+        run: cargo publish --package ${{ needs.parse.outputs.crate }} --verbose --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
       - name: Check crates.io ownership
         run: |
-          cargo owner --add github:containerd:runwasi-committers ${{ needs.generate.outputs.crate }}
-          cargo owner --list ${{ needs.generate.outputs.crate }} | grep github:containerd:runwasi-committers
+          cargo owner --add github:containerd:runwasi-committers ${{ needs.parse.outputs.crate }}
+          cargo owner --list ${{ needs.parse.outputs.crate }} | grep github:containerd:runwasi-committers
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,9 +10,9 @@ This triggers the [release](.github/workflows/release.yml) GitHub Actions workfl
 In the future we may include a workflow for tagging the release but for now this is manual.
 
 The workflow performs the following steps:
-- Build the crate to be released (determined by the tag)
+- Build the crate to be released (determined by the tag), including any artifacts (e.g., associated binaries)
 - Run the tests for that crate (and only that crate!)
-- Build any associated release artifacts (e.g. the containerd-shim-wasmtime crate includes several binaries).
+- Creates a GitHub release for that crate (attaching any artifacts)
 - Publish the crate to crates.io
 
 ### Crate Release Sequence
@@ -23,7 +23,8 @@ The workflow performs the following steps:
 The workflow utilizes a bot account (@containerd-runwasi-release-bot) to publish the crate to crates.io. The bot account is only used to get a limited-scope API token to publish the crate on crates.io. The token is stored as a secret in the repository and is only used by the release workflow.
 
 ## Local Development vs. Release
-Locally, crates reference local paths. During release, they target published versions. Use both `path` and `version` fields in your Cargo.toml:
+Locally, crates reference local paths. During release, they target published versions.
+Use both `path` and `version` fields in the workspace `Cargo.toml`:
 
 e.g.
 

--- a/scripts/parse_ref.sh
+++ b/scripts/parse_ref.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Usage: parse_ref.sh <ref|crate|runtime>
+#
+# This scripts parses a tag ref of the type
+#  refs/tags/<crate>/v<version>
+# and prints
+#  CRATE=<crate>
+#  VERSION=v<version>
+#  RUNTIME=<runtime>
+# with <crate> = containerd-shim-<runtime>
+# The script errors if the crate or the version can't be parsed,
+# or the version doesn't match the value in `crates/<crate>/Cargo.toml`.
+#
+# If <ref> provided, that value is parsed.
+# If <crate> is provided, the most recent tag matching `<crate>/*` is parsed.
+# If <runtime> is provided, the most recent tag matching `containerd-shim-<runtime>/*` is parsed.
+# If no argument is provided, it defaults to `containerd-shim-wasm`.
+
+set -e
+
+if [ ! "${1}" = "${1#refs/*/}" ]; then
+REF="$1"
+else
+REF="${1#containerd-shim-}"
+REF="containerd-shim-${REF:-wasm}"
+REF="refs/tags/$(git describe --tags --abbrev=0 --match "${REF}/*")"
+fi
+
+CRATE="$(cut -d/ -f1 <<<"${REF#refs/*/}")"
+VERSION="$(cut -d/ -f2 <<<"${REF#refs/*/}")"
+RUNTIME="${CRATE#containerd-shim-}"
+TOMLVER="$(./scripts/version.sh "${CRATE}")"
+
+echo "CRATE=${CRATE}"
+echo "VERSION=${VERSION}"
+echo "RUNTIME=${RUNTIME}"
+
+if [ -z "${CRATE}" ]; then
+echo "::error::Could not determine crate name from ref '${REF}'" >&2
+exit 1
+fi
+
+if [ -z "${VERSION}" ]; then
+echo "::error::Could not determine version from ref '${REF}'" >&2
+exit 1
+fi
+
+if [ ! "${VERSION}" = "v${TOMLVER}" ]; then
+echo "::error::Version mismatch: tag version ${VERSION} != crate's Cargo.toml version v${TOMLVER}" >&2
+exit 1
+fi


### PR DESCRIPTION
This PR moves the parse-ref logic from the CI's yaml to a script.
It also adds some hergonomics and documentation to the script so that it is useful beyong CI.