### PR TITLE
Add libzstd-dev as dependencies

### DIFF
--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt -y update
-sudo apt install -y pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev protobuf-compiler
+sudo apt install -y pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev libzstd-dev protobuf-compiler
 
 if [ ! -z "$CI" ] && ! mount | grep cgroup; then
     echo "cgroup is not mounted" 1>&2


### PR DESCRIPTION
When I've run `make build`.
I've got following error without `libzstd-dev`.

```
   Compiling wasmedge-sdk v0.13.2
   Compiling containerd-shim-wasmedge v0.3.1 (/Users/tsakao/runwasi/crates/containerd-shim-wasmedge)
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" ...omit...
  = note: /usr/bin/ld: cannot find -lzstd
          collect2: error: ld returned 1 exit status
          

error: could not compile `containerd-shim-wasmedge` (bin "containerd-shim-wasmedge-v1") due to previous error
make: *** [Makefile:76: build-wasmedge] Error 101
```

Signed-off-by: Takumasa Sakao <tsakao@zlab.co.jp>
