### PR TITLE
feat: support any shim version in `shim_main`

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -36,11 +36,11 @@ macro_rules! revision {
     };
 }
 
-pub fn shim_main<I>(
+pub fn shim_main<'a, I>(
     name: &str,
     version: &str,
-    revision: Option<&str>,
-    shim_version: Option<&str>,
+    revision: impl Into<Option<&'a str>>,
+    shim_version: impl Into<Option<&'a str>>,
     config: Option<Config>,
 ) where
     I: 'static + Instance + Sync + Send,
@@ -55,12 +55,12 @@ pub fn shim_main<I>(
         println!("{argv0}:");
         println!("  Runtime: {name}");
         println!("  Version: {version}");
-        println!("  Revision: {}", revision.unwrap_or("<none>"));
+        println!("  Revision: {}", revision.into().unwrap_or("<none>"));
         println!();
 
         std::process::exit(0);
     }
-    let shim_version = shim_version.unwrap_or("v1");
+    let shim_version = shim_version.into().unwrap_or("v1");
 
     let lower_name = name.to_lowercase();
     let shim_cli = format!("containerd-shim-{lower_name}-{shim_version}");

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -36,8 +36,13 @@ macro_rules! revision {
     };
 }
 
-pub fn shim_main<I>(name: &str, version: &str, revision: Option<&str>, config: Option<Config>)
-where
+pub fn shim_main<I>(
+    name: &str,
+    version: &str,
+    revision: Option<&str>,
+    shim_version: Option<&str>,
+    config: Option<Config>,
+) where
     I: 'static + Instance + Sync + Send,
     I::Engine: Default,
 {
@@ -55,12 +60,13 @@ where
 
         std::process::exit(0);
     }
+    let shim_version = shim_version.unwrap_or("v1");
 
     let lower_name = name.to_lowercase();
-    let shim_cli = format!("containerd-shim-{lower_name}-v1");
-    let shim_client = format!("containerd-shim-{lower_name}d-v1");
+    let shim_cli = format!("containerd-shim-{lower_name}-{shim_version}");
+    let shim_client = format!("containerd-shim-{lower_name}d-{shim_version}");
     let shim_daemon = format!("containerd-{lower_name}d");
-    let shim_id = format!("io.containerd.{lower_name}.v1");
+    let shim_id = format!("io.containerd.{lower_name}.{shim_version}");
 
     match argv0.to_lowercase() {
         s if s == shim_cli => {

--- a/crates/containerd-shim-wasmedge/src/main.rs
+++ b/crates/containerd-shim-wasmedge/src/main.rs
@@ -2,5 +2,5 @@ use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
 use containerd_shim_wasmedge::WasmEdgeInstance;
 
 fn main() {
-    shim_main::<WasmEdgeInstance>("wasmedge", version!(), revision!(), None);
+    shim_main::<WasmEdgeInstance>("wasmedge", version!(), revision!(), Some("v1"), None);
 }

--- a/crates/containerd-shim-wasmedge/src/main.rs
+++ b/crates/containerd-shim-wasmedge/src/main.rs
@@ -2,5 +2,5 @@ use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
 use containerd_shim_wasmedge::WasmEdgeInstance;
 
 fn main() {
-    shim_main::<WasmEdgeInstance>("wasmedge", version!(), revision!(), Some("v1"), None);
+    shim_main::<WasmEdgeInstance>("wasmedge", version!(), revision!(), "v1", None);
 }

--- a/crates/containerd-shim-wasmer/src/main.rs
+++ b/crates/containerd-shim-wasmer/src/main.rs
@@ -2,5 +2,5 @@ use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
 use containerd_shim_wasmer::WasmerInstance;
 
 fn main() {
-    shim_main::<WasmerInstance>("wasmer", version!(), revision!(), Some("v1"), None);
+    shim_main::<WasmerInstance>("wasmer", version!(), revision!(), "v1", None);
 }

--- a/crates/containerd-shim-wasmer/src/main.rs
+++ b/crates/containerd-shim-wasmer/src/main.rs
@@ -2,5 +2,5 @@ use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
 use containerd_shim_wasmer::WasmerInstance;
 
 fn main() {
-    shim_main::<WasmerInstance>("wasmer", version!(), revision!(), None);
+    shim_main::<WasmerInstance>("wasmer", version!(), revision!(), Some("v1"), None);
 }

--- a/crates/containerd-shim-wasmtime/src/main.rs
+++ b/crates/containerd-shim-wasmtime/src/main.rs
@@ -2,5 +2,5 @@ use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
 use containerd_shim_wasmtime::WasmtimeInstance;
 
 fn main() {
-    shim_main::<WasmtimeInstance>("wasmtime", version!(), revision!(), None);
+    shim_main::<WasmtimeInstance>("wasmtime", version!(), revision!(), Some("v1"), None);
 }

--- a/crates/containerd-shim-wasmtime/src/main.rs
+++ b/crates/containerd-shim-wasmtime/src/main.rs
@@ -2,5 +2,5 @@ use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
 use containerd_shim_wasmtime::WasmtimeInstance;
 
 fn main() {
-    shim_main::<WasmtimeInstance>("wasmtime", version!(), revision!(), Some("v1"), None);
+    shim_main::<WasmtimeInstance>("wasmtime", version!(), revision!(), "v1", None);
 }


### PR DESCRIPTION
This PR adds a `shim_version` parameter to `shim_main` macro to relex the version for shim implementations. 