### PR TITLE
Pre-compile each layer individually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "oci-tar-builder",
  "prost-types 0.11.9",
  "protobuf 3.2.0",
+ "rand",
  "serde",
  "serde_json",
  "sha256",
@@ -1624,7 +1625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "stable_deref_trait",
 ]
 
@@ -1934,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
@@ -2466,7 +2467,7 @@ checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.1",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "memchr",
 ]
 
@@ -2489,6 +2490,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
+ "indexmap 2.2.5",
  "log",
  "oci-spec",
  "serde",
@@ -2631,7 +2633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -3551,7 +3553,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -4076,7 +4078,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4089,7 +4091,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4884,7 +4886,7 @@ checksum = "d21472954ee9443235ca32522b17fc8f0fe58e2174556266a0d9766db055cc52"
 dependencies = [
  "anyhow",
  "derive_builder",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "semver",
  "serde",
  "serde_cbor",
@@ -5034,7 +5036,7 @@ version = "0.118.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ee9723b928e735d53000dec9eae7b07a60e490c85ab54abb66659fc61bfcd9"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "semver",
 ]
 
@@ -5045,7 +5047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a03f65ac876612140c57ff6c3b8fe4990067cce97c2cfdb07368a3cc3354b062"
 dependencies = [
  "bitflags 2.4.2",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "semver",
 ]
 
@@ -5072,7 +5074,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "encoding_rs",
  "fxprof-processed-profile",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "libc",
  "log",
  "object",
@@ -5198,7 +5200,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity 0.104.1",
  "gimli 0.28.0",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "log",
  "object",
  "serde",
@@ -5287,7 +5289,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "encoding_rs",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "libc",
  "log",
  "mach",
@@ -5391,7 +5393,7 @@ checksum = "6bb3bc92c031cf4961135bffe055a69c1bd67c253dca20631478189bb05ec27b"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "wit-parser",
 ]
 
@@ -5808,7 +5810,7 @@ checksum = "15df6b7b28ce94b8be39d8df5cb21a08a4f3b9f33b631aedb4aa5776f785ead3"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.0.2",
+ "indexmap 2.2.5",
  "log",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "log",
  "oci-spec",
  "serial_test",
+ "sha256",
  "ttrpc",
  "wasi-common",
  "wasmtime",

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,8 @@ test/k8s/deploy-workload-oci-%: test/k8s/clean test/k8s/cluster-% dist/img-oci.t
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
 	@if [ "$*" = "wasmtime" ]; then \
 		set -e; \
-		echo "checking for pre-compiled label and ensuring can scale"; \
-		docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io i ls | grep "runwasi.io/precompiled"; \
+		echo "checking for pre-compiled labels and ensuring can scale after pre-compile"; \
+		docker exec $(KIND_CLUSTER_NAME)-control-plane ctr -n k8s.io content ls | grep "runwasi.io/precompiled"; \
 		kubectl --context=kind-$(KIND_CLUSTER_NAME) scale deployment wasi-demo --replicas=4; \
 		kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s; \
 	fi
@@ -297,8 +297,8 @@ test/k3s-oci-%: dist/img-oci.tar bin/k3s dist-%
 	sudo bin/k3s kubectl get pods -o wide
 	@if [ "$*" = "wasmtime" ]; then \
 		set -e; \
-		echo "checking for pre-compiled label and ensuring can scale"; \
-		sudo bin/k3s ctr -n k8s.io i ls | grep "runwasi.io/precompiled"; \
+		echo "checking for pre-compiled labels and ensuring can scale"; \
+		sudo bin/k3s ctr -n k8s.io content ls | grep "runwasi.io/precompiled"; \
 		sudo bin/k3s kubectl scale deployment wasi-demo --replicas=4; \
 		sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=5s; \
 	fi

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -35,7 +35,7 @@ futures = { version = "0.3.30" }
 wasmparser = "0.200.0"
 tokio-stream = { version = "0.1" }
 prost-types = "0.11" # should match version in containerd-shim
