### PR TITLE
Add hash of layers to make Unique ImageID for existing tooling

### DIFF
--- a/crates/oci-tar-builder/src/bin.rs
+++ b/crates/oci-tar-builder/src/bin.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::PathBuf;
 use std::{env, fs};
@@ -6,6 +7,7 @@ use anyhow::Context;
 use clap::Parser;
 use oci_spec::image::{self as spec, Arch};
 use oci_tar_builder::{Builder, WASM_LAYER_MEDIA_TYPE};
+use sha256::{digest, try_digest};
 
 pub fn main() {
     let args = Args::parse();
@@ -21,9 +23,15 @@ pub fn main() {
     let entry_point = args.name.clone() + ".wasm";
 
     let mut builder = Builder::default();
+    let mut layer_digests = Vec::new();
     for module_path in args.module.iter() {
         let module_path = PathBuf::from(module_path);
         builder.add_layer_with_media_type(&module_path, WASM_LAYER_MEDIA_TYPE.to_string());
+        layer_digests.push(
+            try_digest(&module_path)
+                .context("failed to calculate digest for module")
+                .unwrap(),
+        );
     }
 
     for layer_config in args.layer.iter() {
@@ -33,6 +41,11 @@ pub fn main() {
         let layer_type = layer_options.first().unwrap();
         let layer_path = PathBuf::from(layer_options.last().unwrap());
         builder.add_layer_with_media_type(&layer_path, layer_type.to_string());
+        layer_digests.push(
+            try_digest(&layer_path)
+                .context("failed to calculate digest for module")
+                .unwrap(),
+        );
     }
 
     if let Some(components_path) = args.components.as_deref() {
@@ -44,6 +57,11 @@ pub fn main() {
             match ext {
                 "wasm" => {
                     builder.add_layer_with_media_type(&path, WASM_LAYER_MEDIA_TYPE.to_string());
+                    layer_digests.push(
+                        try_digest(&path)
+                            .context("failed to calculate digest for module")
+                            .unwrap(),
+                    );
                 }
                 _ => println!(
                     "Skipping Unknown file type: {:?} with extension {:?}",
@@ -54,8 +72,14 @@ pub fn main() {
         }
     }
 
+    // Need each config to be unique since we don't have layers to make them unique in the rootfs
+    // https://github.com/opencontainers/image-spec/pull/1173
+    let unique_id = digest(layer_digests.join(""));
+    let mut labels: HashMap<String, String> = HashMap::new();
+    labels.insert("containerd.runwasi.layers".to_string(), unique_id);
     let config = spec::ConfigBuilder::default()
         .entrypoint(vec![entry_point])
+        .labels(labels)
         .build()
         .unwrap();
 


### PR DESCRIPTION
After discussions with OCI group we need to have something with in the Image Config to make it unique https://github.com/opencontainers/image-spec/pull/1173 otherwise existing tooling might not pick it up.  See https://github.com/spinkube/spin-operator/issues/40#issuecomment-1978776234 for an example with CRI.