### PR TITLE
refactor(*): refactor wasm bytes preparation logic to the core crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// The name to use for this engine
     fn name() -> &'static str;
     /// Run a WebAssembly container
-    fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32>;
+    fn run_wasi(&self, ctx: &impl RuntimeContext, wasm_bytes: &[u8], stdio: Stdio) -> Result<i32>;
     /// Check that the runtime can run the container.
     /// This checks runs after the container creation and before the container starts.
     /// By it checks that the wasi_entrypoint is either:

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -12,7 +12,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     fn name() -> &'static str;
 
     /// Run a WebAssembly container
-    fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32>;
+    fn run_wasi(&self, ctx: &impl RuntimeContext, wasm_bytes: &[u8], stdio: Stdio) -> Result<i32>;
 
     /// Check that the runtime can run the container.
     /// This checks runs after the container creation and before the container starts.

--- a/crates/containerd-shim-wasm/src/container/tests.rs
+++ b/crates/containerd-shim-wasm/src/container/tests.rs
@@ -14,7 +14,12 @@ impl Engine for EngineFailingValidation {
     fn can_handle(&self, _ctx: &impl RuntimeContext) -> anyhow::Result<()> {
         bail!("can't handle");
     }
-    fn run_wasi(&self, _ctx: &impl RuntimeContext, _stdio: Stdio) -> anyhow::Result<i32> {
+    fn run_wasi(
+        &self,
+        _ctx: &impl RuntimeContext,
+        _wasm_bytes: &[u8],
+        _stdio: Stdio,
+    ) -> anyhow::Result<i32> {
         Ok(0)
     }
 }

--- a/crates/containerd-shim-wasmer/src/instance.rs
+++ b/crates/containerd-shim-wasmer/src/instance.rs
@@ -1,7 +1,5 @@
-use anyhow::{bail, Context, Result};
-use containerd_shim_wasm::container::{
-    Engine, Entrypoint, Instance, PathResolve, RuntimeContext, Source, Stdio,
-};
+use anyhow::Result;
+use containerd_shim_wasm::container::{Engine, Entrypoint, Instance, RuntimeContext, Stdio};
 use wasmer::{Module, Store};
 use wasmer_wasix::virtual_fs::host_fs::FileSystem;
 use wasmer_wasix::{WasiEnv, WasiError};
@@ -18,11 +16,11 @@ impl Engine for WasmerEngine {
         "wasmer"
     }
 
-    fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32> {
+    fn run_wasi(&self, ctx: &impl RuntimeContext, wasm_bytes: &[u8], stdio: Stdio) -> Result<i32> {
         let args = ctx.args();
         let envs = std::env::vars();
         let Entrypoint {
-            source,
+            source: _,
             func,
             arg0: _,
             name,
@@ -33,25 +31,7 @@ impl Engine for WasmerEngine {
         log::info!("Create a Store");
         let mut store = Store::new(self.engine.clone());
 
-        let module = match source {
-            Source::File(path) => {
-                log::info!("loading module from file {path:?}");
-                let path = path
-                    .resolve_in_path_or_cwd()
-                    .next()
-                    .context("module not found")?;
-
-                Module::from_file(&store, path)?
-            }
-            Source::Oci([module]) => {
-                log::info!("loading module wasm OCI layers");
-                log::info!("loading module wasm OCI layers");
-                Module::from_binary(&store, &module.layer)?
-            }
-            Source::Oci(_modules) => {
-                bail!("only a single module is supported when using images with OCI layers")
-            }
-        };
+        let module = Module::from_binary(&store, wasm_bytes)?;
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 
 use anyhow::{bail, Context, Result};
 use containerd_shim_wasm::container::{
-    Engine, Entrypoint, Instance, PathResolve, RuntimeContext, Source, Stdio, WasmBinaryType,
+    Engine, Entrypoint, Instance, RuntimeContext, Stdio, WasmBinaryType,
 };
 use wasi_common::I32Exit;
 use wasmtime::component::{self as wasmtime_component, Component};
@@ -60,11 +60,11 @@ impl Engine for WasmtimeEngine {
         "wasmtime"
     }
 
-    fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32> {
+    fn run_wasi(&self, ctx: &impl RuntimeContext, wasm_bytes: &[u8], stdio: Stdio) -> Result<i32> {
         log::info!("setting up wasi");
         let envs: Vec<_> = std::env::vars().collect();
         let Entrypoint {
-            source,
+            source: _,
             func,
             arg0: _,
             name: _,
@@ -76,40 +76,11 @@ impl Engine for WasmtimeEngine {
         let wasi_ctx = prepare_wasi_ctx(ctx, envs)?;
         let store = Store::new(&self.engine, wasi_ctx);
 
-        let status = match source {
-            Source::File(path) => {
-                log::info!("loading module from path {path:?}");
-                let path = path
-                    .resolve_in_path_or_cwd()
-                    .next()
-                    .context("module not found")?;
-
-                let wasm_binary = std::fs::read(path)?;
-                match WasmBinaryType::from_bytes(&wasm_binary) {
-                    Some(WasmBinaryType::Module) => {
-                        self.execute_module(&wasm_binary, store, &func)?
-                    }
-                    Some(WasmBinaryType::Component) => {
-                        self.execute_component(&wasm_binary, store, func)?
-                    }
-                    None => bail!("not a valid wasm binary format"),
-                }
-            }
-            Source::Oci([module]) => {
-                log::info!("loading module wasm OCI layers");
-                match WasmBinaryType::from_bytes(&module.layer) {
-                    Some(WasmBinaryType::Module) => {
-                        self.execute_module(&module.layer, store, &func)?
-                    }
-                    Some(WasmBinaryType::Component) => {
-                        self.execute_component(&module.layer, store, func)?
-                    }
-                    None => bail!("not a valid wasm binary format"),
-                }
-            }
-            Source::Oci(_modules) => {
-                bail!("only a single module is supported when using images with OCI layers")
-            }
+        log::info!("wasi context ready");
+        let status = match WasmBinaryType::from_bytes(wasm_bytes) {
+            Some(WasmBinaryType::Module) => self.execute_module(wasm_bytes, store, &func)?,
+            Some(WasmBinaryType::Component) => self.execute_component(wasm_bytes, store, func)?,
+            None => bail!("not a valid wasm binary format"),
         };
 
         let status = status.map(|_| 0).or_else(|err| {


### PR DESCRIPTION
This PR refactors the common `Source` logic from runtime shim to the core crate. To do so, the core `Engine` trait API has a breaking change:

1. `run_wasi()` now takes a `wasm_bytes: &[u8]` parameter as the wasm module / component loaded from the file system or OCI layers to execute. 


cc @jsturtevant 