### PR TITLE
refactor(*): add source.as_bytes()

### DIFF
--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -1,8 +1,5 @@
-use anyhow::{bail, Context, Result};
-use containerd_shim_wasm::container::{
-    Engine, Entrypoint, Instance, PathResolve, RuntimeContext, Source, Stdio,
-};
-use log::debug;
+use anyhow::{Context, Result};
+use containerd_shim_wasm::container::{Engine, Entrypoint, Instance, RuntimeContext, Stdio};
 use wasmedge_sdk::config::{ConfigBuilder, HostRegistrationConfigOptions};
 use wasmedge_sdk::plugin::PluginManager;
 use wasmedge_sdk::VmBuilder;
@@ -56,26 +53,10 @@ impl Engine for WasmEdgeEngine {
         PluginManager::load(None)?;
         let vm = vm.auto_detect_plugins()?;
 
-        let vm = match source {
-            Source::File(path) => {
-                debug!("loading module from file {path:?}");
-                let path = path
-                    .resolve_in_path_or_cwd()
-                    .next()
-                    .context("module not found")?;
-
-                vm.register_module_from_file(&mod_name, path)
-                    .context("registering module")?
-            }
-            Source::Oci([module]) => {
-                log::info!("loading module from wasm OCI layers");
-                vm.register_module_from_bytes(&mod_name, &module.layer)
-                    .context("registering module")?
-            }
-            Source::Oci(_modules) => {
-                bail!("only a single module is supported when using images with OCI layers")
-            }
-        };
+        let wasm_bytes = source.as_bytes()?;
+        let vm = vm
+            .register_module_from_bytes(&mod_name, wasm_bytes)
+            .context("registering module")?;
 
         stdio.redirect()?;
 

--- a/crates/containerd-shim-wasmer/src/instance.rs
+++ b/crates/containerd-shim-wasmer/src/instance.rs
@@ -1,7 +1,5 @@
-use anyhow::{bail, Context, Result};
-use containerd_shim_wasm::container::{
-    Engine, Entrypoint, Instance, PathResolve, RuntimeContext, Source, Stdio,
-};
+use anyhow::Result;
+use containerd_shim_wasm::container::{Engine, Entrypoint, Instance, RuntimeContext, Stdio};
 use wasmer::{Module, Store};
 use wasmer_wasix::virtual_fs::host_fs::FileSystem;
 use wasmer_wasix::{WasiEnv, WasiError};
@@ -33,25 +31,8 @@ impl Engine for WasmerEngine {
         log::info!("Create a Store");
         let mut store = Store::new(self.engine.clone());
 
-        let module = match source {
-            Source::File(path) => {
-                log::info!("loading module from file {path:?}");
-                let path = path
-                    .resolve_in_path_or_cwd()
-                    .next()
-                    .context("module not found")?;
-
-                Module::from_file(&store, path)?
-            }
-            Source::Oci([module]) => {
-                log::info!("loading module wasm OCI layers");
-                log::info!("loading module wasm OCI layers");
-                Module::from_binary(&store, &module.layer)?
-            }
-            Source::Oci(_modules) => {
-                bail!("only a single module is supported when using images with OCI layers")
-            }
-        };
+        let wasm_bytes = source.as_bytes()?;
+        let module = Module::from_binary(&store, &wasm_bytes)?;
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()


### PR DESCRIPTION
This PR is a preferred way to refactor the usage of `Source` into a `as_bytes()` function in Context. It does not change the APIs of the Engine trait. Closes #448 