### PR TITLE
Add Description and license to oci-tar-builder cargo.toml

### DIFF
--- a/crates/oci-tar-builder/Cargo.toml
+++ b/crates/oci-tar-builder/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "oci-tar-builder"
+description = "Library that can be used to build OCI tar archives"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+readme = "README.md"
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 tar = { workspace = true }


### PR DESCRIPTION
[Cargo publish](https://github.com/containerd/runwasi/actions/runs/8364790324/job/22901153910) requires these fields but interestingly `publish --dry-run` doesn't tell you this when testing with it.

https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate