### PR TITLE
ci(*): merge build action

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -1,3 +1,4 @@
+# this action will require write permission to id-token
 name: Build shims
 
 on:
@@ -22,7 +23,7 @@ on:
 jobs:
   build-sign-upload:
     permissions:
-      # cosign uses the GitHub OIDC token
+      contents: write
       id-token: write
     name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}
@@ -60,7 +61,6 @@ jobs:
           make test-${{ inputs.runtime }}
         if: ${{ inputs.arch == 'x86_64' }}
       - name: Sign the binary
-        shell: bash
         if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' }}
         run: |
           make dist-${{ inputs.runtime }}

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -1,3 +1,6 @@
+
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 # this action will require write permission to id-token
 name: Build shims
 
@@ -19,6 +22,9 @@ on:
       arch:
         required: false
         type: string
+      sign:
+        default: false
+        type: boolean
 
 jobs:
   build-sign-upload:
@@ -45,7 +51,7 @@ jobs:
         if: runner.os == 'Linux'
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
       - name: Setup cosign for signing
-        if: ${{ inputs.runtime != 'common' }}
+        if: ${{ inputs.runtime != 'common' && inputs.sign }}
         uses: sigstore/cosign-installer@v3.3.0
         with:
           cosign-release: 'v2.2.2'
@@ -60,7 +66,7 @@ jobs:
           make test-${{ inputs.runtime }}
         if: ${{ inputs.arch == 'x86_64' }}
       - name: Sign the binary
-        if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' }}
+        if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' && inputs.sign }}
         run: |
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -23,7 +23,6 @@ on:
 jobs:
   build-sign-upload:
     permissions:
-      contents: write
       id-token: write
     name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -45,7 +45,7 @@ jobs:
         if: runner.os == 'Linux'
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
       - name: Setup cosign for signing
-        if: ${{ matrix.is_shim == 'true' }}
+        if: ${{ inputs.runtime != 'common' }}
         uses: sigstore/cosign-installer@v3.3.0
         with:
           cosign-release: 'v2.2.2'
@@ -97,13 +97,13 @@ jobs:
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -C dist/bin .
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -C dist/bin .
           else
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -T /dev/null
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
         uses: actions/upload-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}
-          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}
+          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -15,13 +15,22 @@ on:
       slug:
         required: true
         type: string
+      arch:
+        required: false
+        type: string
 
 jobs:
