### PR TITLE
ci(*): merge build action

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -1,3 +1,4 @@
+# this action will require write permission to id-token
 name: Build shims
 
 on:
@@ -21,9 +22,6 @@ on:
 
 jobs:
   build-sign-upload:
-    permissions:
-      # cosign uses the GitHub OIDC token
-      id-token: write
     name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}
     steps:

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -1,9 +1,6 @@
 # this action will require write permission to id-token
 name: Build shims
 
-permissions:
-  id-token: write
-
 on:
   workflow_call:
     inputs:
@@ -25,6 +22,9 @@ on:
 
 jobs:
   build-sign-upload:
+    permissions:
+      contents: write
+      id-token: write
     name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}
     steps:
@@ -61,7 +61,6 @@ jobs:
           make test-${{ inputs.runtime }}
         if: ${{ inputs.arch == 'x86_64' }}
       - name: Sign the binary
-        shell: bash
         if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' }}
         run: |
           make dist-${{ inputs.runtime }}

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -15,13 +15,22 @@ on:
       slug:
         required: true
         type: string
+      arch:
+        required: false
+        type: string
 
 jobs:
-  build:
+  build-sign-upload:
+    permissions:
+      # cosign uses the GitHub OIDC token
+      id-token: write
     name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - name: describe runner
+        run: |
+          echo "Running job with os: '${{ inputs.os }}', arch: '${{ inputs.arch }}', slug: '${{ inputs.slug }}', runtime: '${{ inputs.runtime }}', target: '${{ inputs.target }}'"
+      - uses: actions/checkout@v4
       - name: Setup build env
         run: |
           os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
@@ -35,12 +44,52 @@ jobs:
       - name: Setup cross-rs
         if: runner.os == 'Linux'
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
+      - name: Setup cosign for signing
+        if: ${{ matrix.is_shim == 'true' }}
+        uses: sigstore/cosign-installer@v3.3.0
+        with:
+          cosign-release: 'v2.2.2'
+      - name: Setup build profile
+        shell: bash
+        run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
       - name: Build
         run: make build-${{ inputs.runtime }}
       - name: Run tests
         timeout-minutes: 5
         run: |
           make test-${{ inputs.runtime }}
