### PR TITLE
Consolidate the RuntimeContext API to use one EntryPoint and expose Source for WASI files

### DIFF
--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -10,14 +10,19 @@ pub trait RuntimeContext {
     // path to the entrypoint executable.
     fn args(&self) -> &[String];
 
-    // ctx.wasi_entrypoint() returns a `WasiEntrypoint` with the path to the module to use
-    // as an entrypoint and the name of the exported function to call, obtained from the
+    // ctx.entrypoint() returns a `Entrypoint` with the following fields obtained from the first argument in the OCI spec for entrypoint:
+    //   - `arg0` - raw entrypoint from the OCI spec
+    //   - `name` - provided as the file name of the module in the entrypoint without the extension
+    //   - `func` - name of the exported function to call, obtained from the
     // arguments on process OCI spec.
-    // The girst argument in the spec is specified as `path#func` where `func` is optional
+    //  - `Source` - either a `File(PathBuf)` or `Oci(WasmLayer)`. When a `File` source the `PathBuf`` is provided by entrypoint in OCI spec.
+    //     If the image contains custom OCI Wasm layers, the source is provided as an array of `WasmLayer` structs.
+    //
+    // The first argument in the OCI spec for entrypoint is specified as `path#func` where `func` is optional
     // and defaults to _start, e.g.:
-    //   "/app/app.wasm#entry" -> { path: "/app/app.wasm", func: "entry" }
-    //   "my_module.wat" -> { path: "my_module.wat", func: "_start" }
-    //   "#init" -> { path: "", func: "init" }
+    //   "/app/app.wasm#entry" -> { source: File("/app/app.wasm"), func: "entry", name: "Some(app)", arg0: "/app/app.wasm#entry" }
+    //   "my_module.wat" -> { source: File("my_module.wat"), func: "_start", name: "Some(my_module)", arg0: "my_module.wat" }
+    //   "#init" -> { source: File(""), func: "init", name: None, arg0: "#init" }
     fn entrypoint(&self) -> Entrypoint;
 
     // the platform for the container using the struct defined on the OCI spec definition

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -20,7 +20,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// * a parsable `wat` file.
     fn can_handle(&self, ctx: &impl RuntimeContext) -> Result<()> {
         let path = ctx
-            .wasi_entrypoint()
+            .entrypoint()
             .path
             .resolve_in_path_or_cwd()
             .next()
@@ -35,5 +35,9 @@ pub trait Engine: Clone + Send + Sync + 'static {
         }
 
         Ok(())
+    }
+
+    fn supported_layers_types() -> &'static [&'static str] {
+        &["application/vnd.bytecodealliance.wasm.component.layer.v0+wasm"]
     }
 }

--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -15,7 +15,7 @@ mod engine;
 mod path;
 
 pub(crate) use context::WasiContext;
-pub use context::{RuntimeContext, WasiEntrypoint};
+pub use context::{RuntimeContext, WasiEntrypoint, WasiLoadingStrategy};
 pub use engine::Engine;
 pub use instance::Instance;
 pub use path::PathResolve;

--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -15,7 +15,7 @@ mod engine;
 mod path;
 
 pub(crate) use context::WasiContext;
