### PR TITLE
Update rust-extensions to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,8 +600,9 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim"
-version = "0.7.0"
-source = "git+https://github.com/containerd/rust-extensions?rev=6b9e5b28be2870731a18ca83c13e63a98f35e149#6b9e5b28be2870731a18ca83c13e63a98f35e149"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecfe3bbd2e126cbd3b37ebc7faadedeeb5a87a389dc1668f1f0f4d246e46769"
 dependencies = [
  "cgroups-rs",
  "command-fds",
@@ -627,7 +628,8 @@ dependencies = [
 [[package]]
 name = "containerd-shim-protos"
 version = "0.7.0"
-source = "git+https://github.com/containerd/rust-extensions?rev=6b9e5b28be2870731a18ca83c13e63a98f35e149#6b9e5b28be2870731a18ca83c13e63a98f35e149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ef8fa542cd6964b2705983d02de4f4bdaaac8d25feabcef5c43a87ac58291"
 dependencies = [
  "protobuf 3.2.0",
  "ttrpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ homepage = "https://github.com/containerd/runwasi"
 anyhow = "1.0"
 cap-std = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-containerd-shim = { git = "https://github.com/containerd/rust-extensions", rev = "6b9e5b28be2870731a18ca83c13e63a98f35e149" }
+containerd-shim = "0.7.1"
 containerd-shim-wasm = { path = "crates/containerd-shim-wasm", version = "0.5.0" }
 containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules", version = "0.4.0"}
 oci-tar-builder = { path = "crates/oci-tar-builder", version = "0.4.0" }


### PR DESCRIPTION
Updates to use the released version of rust-extensions which contains the cgroups parsing. With this fix and many others that have come in the last few weeks I think we can do a release of runwasi.