### PR TITLE
Fix image name of test-image/oci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,13 @@ test/k8s-%: test/k8s/clean test/k8s/cluster-%
 	sleep 5s
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
 
+.PHONY: test/k8s-oci-%
+test/k8s-oci-%: test/k8s/clean test/k8s/cluster-oci-%
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) apply -f test/k8s/deploy.oci.yaml
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=90s
+	# verify that we are still running after some time
+	sleep 5s
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
 
 .PHONY: test/k8s/clean
 test/k8s/clean: bin/kind

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ load/oci: dist/img-oci.tar
 .PHONY:
 target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
 	mkdir -p ${CURDIR}/bin/$(OPT_PROFILE)/
-	cargo run --bin oci-tar-builder -- --name wasi-demo-app --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm -o target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar
+	cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm -o target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar
 
 bin/kind: test/k8s/Dockerfile
 	$(DOCKER_BUILD) --output=bin/ -f test/k8s/Dockerfile --target=kind .

--- a/test/k8s/deploy.oci.yaml
+++ b/test/k8s/deploy.oci.yaml
@@ -1,0 +1,31 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: wasm
+handler: wasm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasi-demo
+  labels:
+    app: wasi-demo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: wasi-demo
+  template:
+    metadata:
+      labels:
+        app: wasi-demo
+    spec:
+      runtimeClassName: wasm
+      containers:
+        - name: demo
+          image: ghcr.io/containerd/runwasi/wasi-demo-oci:latest
+          imagePullPolicy: Never
+        - name: nginx
+          image: docker.io/nginx:latest
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
The image name expected in https://github.com/containerd/runwasi/blob/ec3d24d9abf0ff007ab56d07fbe040b1753d6b20/README.md#L289 is `ghcr.io/containerd/runwasi/wasi-demo-oci`.
But the image name created by `make test-image/oci` is `wasi-demo-app`.
So I've fixed the image name to `wasi-demo-oci`.

Signed-off-by: Takumasa Sakao <tsakao@zlab.co.jp>
