### PR TITLE
Fix missing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To begin contributing, learn to build and test the project or to add a new shim 
 
 ### Installing the shims for use with Containerd
 
-Make sure you have [installed dependencies](#Building) and install the shims:
+Make sure you have [installed dependencies](./CONTRIBUTING.md#setting-up-your-local-environment) and install the shims:
 
 ```terminal
 make build


### PR DESCRIPTION
I've fixed the missing link in README.md .
The section #Building is not exist now.