-pub use context::{RuntimeContext, WasiEntrypoint, WasiLoadingStrategy};
+pub use context::{Entrypoint, RuntimeContext, Source};
 pub use engine::Engine;
 pub use instance::Instance;
 pub use path::PathResolve;

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -105,6 +105,7 @@ impl<E: Engine> Executor<E> {
 fn is_linux_container(ctx: &impl RuntimeContext) -> Result<()> {
     let executable = ctx
         .entrypoint()
+        .arg0
         .context("no entrypoint provided")?
         .resolve_in_path()
         .find_map(|p| -> Option<PathBuf> {

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -13,7 +13,7 @@ use libcontainer::workload::{
 use oci_spec::image::Platform;
 use oci_spec::runtime::Spec;
 
-use crate::container::{Engine, PathResolve, RuntimeContext, Stdio, WasiContext};
+use crate::container::{Engine, PathResolve, RuntimeContext, Source, Stdio, WasiContext};
 use crate::sandbox::oci::WasmLayer;
 
 #[derive(Clone)]
@@ -88,10 +88,7 @@ impl<E: Engine> Executor<E> {
 
     fn inner(&self, spec: &Spec) -> &InnerExecutor {
         self.inner.get_or_init(|| {
-            // if the spec has oci annotations we know it is wasm so short circuit checks
-            if !self.wasm_layers.is_empty() {
-                InnerExecutor::Wasm
-            } else if is_linux_container(&self.ctx(spec)).is_ok() {
+            if is_linux_container(&self.ctx(spec)).is_ok() {
                 InnerExecutor::Linux
             } else if self.engine.can_handle(&self.ctx(spec)).is_ok() {
                 InnerExecutor::Wasm
@@ -103,6 +100,10 @@ impl<E: Engine> Executor<E> {
 }
 
 fn is_linux_container(ctx: &impl RuntimeContext) -> Result<()> {
+    if let Source::Oci(_) = ctx.entrypoint().source {
+        bail!("the entry point contains wasm layers")
+    };
+
     let executable = ctx
         .entrypoint()
         .arg0

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -45,7 +45,7 @@ impl<E: Engine> SandboxInstance for Instance<E> {
 
         // check if container is OCI image with wasm layers and attempt to read the module
         let (modules, platform) = containerd::Client::connect(cfg.get_containerd_address(), &namespace)?
-            .load_modules(&id)
+            .load_modules(&id, E::supported_layers_types())
             .unwrap_or_else(|e| {
                 log::warn!("Error obtaining wasm layers for container {id}.  Will attempt to use files inside container image. Error: {e}");
                 (vec![], Platform::default())

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use containerd_shim_wasm::container::{
-    Engine, Instance, PathResolve, RuntimeContext, Stdio, WasiEntrypoint, WasiLoadingStrategy,
+    Engine, Entrypoint, Instance, PathResolve, RuntimeContext, Source, Stdio,
 };
 use log::debug;
 use wasmedge_sdk::config::{ConfigBuilder, HostRegistrationConfigOptions};
@@ -35,10 +35,11 @@ impl Engine for WasmEdgeEngine {
     fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32> {
         let args = ctx.args();
         let envs: Vec<_> = std::env::vars().map(|(k, v)| format!("{k}={v}")).collect();
-        let WasiEntrypoint {
-            path: entrypoint_path,
+        let Entrypoint {
+            source,
             func,
             arg0: _,
+            name,
         } = ctx.entrypoint();
 
         let mut vm = self.vm.clone();
@@ -50,16 +51,13 @@ impl Engine for WasmEdgeEngine {
                 Some(vec!["/:/"]),
             );
 
-        let mod_name = match entrypoint_path.file_stem() {
-            Some(name) => name.to_string_lossy().to_string(),
-            None => "main".to_string(),
-        };
+        let mod_name = name.unwrap_or_else(|| "main".to_string());
 
         PluginManager::load(None)?;
         let vm = vm.auto_detect_plugins()?;
 
-        let vm = match ctx.wasi_loading_strategy() {
-            WasiLoadingStrategy::File(path) => {
+        let vm = match source {
+            Source::File(path) => {
                 debug!("loading module from file {path:?}");
                 let path = path
                     .resolve_in_path_or_cwd()
@@ -69,12 +67,12 @@ impl Engine for WasmEdgeEngine {
                 vm.register_module_from_file(&mod_name, path)
                     .context("registering module")?
             }
-            WasiLoadingStrategy::Oci([module]) => {
+            Source::Oci([module]) => {
                 log::info!("loading module from wasm OCI layers");
                 vm.register_module_from_bytes(&mod_name, &module.layer)
                     .context("registering module")?
             }
-            WasiLoadingStrategy::Oci(_modules) => {
+            Source::Oci(_modules) => {
                 bail!("only a single module is supported when using images with OCI layers")
             }
         };

--- a/crates/containerd-shim-wasmer/src/instance.rs
+++ b/crates/containerd-shim-wasmer/src/instance.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use containerd_shim_wasm::container::{
-    Engine, Instance, PathResolve, RuntimeContext, Stdio, WasiEntrypoint, WasiLoadingStrategy,
+    Engine, Entrypoint, Instance, PathResolve, RuntimeContext, Source, Stdio,
 };
 use wasmer::{Module, Store};
 use wasmer_wasix::virtual_fs::host_fs::FileSystem;
@@ -21,22 +21,20 @@ impl Engine for WasmerEngine {
     fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32> {
         let args = ctx.args();
         let envs = std::env::vars();
-        let WasiEntrypoint {
-            path,
+        let Entrypoint {
+            source,
             func,
             arg0: _,
+            name,
         } = ctx.entrypoint();
 
-        let mod_name = match path.file_stem() {
-            Some(name) => name.to_string_lossy().to_string(),
-            None => "main".to_string(),
-        };
+        let mod_name = name.unwrap_or_else(|| "main".to_string());
 
         log::info!("Create a Store");
         let mut store = Store::new(self.engine.clone());
 
-        let module = match ctx.wasi_loading_strategy() {
-            WasiLoadingStrategy::File(path) => {
+        let module = match source {
+            Source::File(path) => {
                 log::info!("loading module from file {path:?}");
                 let path = path
                     .resolve_in_path_or_cwd()
@@ -45,12 +43,12 @@ impl Engine for WasmerEngine {
 
                 Module::from_file(&store, path)?
             }
-            WasiLoadingStrategy::Oci([module]) => {
+            Source::Oci([module]) => {
                 log::info!("loading module wasm OCI layers");
                 log::info!("loading module wasm OCI layers");
                 Module::from_binary(&store, &module.layer)?
             }
-            WasiLoadingStrategy::Oci(_modules) => {
+            Source::Oci(_modules) => {
                 bail!("only a single module is supported when using images with OCI layers")
             }
         };

--- a/crates/containerd-shim-wasmer/src/instance.rs
+++ b/crates/containerd-shim-wasmer/src/instance.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use containerd_shim_wasm::container::{
-    Engine, Instance, PathResolve, RuntimeContext, Stdio, WasiEntrypoint,
+    Engine, Instance, PathResolve, RuntimeContext, Stdio, WasiEntrypoint, WasiLoadingStrategy,
 };
 use wasmer::{Module, Store};
 use wasmer_wasix::virtual_fs::host_fs::FileSystem;
@@ -21,7 +21,11 @@ impl Engine for WasmerEngine {
     fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32> {
         let args = ctx.args();
         let envs = std::env::vars();
-        let WasiEntrypoint { path, func } = ctx.wasi_entrypoint();
+        let WasiEntrypoint {
+            path,
+            func,
+            arg0: _,
+        } = ctx.entrypoint();
 
         let mod_name = match path.file_stem() {
             Some(name) => name.to_string_lossy().to_string(),
@@ -31,8 +35,8 @@ impl Engine for WasmerEngine {
         log::info!("Create a Store");
         let mut store = Store::new(self.engine.clone());
 
-        let module = match ctx.wasm_layers() {
-            [] => {
+        let module = match ctx.wasi_loading_strategy() {
+            WasiLoadingStrategy::File(path) => {
                 log::info!("loading module from file {path:?}");
                 let path = path
                     .resolve_in_path_or_cwd()
@@ -41,11 +45,14 @@ impl Engine for WasmerEngine {
 
                 Module::from_file(&store, path)?
             }
-            [module] => {
+            WasiLoadingStrategy::Oci([module]) => {
+                log::info!("loading module wasm OCI layers");
                 log::info!("loading module wasm OCI layers");
                 Module::from_binary(&store, &module.layer)?
             }
-            [..] => bail!("only a single module is supported when using images with OCI layers"),
+            WasiLoadingStrategy::Oci(_modules) => {
+                bail!("only a single module is supported when using images with OCI layers")
+            }
         };
 
         let runtime = tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
This PR makes a few changes to the the `RuntimeContext` API regarding OCI:

 - use an enum which makes the API clearer when using.  
 - changes the way the wasm layers are filtered based on https://github.com/containerd/runwasi/pull/147#discussion_r1371838109 
 - uses a single entrypoint function instead of 2.  I was initially confused when looking at `entrypoint` vs `wasiEntrypoint` and thought this might simplify it. Feedback welcome.