-  build:
+  build-sign-upload:
+    permissions:
+      # cosign uses the GitHub OIDC token
+      id-token: write
     name: build for ${{ inputs.slug }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - name: describe runner
+        run: |
+          echo "Running job with os: '${{ inputs.os }}', arch: '${{ inputs.arch }}', slug: '${{ inputs.slug }}', runtime: '${{ inputs.runtime }}', target: '${{ inputs.target }}'"
+      - uses: actions/checkout@v4
       - name: Setup build env
         run: |
           os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
@@ -35,12 +44,52 @@ jobs:
       - name: Setup cross-rs
         if: runner.os == 'Linux'
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
+      - name: Setup cosign for signing
+        if: ${{ matrix.is_shim == 'true' }}
+        uses: sigstore/cosign-installer@v3.3.0
+        with:
+          cosign-release: 'v2.2.2'
+      - name: Setup build profile
+        shell: bash
+        run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
       - name: Build
         run: make build-${{ inputs.runtime }}
       - name: Run tests
         timeout-minutes: 5
         run: |
           make test-${{ inputs.runtime }}
+        if: ${{ inputs.arch == 'x86_64' }}
+      - name: Sign the binary
+        shell: bash
+        if: ${{ inputs.runtime != 'common' }}
+        run: |
+          make dist-${{ inputs.runtime }}
+          # Check if there's any files to archive as tar fails otherwise
+          if stat dist/bin/* >/dev/null 2>&1; then
+            cosign sign-blob --yes \
+              --output-signature containerd-shim-${{ inputs.runtime }}-v1.sig \
+              --output-certificate containerd-shim-${{ inputs.runtime }}-v1.pem \
+              --bundle containerd-shim-${{ inputs.runtime }}-v1.bundle \
+              dist/bin/containerd-shim-${{ inputs.runtime }}-v1
+            
+            cosign sign-blob --yes \
+              --output-signature containerd-shim-${{ inputs.runtime }}d-v1.sig \
+              --output-certificate containerd-shim-${{ inputs.runtime }}d-v1.pem \
+              --bundle containerd-shim-${{ inputs.runtime }}d-v1.bundle \
+              dist/bin/containerd-shim-${{ inputs.runtime }}d-v1
+
+            cosign sign-blob --yes \
+              --output-signature containerd-${{ inputs.runtime }}d.sig \
+              --output-certificate containerd-${{ inputs.runtime }}d.pem \
+              --bundle containerd-${{ inputs.runtime }}d.bundle \
+              dist/bin/containerd-${{ inputs.runtime }}d
+            
+            # Copy the certs to the dist/bin folder
+            cp *.sig dist/bin/
+            cp *.pem dist/bin/
+          else
+            echo "No files to sign"
+          fi
       - name: Package artifacts
         if: ${{ inputs.runtime != 'common' }}
         shell: bash
@@ -48,13 +97,13 @@ jobs:
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -C dist/bin .
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -C dist/bin .
           else
-            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz -T /dev/null
+            tar -czf dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz -T /dev/null
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
         uses: actions/upload-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}
-          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz
+          name: containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}
+          path: dist/containerd-shim-${{ inputs.runtime }}-${{ inputs.arch }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -50,11 +50,6 @@ jobs:
       - name: Setup cross-rs
         if: runner.os == 'Linux'
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
-      - name: Setup cosign for signing
-        if: ${{ inputs.runtime != 'common' && inputs.sign }}
-        uses: sigstore/cosign-installer@v3.3.0
-        with:
-          cosign-release: 'v2.2.2'
       - name: Setup build profile
         shell: bash
         run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
@@ -67,35 +62,10 @@ jobs:
         if: ${{ inputs.arch == 'x86_64' }}
       - name: Sign the binary
         if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' && inputs.sign }}
-        run: |
-          make dist-${{ inputs.runtime }}
-          # Check if there's any files to archive as tar fails otherwise
-          if stat dist/bin/* >/dev/null 2>&1; then
-            echo "::notice::Signing the binary"
-            cosign sign-blob --yes \
-              --output-signature containerd-shim-${{ inputs.runtime }}-v1.sig \
-              --output-certificate containerd-shim-${{ inputs.runtime }}-v1.pem \
-              --bundle containerd-shim-${{ inputs.runtime }}-v1.bundle \
-              dist/bin/containerd-shim-${{ inputs.runtime }}-v1
-            
-            cosign sign-blob --yes \
-              --output-signature containerd-shim-${{ inputs.runtime }}d-v1.sig \
-              --output-certificate containerd-shim-${{ inputs.runtime }}d-v1.pem \
-              --bundle containerd-shim-${{ inputs.runtime }}d-v1.bundle \
-              dist/bin/containerd-shim-${{ inputs.runtime }}d-v1
-
-            cosign sign-blob --yes \
-              --output-signature containerd-${{ inputs.runtime }}d.sig \
-              --output-certificate containerd-${{ inputs.runtime }}d.pem \
-              --bundle containerd-${{ inputs.runtime }}d.bundle \
-              dist/bin/containerd-${{ inputs.runtime }}d
-            
-            # Copy the certs to the dist/bin folder
-            cp *.sig dist/bin/
-            cp *.pem dist/bin/
-          else
-            echo "::warning::No files to sign"
-          fi
+        uses: ./.github/workflows/action-sign.yml
+        with:
+          runtime: ${{ inputs.runtime }}
+          os: ${{ inputs.os }}
       - name: Package artifacts
         if: ${{ inputs.runtime != 'common' }}
         shell: bash

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ inputs.arch == 'x86_64' }}
       - name: Sign the binary
         shell: bash
-        if: ${{ inputs.runtime != 'common' }}
+        if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' }}
         run: |
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: describe runner
         run: |
-          echo "Running job with os: '${{ inputs.os }}', arch: '${{ inputs.arch }}', slug: '${{ inputs.slug }}', runtime: '${{ inputs.runtime }}', target: '${{ inputs.target }}'"
+          echo "::notice::Running job with os: '${{ inputs.os }}', arch: '${{ inputs.arch }}', slug: '${{ inputs.slug }}', runtime: '${{ inputs.runtime }}', target: '${{ inputs.target }}'"
       - uses: actions/checkout@v4
       - name: Setup build env
         run: |
@@ -71,6 +71,7 @@ jobs:
           make dist-${{ inputs.runtime }}
           # Check if there's any files to archive as tar fails otherwise
           if stat dist/bin/* >/dev/null 2>&1; then
+            echo "::notice::Signing the binary"
             cosign sign-blob --yes \
               --output-signature containerd-shim-${{ inputs.runtime }}-v1.sig \
               --output-certificate containerd-shim-${{ inputs.runtime }}-v1.pem \
@@ -93,7 +94,7 @@ jobs:
             cp *.sig dist/bin/
             cp *.pem dist/bin/
           else
-            echo "No files to sign"
+            echo "::warning::No files to sign"
           fi
       - name: Package artifacts
         if: ${{ inputs.runtime != 'common' }}

--- a/.github/workflows/action-fmt.yml
+++ b/.github/workflows/action-fmt.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: Run lint
 
 on:

--- a/.github/workflows/action-sign.yml
+++ b/.github/workflows/action-sign.yml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
+name: Signing
+
+on:
+  workflow_call:
+    inputs:
+      runtime:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+jobs:
+  sign:
+    name: Sign the binaries on ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
+    steps:
+    - name: Setup cosign for signing
+      uses: sigstore/cosign-installer@v3.3.0
+      with:
+        cosign-release: 'v2.2.2'
+    - name: Sign the binaries
+      run: |
+        make dist-${{ inputs.runtime }}
+        # Check if there's any files to archive as tar fails otherwise
+        if stat dist/bin/* >/dev/null 2>&1; then
+          echo "::notice::Signing the binary"
+          cosign sign-blob --yes \
+            --output-signature containerd-shim-${{ inputs.runtime }}-v1.sig \
+            --output-certificate containerd-shim-${{ inputs.runtime }}-v1.pem \
+            --bundle containerd-shim-${{ inputs.runtime }}-v1.bundle \
+            dist/bin/containerd-shim-${{ inputs.runtime }}-v1
+          
+          cosign sign-blob --yes \
+            --output-signature containerd-shim-${{ inputs.runtime }}d-v1.sig \
+            --output-certificate containerd-shim-${{ inputs.runtime }}d-v1.pem \
+            --bundle containerd-shim-${{ inputs.runtime }}d-v1.bundle \
+            dist/bin/containerd-shim-${{ inputs.runtime }}d-v1
+
+          cosign sign-blob --yes \
+            --output-signature containerd-${{ inputs.runtime }}d.sig \
+            --output-certificate containerd-${{ inputs.runtime }}d.pem \
+            --bundle containerd-${{ inputs.runtime }}d.bundle \
+            dist/bin/containerd-${{ inputs.runtime }}d
+          
+          # Copy the certs to the dist/bin folder
+          cp *.sig dist/bin/
+          cp *.pem dist/bin/
+        else
+          echo "::warning::No files to sign"
+        fi

--- a/.github/workflows/action-test-image.yml
+++ b/.github/workflows/action-test-image.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: Run end to end tests on kind
 
 on:

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-linux-musl
+          name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
       - name: Unpack artifats
         shell: bash
         run: |
           mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-linux-musl.tar.gz -C dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: Run end to end tests on k3s
 
 on:

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-linux-musl
+          name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
       - name: Unpack artifats
         shell: bash
         run: |
           mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-linux-musl.tar.gz -C dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: Run end to end tests on kind
 
 on:

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:
-          name: containerd-shim-${{ inputs.runtime }}-linux-musl
+          name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
       - name: Unpack artifats
         shell: bash
         run: |
           mkdir -p dist/bin
-          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-linux-musl.tar.gz -C dist/bin
+          tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: Run smoke tests
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,14 @@ jobs:
         os: ["ubuntu-22.04"]
         runtime: ["common", "wasmtime", "wasmedge", "wasmer"]
         libc: ["musl", "gnu"]
+        arch: ["x86_64", "aarch64"]
     uses: ./.github/workflows/action-build.yml
     with:
       os: ${{ matrix.os }}
       runtime: ${{ matrix.runtime }}
-      target: "x86_64-unknown-linux-${{ matrix.libc }}"
+      target: "${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}"
       slug: "linux-${{ matrix.libc }}"
+      arch: ${{ matrix.arch }}
 
   build-windows:
     name: ${{ matrix.runtime }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       os: ${{ matrix.os }}
       runtime: ${{ matrix.runtime }}
       target: "${{ matrix.arch }}-unknown-linux-${{ matrix.libc }}"
-      slug: "linux-${{ matrix.libc }}"
+      slug: "${{ matrix.arch }}-linux-${{ matrix.libc }}"
       arch: ${{ matrix.arch }}
 
   build-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
 
   build-ubuntu:
     name: ${{ matrix.runtime }}
+    permissions:
+      contents: write
+      id-token: write
     strategy:
       matrix:
         os: ["ubuntu-22.04"]
@@ -55,6 +58,9 @@ jobs:
 
   build-windows:
     name: ${{ matrix.runtime }}
+    permissions:
+      contents: write
+      id-token: write
     strategy:
       matrix:
         os: ["windows-latest"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
   build-ubuntu:
     name: ${{ matrix.runtime }}
     permissions:
-      contents: write
       id-token: write
     strategy:
       matrix:
@@ -59,7 +58,6 @@ jobs:
   build-windows:
     name: ${{ matrix.runtime }}
     permissions:
-      contents: write
       id-token: write
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
 name: Release
 run-name: ${{ inputs.crate }}@${{ inputs.version }} (DryRun:${{ inputs.dry_run }})
 
@@ -100,6 +102,7 @@ jobs:
       target: "${{ matrix.arch }}-unknown-linux-musl"
       slug: "${{ matrix.arch }}-linux-musl"
       arch: ${{ matrix.arch }}
+      sign: true
 
   release:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Fail if branch is not main
         if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
         run: |
-          echo "This workflow should not be triggered with workflow_dispatch on a branch other than main"
+          echo "::error::This workflow should not be triggered with workflow_dispatch on a branch other than main"
           exit 1
       - uses: actions/checkout@v4
       ### Determine the name of the runtime and if it is a binary release or crates.io
@@ -80,13 +80,13 @@ jobs:
         if: ${{ steps.runtime_sub.outputs.is_shim != 'true' }}
         run: |
           cargo owner --list ${{ inputs.crate }} | grep github:containerd:runwasi-committers || \
-            cargo owner --add github:containerd:runwasi-committers ${{ inputs.crate }}
+          cargo owner --add github:containerd:runwasi-committers ${{ inputs.crate }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
       - name: Verify version matches
         run: |
           if [ "$(grep -c "version = \"${{ inputs.version }}\"" crates/${{ inputs.crate }}/Cargo.toml)" -ne 1 ]; then
-            echo "Version in Cargo.toml does not match the version input"
+            echo "::error::Version in Cargo.toml does not match the version input"
             exit 1
           fi
 
@@ -124,7 +124,7 @@ jobs:
     steps:
       - name: Matrix description
         run: |
-          echo "Running job with dry_run: '${{ inputs.dry_run }}', crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
+          echo "::notice::Running job with dry_run: '${{ inputs.dry_run }}', crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
       - uses: actions/checkout@v4
       - name: Setup build env
         run: ./scripts/setup-linux.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,9 @@ jobs:
           fi
 
   build-and-sign:
+    permissions:
+      id-token: write
+      contents: write
     needs:
       - pre-release
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,6 @@ jobs:
           fi
 
   build-and-sign:
-    permissions:
-      # cosign uses the GitHub OIDC token
-      id-token: write
     needs:
       - pre-release
     strategy:
@@ -94,83 +91,13 @@ jobs:
         arch: ["x86_64", "aarch64"]
         include: 
           - ${{ needs.pre-release.outputs }}
-    runs-on: "ubuntu-22.04"
-    steps:
-      - name: Matrix description
-        run: |
-          echo "Running job with dry_run: '${{ inputs.dry_run }}' crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
-      - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-      - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        env:
-          RUST_CACHE_KEY_OS: rust-release-cache-${{ matrix.crate }}-${{ matrix.arch }}
-        with:
-          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup cross-rs
-        run: ./scripts/setup-cross.sh ${{ matrix.arch }}-unknown-linux-musl
-      - name: Setup build profile
-        shell: bash
-        run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
-      - name: Setup cosign for signing
-        if: ${{ matrix.is_shim == 'true' }}
-        uses: sigstore/cosign-installer@v3.3.0
-        with:
-          cosign-release: 'v2.2.2'
-      - name: Build
-        timeout-minutes: 20
-        run: make build-${{ matrix.runtime }}
-      - name: Test
-        if: ${{ matrix.arch == 'x86_64' }}
-        timeout-minutes: 10
-        run: make test-${{ matrix.runtime }}
-      - name: Sign the binary
-        if: ${{ matrix.is_shim == 'true' }}
-        run: |
-          make dist-${{ matrix.runtime }}
-          # Check if there's any files to archive as tar fails otherwise
-          if stat dist/bin/* >/dev/null 2>&1; then
-            cosign sign-blob --yes \
-              --output-signature containerd-shim-${{ matrix.runtime }}-v1.sig \
-              --output-certificate containerd-shim-${{ matrix.runtime }}-v1.pem \
-              --bundle containerd-shim-${{ matrix.runtime }}-v1.bundle \
-              dist/bin/containerd-shim-${{ matrix.runtime }}-v1
-            
-            cosign sign-blob --yes \
-              --output-signature containerd-shim-${{ matrix.runtime }}d-v1.sig \
-              --output-certificate containerd-shim-${{ matrix.runtime }}d-v1.pem \
-              --bundle containerd-shim-${{ matrix.runtime }}d-v1.bundle \
-              dist/bin/containerd-shim-${{ matrix.runtime }}d-v1
-
-            cosign sign-blob --yes \
-              --output-signature containerd-${{ matrix.runtime }}d.sig \
-              --output-certificate containerd-${{ matrix.runtime }}d.pem \
-              --bundle containerd-${{ matrix.runtime }}d.bundle \
-              dist/bin/containerd-${{ matrix.runtime }}d
-            
-            # Copy the certs to the dist/bin folder
-            cp *.sig dist/bin/
-            cp *.pem dist/bin/
-          else
-            echo "No files to sign"
-          fi
-      - name: Package artifacts
-        if: ${{ matrix.is_shim == 'true' }}
-        shell: bash
-        run: |
-          # Check if there's any files to archive as tar fails otherwise
-          if stat dist/bin/* >/dev/null 2>&1; then
-            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}.tar.gz -C dist/bin .
-          else
-            tar -czf dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}.tar.gz -T /dev/null
-          fi
-      - name: Upload artifacts
-        if: ${{ matrix.is_shim == 'true' }}
-        uses: actions/upload-artifact@master
-        with:
-          name: containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}
-          path: dist/containerd-shim-${{ matrix.runtime }}-${{ matrix.arch }}.tar.gz
+    uses: ./.github/workflows/action-build.yml
+    with:
+      os: "ubuntu-22.04"
+      runtime: ${{ matrix.runtime }}
+      target: "${{ matrix.arch }}-unknown-linux-musl"
+      slug: "linux-musl"
+      arch: ${{ matrix.arch }}
 
   release:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
   build-and-sign:
     permissions:
       id-token: write
-      contents: write
     needs:
       - pre-release
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       os: "ubuntu-22.04"
       runtime: ${{ matrix.runtime }}
       target: "${{ matrix.arch }}-unknown-linux-musl"
-      slug: "linux-musl"
+      slug: "${{ matrix.arch }}-linux-musl"
       arch: ${{ matrix.arch }}
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,15 @@ jobs:
         with:
           script: |
             const crate = '${{ inputs.crate }}';
-            let runtime = crate.replace(/^containerd-shim-/, '');
-            core.setOutput('runtime', runtime);
             const non_shim_crates = ['wasm', 'wasm-test-modules', 'oci-tar-builder'];
-            core.setOutput('is_shim', !non_shim_crates.includes(runtime));
+            if non_shim_crates.includes(runtime) {
+              core.setOutput('runtime', 'common');
+              core.setOutput('is_shim', false)
+            } else {
+              const runtime = crate.replace(/^containerd-shim-/, '');
+              core.setOutput('runtime', runtime);
+              core.setOutput('is_shim', true);
+            }
       ### If we are releasing a crate rather than producing a bin, check for crates.io access
       - name: Check crates.io ownership
         if: ${{ steps.runtime_sub.outputs.is_shim != 'true' }}


### PR DESCRIPTION
this commit merges the build step in the release action and the one in the ci action since they share a large overlap code.

the build step not only builds the binary, but signs it, and upload as action artifacts. this step is now running for every ci run, including PR and release pipeline.