### PR TITLE
Enable building and release of oci-tar-builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         run: make test-${{ needs.parse.outputs.runtime }}
 
       - name: Sign the binary
-        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' && needs.parse.outputs.runtime != 'oci-tar-builder'}}
         run: |
           make dist-${{ needs.parse.outputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
@@ -99,7 +99,7 @@ jobs:
           fi
 
       - name: Package artifacts
-        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' && needs.parse.outputs.runtime != 'oci-tar-builder'}}
         shell: bash
         run: |
           # Check if there's any files to archive as tar fails otherwise
@@ -109,7 +109,7 @@ jobs:
             tar -czf dist/containerd-shim-${{ needs.parse.outputs.runtime }}-${{ matrix.arch }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
-        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' && needs.parse.outputs.runtime != 'oci-tar-builder'}}
         uses: actions/upload-artifact@master
         with:
           name: containerd-shim-${{ needs.parse.outputs.runtime }}-${{ matrix.arch }}
@@ -127,7 +127,7 @@ jobs:
       - name: Setup build env
         run: ./scripts/setup-linux.sh
       - name: Download artifacts
-        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' && needs.parse.outputs.runtime != 'oci-tar-builder'}}
         uses: actions/download-artifact@master
         with:
           path: release
@@ -138,7 +138,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NAME: ${{ needs.parse.outputs.crate }}/${{ needs.parse.outputs.version }}
       - name: Upload release artifacts
-        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' }}
+        if: ${{ needs.parse.outputs.runtime != 'wasm' && needs.parse.outputs.runtime != 'wasm-test-modules' && needs.parse.outputs.runtime != 'oci-tar-builder'}}
         run: |
           for i in release/*/*; do
             gh release upload ${RELEASE_NAME} $i

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ build-wasm:
 build-%:
 	$(CARGO) build $(TARGET_FLAG) -p containerd-shim-$* $(FEATURES_$*) $(RELEASE_FLAG)
 
+build-oci-tar-builder:
+	$(CARGO) build $(TARGET_FLAG) -p oci-tar-builder $(FEATURES_$*) $(RELEASE_FLAG)
+
 .PHONY: check check-common check-wasm check-%
 check: check-wasm $(RUNTIMES:%=check-%);
 
@@ -123,6 +126,9 @@ endif
 test-%:
 	# run tests in one thread to prevent paralellism
 	RUST_LOG=trace $(CARGO) test $(TARGET_FLAG) --package containerd-shim-$* $(FEATURES_$*) --lib --verbose $(TEST_ARGS_SEP) --nocapture --test-threads=1
+
+test-oci-tar-builder:
+	RUST_LOG=trace $(CARGO) test $(TARGET_FLAG) --package oci-tar-builder $(FEATURES_$*) --verbose $(TEST_ARGS_SEP) --nocapture --test-threads=1
 
 .PHONY: install install-%
 install: $(RUNTIMES:%=install-%);


### PR DESCRIPTION
The [0.5.0 release](https://github.com/containerd/runwasi/actions/runs/8351251493) is failing due to missing `  no matching package named `oci-tar-builder` found`.  After attempting to release this package the [release build](https://github.com/containerd/runwasi/actions/runs/8362454303/job/22893107967) failed with:

```
error: package ID specification `containerd-shim-oci-tar-builder` did not match any packages
```

This make the updates to the makefile to support building and publishing this package.  At a later time, we can build the `oci-tar-builder` binary and create a release artifact but for now we can release the library as is.