-sha256 = "1.4.0"
+sha256 = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 caps = "0.5"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -56,6 +56,7 @@ containerd-shim-wasm-test-modules = { workspace = true }
 env_logger = { workspace = true }
 tempfile = { workspace = true }
 oci-tar-builder = { workspace = true}
+rand= "0.8" 
 
 [features]
 testing = ["dep:containerd-shim-wasm-test-modules", "dep:env_logger", "dep:tempfile", "dep:oci-tar-builder"]

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Context, Result};
 
 use super::Source;
 use crate::container::{PathResolve, RuntimeContext};
+use crate::sandbox::oci::WasmLayer;
 use crate::sandbox::Stdio;
 
 pub trait Engine: Clone + Send + Sync + 'static {
@@ -57,8 +58,8 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// This is used to precompile a module before it is run and will be called if can_precompile returns true.
     /// It is called only the first time a module is run and the resulting bytes will be cached in the containerd content store.  
     /// The cached, precompiled module will be reloaded on subsequent runs.
-    fn precompile(&self, _layers: &[Vec<u8>]) -> Result<Vec<u8>> {
-        bail!("precompilation not supported for this runtime")
+    fn precompile(&self, _layer: &WasmLayer) -> Option<Result<Vec<u8>>> {
+        None
     }
 
     /// Can_precompile lets the shim know if the runtime supports precompilation.

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -58,7 +58,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// This is used to precompile a module before it is run and will be called if can_precompile returns true.
     /// It is called only the first time a module is run and the resulting bytes will be cached in the containerd content store.  
     /// The cached, precompiled module will be reloaded on subsequent runs.
-    fn precompile(&self, _layer: &WasmLayer) -> Option<Result<Vec<u8>>> {
+    fn precompile(&self, _layers: &[WasmLayer]) -> Option<Result<Vec<WasmLayer>>> {
         None
     }
 

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Read;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 
 use super::Source;
 use crate::container::{PathResolve, RuntimeContext};
@@ -58,10 +58,10 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// This is used to precompile the layers before they are run and will be called if can_precompile returns true.
     /// It is called only the first time a module is run and the resulting bytes will be cached in the containerd content store.  
     /// The cached, precompiled layers will be reloaded on subsequent runs.
-    /// The runtime is expected to runtime the same number of layers passed in.
-    /// In some cases it is possible in some edge cases that the layers may already be precompiled and the runtime can return the layers as is.  
-    fn precompile(&self, _layers: &[WasmLayer]) -> Option<Result<Vec<WasmLayer>>> {
-        None
+    /// The runtime is expected to runtime the same number of layers passed in, if the layer cannot be precompiled it should return None for that layer.
+    /// In some cases it is possible in some edge cases that the layers may already be precompiled and None should be returned in this case.
+    fn precompile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<WasmLayer>>> {
+        bail!("precompile not supported");
     }
 
     /// Can_precompile lets the shim know if the runtime supports precompilation.

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -60,7 +60,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// The cached, precompiled layers will be reloaded on subsequent runs.
     /// The runtime is expected to runtime the same number of layers passed in, if the layer cannot be precompiled it should return None for that layer.
     /// In some edge cases it is possible that the layers may already be precompiled and None should be returned in this case.
-    fn precompile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<WasmLayer>>> {
+    fn precompile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<Vec<u8>>>> {
         bail!("precompile not supported");
     }
 

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Read;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 
 use super::Source;
 use crate::container::{PathResolve, RuntimeContext};

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -54,10 +54,12 @@ pub trait Engine: Clone + Send + Sync + 'static {
         &["application/vnd.bytecodealliance.wasm.component.layer.v0+wasm"]
     }
 
-    /// Precompiles a module that is in the WASM OCI layer format
-    /// This is used to precompile a module before it is run and will be called if can_precompile returns true.
+    /// Precompiles a passes supported OCI layers to engine for compilation
+    /// This is used to precompile the layers before they are run and will be called if can_precompile returns true.
     /// It is called only the first time a module is run and the resulting bytes will be cached in the containerd content store.  
-    /// The cached, precompiled module will be reloaded on subsequent runs.
+    /// The cached, precompiled layers will be reloaded on subsequent runs.
+    /// The runtime is expected to runtime the same number of layers passed in.
+    /// In some cases it is possible in some edge cases that the layers may already be precompiled and the runtime can return the layers as is.  
     fn precompile(&self, _layers: &[WasmLayer]) -> Option<Result<Vec<WasmLayer>>> {
         None
     }

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -59,7 +59,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// It is called only the first time a module is run and the resulting bytes will be cached in the containerd content store.  
     /// The cached, precompiled layers will be reloaded on subsequent runs.
     /// The runtime is expected to runtime the same number of layers passed in, if the layer cannot be precompiled it should return None for that layer.
-    /// In some cases it is possible in some edge cases that the layers may already be precompiled and None should be returned in this case.
+    /// In some edge cases it is possible that the layers may already be precompiled and None should be returned in this case.
     fn precompile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<WasmLayer>>> {
         bail!("precompile not supported");
     }

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -54,11 +54,11 @@ pub trait Engine: Clone + Send + Sync + 'static {
         &["application/vnd.bytecodealliance.wasm.component.layer.v0+wasm"]
     }
 
-    /// Precompiles a passes supported OCI layers to engine for compilation
-    /// This is used to precompile the layers before they are run and will be called if can_precompile returns true.
+    /// Precompile passes supported OCI layers to engine for compilation
+    /// This is used to precompile the layers before they are run and will be called if `can_precompile` returns `true`.
     /// It is called only the first time a module is run and the resulting bytes will be cached in the containerd content store.  
     /// The cached, precompiled layers will be reloaded on subsequent runs.
-    /// The runtime is expected to runtime the same number of layers passed in, if the layer cannot be precompiled it should return None for that layer.
+    /// The runtime is expected to return the same number of layers passed in, if the layer cannot be precompiled it should return `None` for that layer.
     /// In some edge cases it is possible that the layers may already be precompiled and None should be returned in this case.
     fn precompile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<Vec<u8>>>> {
         bail!("precompile not supported");

--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -19,3 +19,4 @@ pub use stdio::Stdio;
 
 pub(crate) mod containerd;
 pub(crate) mod oci;
+pub use oci::WasmLayer;

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -10,6 +10,7 @@ containerd-shim-wasm = { workspace = true }
 log = { workspace = true }
 oci-spec = { workspace = true, features = ["runtime"] }
 ttrpc = { workspace = true }
+sha256 = { workspace = true }
 
 # We are not including the `async` feature here:
 # 1. Because we don't even use it

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 use containerd_shim_wasm::container::{
     Engine, Entrypoint, Instance, RuntimeContext, Stdio, WasmBinaryType,
 };
+use containerd_shim_wasm::sandbox::WasmLayer;
 use wasi_common::I32Exit;
 use wasmtime::component::{self as wasmtime_component, Component, ResourceTable};
 use wasmtime::{Config, Module, Precompiled, Store};
@@ -112,11 +113,8 @@ impl<T: WasiConfig> Engine for WasmtimeEngine<T> {
         Ok(status)
     }
 
-    fn precompile(&self, layers: &[Vec<u8>]) -> Result<Vec<u8>> {
-        match layers {
-            [layer] => self.engine.precompile_module(layer),
-            _ => bail!("only a single module is supported when precompiling"),
-        }
+    fn precompile(&self, layer: &WasmLayer) -> Option<Result<Vec<u8>>> {
+         Some(self.engine.precompile_module(&layer.layer))
     }
 
     fn can_precompile(&self) -> Option<String> {

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -114,7 +114,7 @@ impl<T: WasiConfig> Engine for WasmtimeEngine<T> {
     }
 
     fn precompile(&self, layer: &WasmLayer) -> Option<Result<Vec<u8>>> {
-         Some(self.engine.precompile_module(&layer.layer))
+        Some(self.engine.precompile_module(&layer.layer))
     }
 
     fn can_precompile(&self) -> Option<String> {

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -118,6 +118,12 @@ impl<T: WasiConfig> Engine for WasmtimeEngine<T> {
         let mut v = Vec::<WasmLayer>::with_capacity(layers.len());
 
         for layer in layers {
+            if self.engine.detect_precompiled(&layer.layer).is_some() {
+                log::info!("Already precompiled");
+                v.push(layer.clone());
+                continue;
+            }
+
             let compiled_layer = match self.engine.precompile_module(&layer.layer) {
                 Ok(compiled_layer) => compiled_layer,
                 Err(err) => return Some(Err(err)),

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -84,6 +84,8 @@ fn test_hello_world_oci_uses_precompiled() -> anyhow::Result<()> {
         id
     );
 
+    std::thread::sleep(std::time::Duration::from_secs(30));
+
     // run second time, it should succeed without recompiling
     let (builder, _oci_cleanup2) = WasiTest::<WasiInstance>::builder()?
         .with_wasm(HELLO_WORLD)?

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -69,7 +69,10 @@ fn test_hello_world_oci() -> anyhow::Result<()> {
 fn test_hello_world_oci_uses_precompiled() -> anyhow::Result<()> {
     let (builder, _oci_cleanup1) = WasiTest::<WasiInstance>::builder()?
         .with_wasm(HELLO_WORLD)?
-        .as_oci_image(None, Some("c1".to_string()))?;
+        .as_oci_image(
+            Some("localhost/hello:latest".to_string()),
+            Some("c1".to_string()),
+        )?;
 
     let (exit_code, stdout, _) = builder.build()?.start()?.wait(Duration::from_secs(10))?;
 
@@ -86,7 +89,10 @@ fn test_hello_world_oci_uses_precompiled() -> anyhow::Result<()> {
     // run second time, it should succeed without recompiling
     let (builder, _oci_cleanup2) = WasiTest::<WasiInstance>::builder()?
         .with_wasm(HELLO_WORLD)?
-        .as_oci_image(None, Some("c2".to_string()))?;
+        .as_oci_image(
+            Some("localhost/hello:latest".to_string()),
+            Some("c2".to_string()),
+        )?;
 
     let (exit_code, stdout, _) = builder.build()?.start()?.wait(Duration::from_secs(10))?;
 
@@ -101,7 +107,10 @@ fn test_hello_world_oci_uses_precompiled() -> anyhow::Result<()> {
 fn test_hello_world_oci_uses_precompiled_when_content_removed() -> anyhow::Result<()> {
     let (builder, _oci_cleanup1) = WasiTest::<WasiInstance>::builder()?
         .with_wasm(HELLO_WORLD)?
-        .as_oci_image(None, Some("c1".to_string()))?;
+        .as_oci_image(
+            Some("localhost/hello:latest".to_string()),
+            Some("c1".to_string()),
+        )?;
 
     let (exit_code, stdout, _) = builder.build()?.start()?.wait(Duration::from_secs(10))?;
 
@@ -120,7 +129,10 @@ fn test_hello_world_oci_uses_precompiled_when_content_removed() -> anyhow::Resul
     // run second time, it should succeed
     let (builder, _oci_cleanup2) = WasiTest::<WasiInstance>::builder()?
         .with_wasm(HELLO_WORLD)?
-        .as_oci_image(None, Some("c2".to_string()))?;
+        .as_oci_image(
+            Some("localhost/hello:latest".to_string()),
+            Some("c2".to_string()),
+        )?;
 
     let (exit_code, stdout, _) = builder.build()?.start()?.wait(Duration::from_secs(10))?;
 

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -76,13 +76,6 @@ fn test_hello_world_oci_uses_precompiled() -> anyhow::Result<()> {
     assert_eq!(exit_code, 0);
     assert_eq!(stdout, "hello world\n");
 
-    let (label, id) = oci_helpers::get_image_label()?;
-    assert!(
-        label.starts_with("runwasi.io/precompiled/wasmtime/"),
-        "was {}",
-        label
-    );
-    assert_eq!(id, "true");
     let (label, _id) = oci_helpers::get_content_label()?;
     assert!(
         label.starts_with("runwasi.io/precompiled/wasmtime/"),
@@ -114,10 +107,6 @@ fn test_hello_world_oci_uses_precompiled_when_content_removed() -> anyhow::Resul
 
     assert_eq!(exit_code, 0);
     assert_eq!(stdout, "hello world\n");
-
-    let (label, id) = oci_helpers::get_image_label()?;
-    assert!(label.starts_with("runwasi.io/precompiled/wasmtime/"));
-    assert_eq!(id, "true");
 
     // remove the compiled content from the cache
     let (label, id) = oci_helpers::get_content_label()?;

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -79,12 +79,16 @@ fn test_hello_world_oci_uses_precompiled() -> anyhow::Result<()> {
     let (label, id) = oci_helpers::get_image_label()?;
     assert!(
         label.starts_with("runwasi.io/precompiled/wasmtime/"),
-        "was {}={}",
-        label,
-        id
+        "was {}",
+        label
     );
-
-    std::thread::sleep(std::time::Duration::from_secs(30));
+    assert_eq!(id, "true");
+    let (label, _id) = oci_helpers::get_content_label()?;
+    assert!(
+        label.starts_with("runwasi.io/precompiled/wasmtime/"),
+        "was {}",
+        label
+    );
 
     // run second time, it should succeed without recompiling
     let (builder, _oci_cleanup2) = WasiTest::<WasiInstance>::builder()?
@@ -112,9 +116,16 @@ fn test_hello_world_oci_uses_precompiled_when_content_removed() -> anyhow::Resul
     assert_eq!(stdout, "hello world\n");
 
     let (label, id) = oci_helpers::get_image_label()?;
+    assert!(label.starts_with("runwasi.io/precompiled/wasmtime/"));
+    assert_eq!(id, "true");
 
     // remove the compiled content from the cache
-    assert!(label.starts_with("runwasi.io/precompiled/wasmtime/"));
+    let (label, id) = oci_helpers::get_content_label()?;
+    assert!(
+        label.starts_with("runwasi.io/precompiled/wasmtime/"),
+        "was {}",
+        label
+    );
     oci_helpers::remove_content(id)?;
 
     // run second time, it should succeed

--- a/crates/oci-tar-builder/Cargo.toml
+++ b/crates/oci-tar-builder/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 clap = { version = "4.5.1", features = ["derive"] }
+indexmap = "2.2.5"
 
 [lib]
 path = "src/lib.rs"

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::fs::metadata;
 use std::io::Write;
 use std::path::PathBuf;
@@ -65,7 +65,7 @@ impl Builder {
         let mut tb = tar::Builder::new(w);
         let mut manifests = Vec::new();
         // use IndexMap in order to keep layers in order they were added.
-        let mut layer_digests = IndexMap::new(); 
+        let mut layer_digests = IndexMap::new();
 
         if self.configs.len() > 1 {
             anyhow::bail!("only one config is supported");

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::metadata;
 use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::{Context, Error, Result};
+use indexmap::IndexMap;
 use log::{debug, warn};
 use oci_spec::image::{
     DescriptorBuilder, ImageConfiguration, ImageIndexBuilder, ImageManifestBuilder, MediaType,
@@ -63,7 +64,8 @@ impl Builder {
     pub fn build<W: Write>(&mut self, w: W) -> Result<(), Error> {
         let mut tb = tar::Builder::new(w);
         let mut manifests = Vec::new();
-        let mut layer_digests = HashMap::new();
+        // use IndexMap in order to keep layers in order they were added.
+        let mut layer_digests = IndexMap::new(); 
 
         if self.configs.len() > 1 {
             anyhow::bail!("only one config is supported");


### PR DESCRIPTION
After some feedback we found some runtimes require ability to individually pre-compile layers.  This attempts to address that ability. 

This also fixes a bug that was introduced when adding pre-compilation where the media types were being overwritten.
