### PR TITLE
Bump test module crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm-test-modules"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/crates/containerd-shim-wasm-test-modules/Cargo.toml
+++ b/crates/containerd-shim-wasm-test-modules/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd-shim-wasm-test-modules"
 description = "Set of WebAssembly modules for testing containerd shims for wasm"
-version.workspace = true
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 


### PR DESCRIPTION
The test modules crate already has a tag https://github.com/containerd/runwasi/releases/tag/containerd-shim-wasm-test-modules%2Fv0.4.0  so this bumps it to 0.4.1 so we can release it properly since it failed last time we tried: https://github.com/containerd/runwasi/actions/runs/7935545087. 

This is needed for the release when trying a dry-run:

```
Caused by:
  failed to select a version for the requirement `containerd-shim-wasm-test-modules = "^0.4.0"`
  candidate versions found which didn't match: 0.3.1, 0.3.0
```