+        if: ${{ inputs.arch == 'x86_64' }}
+      - name: Sign the binary
+        shell: bash
+        if: ${{ inputs.runtime != 'common' }}
+        run: |
+          make dist-${{ inputs.runtime }}
+          # Check if there's any files to archive as tar fails otherwise
+          if stat dist/bin/* >/dev/null 2>&1; then
+            cosign sign-blob --yes \
+              --output-signature containerd-shim-${{ inputs.runtime }}-v1.sig \
+              --output-certificate containerd-shim-${{ inputs.runtime }}-v1.pem \
+              --bundle containerd-shim-${{ inputs.runtime }}-v1.bundle \
+              dist/bin/containerd-shim-${{ inputs.runtime }}-v1
+            
+            cosign sign-blob --yes \
+              --output-signature containerd-shim-${{ inputs.runtime }}d-v1.sig \
+              --output-certificate containerd-shim-${{ inputs.runtime }}d-v1.pem \
+              --bundle containerd-shim-${{ inputs.runtime }}d-v1.bundle \
+              dist/bin/containerd-shim-${{ inputs.runtime }}d-v1
+
+            cosign sign-blob --yes \
+              --output-signature containerd-${{ inputs.runtime }}d.sig \
+              --output-certificate containerd-${{ inputs.runtime }}d.pem \
+              --bundle containerd-${{ inputs.runtime }}d.bundle \
+              dist/bin/containerd-${{ inputs.runtime }}d
+            
+            # Copy the certs to the dist/bin folder
+            cp *.sig dist/bin/
+            cp *.pem dist/bin/
+          else
+            echo "No files to sign"
+          fi
       - name: Package artifacts
         if: ${{ inputs.runtime != 'common' }}
         shell: bash
@@ -48,13 +97,13 @@ jobs:
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -C dist/bin .
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -C dist/bin .
           else
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -T /dev/null
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
         uses: actions/upload-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}
-          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}
+          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -45,7 +45,7 @@ jobs:
         if: runner.os == 'Linux'
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
       - name: Setup cosign for signing
-        if: ${{ matrix.is_shim == 'true' }}
+        if: ${{ inputs.runtime != 'common' }}
         uses: sigstore/cosign-installer@v3.3.0
         with:
           cosign-release: 'v2.2.2'

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -97,13 +97,13 @@ jobs:
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -C dist/bin .
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -C dist/bin .
           else
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -T /dev/null
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
         uses: actions/upload-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}
-          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}
+          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -1,6 +1,9 @@
 # this action will require write permission to id-token
 name: Build shims
 
+permissions:
+  id-token: write
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ inputs.arch == 'x86_64' }}
       - name: Sign the binary
         shell: bash
-        if: ${{ inputs.runtime != 'common' }}
+        if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' }}
         run: |
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,14 @@ jobs:
         os: ["ubuntu-22.04"]
         runtime: ["common", "wasmtime", "wasmedge", "wasmer"]
         libc: ["musl", "gnu"]
+        arch: ["x86_64", "aarch64"]
     uses: ./.github/workflows/action-build.yml
     with:
       os: ${{ matrix.os }}
       runtime: ${{ matrix.runtime }}
-      target: "x86_64-unknown-linux-${{ matrix.libc }}"
+      target: "${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}"
       slug: "linux-${{ matrix.libc }}"
+      arch: ${{ matrix.arch }}
 
   build-windows:
     name: ${{ matrix.runtime }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       image: img-oci
 
   build-ubuntu:
+    permissions:
+      # cosign uses the GitHub OIDC token
+      id-token: write
     name: ${{ matrix.runtime }}
     strategy:
       matrix:
@@ -54,6 +57,9 @@ jobs:
       arch: ${{ matrix.arch }}
 
   build-windows:
+    permissions:
+      # cosign uses the GitHub OIDC token
+      id-token: write
     name: ${{ matrix.runtime }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       os: ${{ matrix.os }}
       runtime: ${{ matrix.runtime }}
       target: "${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}"
-      slug: "linux-${{ matrix.libc }}"
+      slug: "${{ matrix.arch }}-linux-${{ matrix.libc }}"
       arch: ${{ matrix.arch }}
 
   build-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
   build-ubuntu:
     name: ${{ matrix.runtime }}
     permissions:
+      contents: write
       id-token: write
     strategy:
       matrix:
@@ -58,6 +59,7 @@ jobs:
   build-windows:
     name: ${{ matrix.runtime }}
     permissions:
+      contents: write
       id-token: write
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,9 @@ jobs:
       image: img-oci
 
   build-ubuntu:
-    permissions:
-      # cosign uses the GitHub OIDC token
-      id-token: write
     name: ${{ matrix.runtime }}
+    permissions:
+      id-token: write
     strategy:
       matrix:
         os: ["ubuntu-22.04"]
@@ -57,10 +56,9 @@ jobs:
       arch: ${{ matrix.arch }}
 
   build-windows:
-    permissions:
-      # cosign uses the GitHub OIDC token
-      id-token: write
     name: ${{ matrix.runtime }}
+    permissions:
+      id-token: write
     strategy:
       matrix:
         os: ["windows-latest"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,6 @@ jobs:
           fi
 
   build-and-sign:
-    permissions:
-      # cosign uses the GitHub OIDC token
-      id-token: write
     needs:
       - pre-release
     strategy:
@@ -94,83 +91,13 @@ jobs:
         arch: ["x86_64", "aarch64"]
         include: 
           - ${{ needs.pre-release.outputs }}
-    runs-on: "ubuntu-22.04"
-    steps:
-      - name: Matrix description
-        run: |
-          echo "Running job with dry_run: '${{ inputs.dry_run }}' crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
-      - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-      - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        env:
-          RUST_CACHE_KEY_OS: rust-release-cache-${{ matrix.crate }}-${{ matrix.arch }}
-        with:
-          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup cross-rs
-        run: ./scripts/setup-cross.sh ${{ matrix.arch }}-unknown-linux-musl
-      - name: Setup build profile
-        shell: bash
-        run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
-      - name: Setup cosign for signing
-        if: ${{ matrix.is_shim == 'true' }}
-        uses: sigstore/cosign-installer@v3.3.0
-        with:
-          cosign-release: 'v2.2.2'
-      - name: Build
-        timeout-minutes: 20
-        run: make build-${{ matrix.runtime }}
-      - name: Test
-        if: ${{ matrix.arch == 'x86_64' }}
-        timeout-minutes: 10
-        run: make test-${{ matrix.runtime }}
-      - name: Sign the binary
-        if: ${{ matrix.is_shim == 'true' }}
-        run: |
-          make dist-${{ matrix.runtime }}
-          # Check if there's any files to archive as tar fails otherwise
-          if stat dist/bin/* >/dev/null 2>&1; then
-            cosign sign-blob --yes \
-              --output-signature containerd-shim-${{ matrix.runtime }}-v1.sig \
-              --output-certificate containerd-shim-${{ matrix.runtime }}-v1.pem \
-              --bundle containerd-shim-${{ matrix.runtime }}-v1.bundle \
-              dist/bin/containerd-shim-${{ matrix.runtime }}-v1
-            
-            cosign sign-blob --yes \
-              --output-signature containerd-shim-${{ matrix.runtime }}d-v1.sig \
-              --output-certificate containerd-shim-${{ matrix.runtime }}d-v1.pem \
-              --bundle containerd-shim-${{ matrix.runtime }}d-v1.bundle \
-              dist/bin/containerd-shim-${{ matrix.runtime }}d-v1
-
-            cosign sign-blob --yes \
-              --output-signature containerd-${{ matrix.runtime }}d.sig \
-              --output-certificate containerd-${{ matrix.runtime }}d.pem \
-              --bundle containerd-${{ matrix.runtime }}d.bundle \
-              dist/bin/containerd-${{ matrix.runtime }}d
-            
-            # Copy the certs to the dist/bin folder
-            cp *.sig dist/bin/
-            cp *.pem dist/bin/
-          else
-            echo "No files to sign"
-          fi
-      - name: Package artifacts
-        if: ${{ matrix.is_shim == 'true' }}
-        shell: bash
-        run: |
-          # Check if there's any files to archive as tar fails otherwise
-          if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}.tar.gz -C dist/bin .
-          else
-            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}.tar.gz -T /dev/null
-          fi
-      - name: Upload artifacts
-        if: ${{ matrix.is_shim == 'true' }}
-        uses: actions/upload-artifact@master
-        with:
-          name: containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}
-          path: dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}.tar.gz
+    uses: ./.github/workflows/action-build.yml
+    with:
+      os: "ubuntu-22.04"
+      runtime: ${{ matrix.runtime }}
+      target: "${{ matrix.arch }}-unknown-linux-musl"
+      slug: "linux-musl"
+      arch: ${{ matrix.arch }}
 
   release:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
   build-and-sign:
     permissions:
       id-token: write
+      contents: write
     needs:
       - pre-release
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       os: "ubuntu-22.04"
       runtime: ${{ matrix.runtime }}
       target: "${{ matrix.arch }}-unknown-linux-musl"
-      slug: "linux-musl"
+      slug: "${{ matrix.arch }}-linux-musl"
       arch: ${{ matrix.arch }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
           fi
 
   build-and-sign:
+    permissions:
+      id-token: write
     needs:
       - pre-release
     strategy:


### PR DESCRIPTION
this commit merges the build step in the release action and the one in the ci action since they share a large overlap code.

the build step not only builds the binary, but signs it, and upload as action artifacts. this step is now running for every ci run, including PR and release pipeline.