### PR TITLE
test(*): verify pods get deleted successfully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,10 @@ test/k8s-%: test/k8s/clean test/k8s/cluster-%
 	sleep 5s
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
 
+	# verify that we are able to delete the deployment
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) delete -f test/k8s/deploy.yaml
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for delete --timeout=60s
+
 .PHONY: test/k8s-oci-%
 test/k8s-oci-%: test/k8s/clean test/k8s/cluster-oci-%
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) apply -f test/k8s/deploy.oci.yaml
@@ -241,6 +245,10 @@ test/k8s-oci-%: test/k8s/clean test/k8s/cluster-oci-%
 	# verify that we are still running after some time
 	sleep 5s
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
+
+	# verify that we are able to delete the deployment
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) delete -f test/k8s/deploy.oci.yaml
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for delete --timeout=60s
 
 .PHONY: test/k8s/clean
 test/k8s/clean: bin/kind

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ test/k8s/deploy-workload-%: test/k8s/clean test/k8s/cluster-%
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
 
 .PHONY: test/k8s/deploy-workload-oci-%
-test/k8s/deploy-workload-%: test/k8s/clean test/k8s/cluster-oci-%
+test/k8s/deploy-workload-oci-%: test/k8s/clean test/k8s/cluster-oci-%
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) apply -f test/k8s/deploy.oci.yaml
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=90s
 	# verify that we are still running after some time


### PR DESCRIPTION
This PR adds a few commands to the Makefile, and thus the CI/CD pipelines, to verify the workflow could be deleted successfully, not stucking in a terminating status forever. 

Related to issue #418 