### PR TITLE
ci(*): automate the version bump process

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -22,12 +22,9 @@ on:
       arch:
         required: false
         type: string
-      sign:
-        default: false
-        type: boolean
 
 jobs:
-  build-sign-upload:
+  build-upload:
     permissions:
       id-token: write
     name: build for ${{ inputs.slug }}
@@ -60,12 +57,6 @@ jobs:
         run: |
           make test-${{ inputs.runtime }}
         if: ${{ inputs.arch == 'x86_64' }}
-      - name: Sign the binary
-        if: ${{ inputs.runtime != 'common' && inputs.slug != 'windows' && inputs.sign }}
-        uses: ./.github/workflows/action-sign.yml
-        with:
-          runtime: ${{ inputs.runtime }}
-          os: ${{ inputs.os }}
       - name: Package artifacts
         if: ${{ inputs.runtime != 'common' }}
         shell: bash

--- a/.github/workflows/action-sign.yml
+++ b/.github/workflows/action-sign.yml
@@ -8,14 +8,15 @@ on:
       runtime:
         required: true
         type: string
-      os:
+      path: 
         required: true
         type: string
 jobs:
   sign:
-    name: Sign the binaries on ${{ inputs.os }}
-    runs-on: ${{ inputs.os }}
+    name: Sign the binaries
+    runs-on: "ubuntu-latest"
     steps:
+    - uses: actions/checkout@v4
     - name: Setup cosign for signing
       uses: sigstore/cosign-installer@v3.3.0
       with:
@@ -24,29 +25,29 @@ jobs:
       run: |
         make dist-${{ inputs.runtime }}
         # Check if there's any files to archive as tar fails otherwise
-        if stat dist/bin/* >/dev/null 2>&1; then
+        if stat ${{ inputs.path }}/* >/dev/null 2>&1; then
           echo "::notice::Signing the binary"
           cosign sign-blob --yes \
             --output-signature containerd-shim-${{ inputs.runtime }}-v1.sig \
             --output-certificate containerd-shim-${{ inputs.runtime }}-v1.pem \
             --bundle containerd-shim-${{ inputs.runtime }}-v1.bundle \
-            dist/bin/containerd-shim-${{ inputs.runtime }}-v1
+            ${{ inputs.path }}/containerd-shim-${{ inputs.runtime }}-v1
           
           cosign sign-blob --yes \
             --output-signature containerd-shim-${{ inputs.runtime }}d-v1.sig \
             --output-certificate containerd-shim-${{ inputs.runtime }}d-v1.pem \
             --bundle containerd-shim-${{ inputs.runtime }}d-v1.bundle \
-            dist/bin/containerd-shim-${{ inputs.runtime }}d-v1
+            ${{ inputs.path }}/containerd-shim-${{ inputs.runtime }}d-v1
 
           cosign sign-blob --yes \
             --output-signature containerd-${{ inputs.runtime }}d.sig \
             --output-certificate containerd-${{ inputs.runtime }}d.pem \
             --bundle containerd-${{ inputs.runtime }}d.bundle \
-            dist/bin/containerd-${{ inputs.runtime }}d
+            ${{ inputs.path }}/containerd-${{ inputs.runtime }}d
           
           # Copy the certs to the dist/bin folder
-          cp *.sig dist/bin/
-          cp *.pem dist/bin/
+          cp *.sig ${{ inputs.path }}/
+          cp *.pem ${{ inputs.path }}/
         else
           echo "::warning::No files to sign"
         fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       is_binary: ${{ steps.parse_crate.outputs.is_binary }}
       is_crate: ${{ steps.parse_crate.outputs.is_crate }}
-      #  e0ef1cf000bfb3f12e5b8613977ac9d901e39fbd...1ab3eb4318fb824cc44e36530b48e600fe18f258
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,9 +50,9 @@ jobs:
           echo "crate: $crate"
           echo "version: $version"
           
-          echo "dry_run:$dry_run" >> $GITHUB_OUTPUT
-          echo "crate:$crate" >> $GITHUB_OUTPUT
-          echo "version:$version" >> $GITHUB_OUTPUT
+          echo "dry_run=$dry_run" >> $GITHUB_OUTPUT
+          echo "crate=$crate" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
         
       - name: parse crate
         id: parse_crate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,16 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       is_binary: ${{ steps.parse_crate.outputs.is_binary }}
       is_crate: ${{ steps.parse_crate.outputs.is_crate }}
+      #  e0ef1cf000bfb3f12e5b8613977ac9d901e39fbd...1ab3eb4318fb824cc44e36530b48e600fe18f258
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
       - name: Test if tag is needed
         id: tag
         run: |
-          git fetch origin
+          git log -n 2 | cat
           git log ${{ github.event.before }}...${{ github.event.after }} | tee main.log
           if grep -q "automatically-tag-and-release-this-commit" main.log; then
             echo push-tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+
+name: Publish Artifacts
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+    contents: write
+
+jobs:
+  parse:
+    runs-on: ubuntu-latest
+    outputs:
+      push_tag: ${{ steps.tag.outputs.push_tag }}
+      dry_run: ${{ steps.parse.outputs.dry_run }}
+      crate: ${{ steps.parse.outputs.crate }}
+      version: ${{ steps.parse.outputs.version }}
+      is_binary: ${{ steps.parse_crate.outputs.is_binary }}
+      is_crate: ${{ steps.parse_crate.outputs.is_crate }}
+    steps:
+      - name: Test if tag is needed
+        id: tag
+        run: |
+          git log ${{ github.event.before }}...${{ github.event.after }} | tee main.log
+          if grep -q "automatically-tag-and-release-this-commit" main.log; then
+            echo push-tag
+            echo "push_tag=yes" >> $GITHUB_OUTPUT
+          else
+            echo no-push-tag
+            echo "push_tag=no" >> $GITHUB_OUTPUT
+          fi
+      - name: Parse commit message
+        id: parse
+        if: steps.tag.outputs.push_tag == 'yes'
+        run: |
+          dry_run=false
+          crate=$(grep 'Release ' main.log | sed 's/.*Release \([a-zA-Z0-9_-]*\).*/\1/')
+          version=$(grep 'Release ' main.log | sed 's/.* v\(.*\)/\1/')
+          if grep -q '\[dry-run\]' main.log; then
+              dry_run=true
+          fi
+
+          echo "dry_run: $dry_run"
+          echo "crate: $crate"
+          echo "version: $version"
+          
+          echo "dry_run:$dry_run" >> $GITHUB_OUTPUT
+          echo "crate:$crate" >> $GITHUB_OUTPUT
+          echo "version:$version" >> $GITHUB_OUTPUT
+        
+      - name: parse crate
+        id: parse_crate
+        if: steps.tag.outputs.push_tag == 'yes'
+        run: |
+          ./scripts/parse-crate.sh ${{ steps.parse.outputs.crate }} >> $GITHUB_OUTPUT
+        
+  release:
+    runs-on: "ubuntu-latest"
+    needs: parse
+    if: needs.parse.outputs.push_tag == 'yes'
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download artifacts
+        if: needs.parse.outputs.is_binary == 'true'
+        uses: actions/download-artifact@master
+        with:
+          path: release
+      
+      - name: Cargo publish
+        if: needs.parse.outputs.is_crate == 'true'
+        run: |
+          echo "DRY_RUN_FLAG=$( [ '${{ needs.parse.outputs.dry_run }}' = 'true' ] && echo '--dry-run' || echo '' )" >> $GITHUB_ENV
+          cargo publish $DRY_RUN_FLAG --package ${{ needs.parse.outputs.crate }} --verbose --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
+
+      - name: Tag the the release
+        if: needs.parse.outputs.dry_run == 'false'
+        run: |
+          git tag "${{ needs.parse.outputs.crate }}/v${{ needs.parse.outputs.version }}"
+          git push origin "${{ needs.parse.outputs.crate }}/v${{ needs.parse.outputs.version }}"
+
+      - name: Create release
+        if: needs.parse.outputs.dry_run == 'false'
+        run: |
+          gh release create 'refs/tags/${{ needs.parse.outputs.crate }}/v${{ needs.parse.outputs.version }}' --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NAME: ${{ needs.parse.outputs.crate }}/v${{ needs.parse.outputs.version }}
+
+      - name: Upload release artifacts
+        if: needs.parse.outputs.dry_run == 'false'
+        run: |
+          for i in release/*/*; do
+            gh release upload ${RELEASE_NAME} $i
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NAME: ${{ needs.parse.outputs.crate }}/v${{ needs.parse.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       is_binary: ${{ steps.parse_crate.outputs.is_binary }}
       is_crate: ${{ steps.parse_crate.outputs.is_crate }}
     steps:
+      - uses: actions/checkout@v4
       - name: Test if tag is needed
         id: tag
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Test if tag is needed
         id: tag
         run: |
+          git fetch origin
           git log ${{ github.event.before }}...${{ github.event.after }} | tee main.log
           if grep -q "automatically-tag-and-release-this-commit" main.log; then
             echo push-tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,10 @@ jobs:
       push_tag: ${{ steps.tag.outputs.push_tag }}
       dry_run: ${{ steps.parse.outputs.dry_run }}
       crate: ${{ steps.parse.outputs.crate }}
+      runtime: ${{ steps.parse.outputs.runtime }}
       version: ${{ steps.parse.outputs.version }}
-      is_binary: ${{ steps.parse_crate.outputs.is_binary }}
-      is_crate: ${{ steps.parse_crate.outputs.is_crate }}
+      is_binary: ${{ steps.parse.outputs.is_binary }}
+      is_crate: ${{ steps.parse.outputs.is_crate }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,27 +40,7 @@ jobs:
         id: parse
         if: steps.tag.outputs.push_tag == 'yes'
         run: |
-          dry_run=false
-          crate=$(grep 'Release ' main.log | sed 's/.*Release \([a-zA-Z0-9_-]*\).*/\1/')
-          version=$(grep 'Release ' main.log | sed 's/.* v\(.*\)/\1/')
-          if grep -q '\[dry-run\]' main.log; then
-              dry_run=true
-          fi
-
-          echo "dry_run: $dry_run"
-          echo "crate: $crate"
-          echo "version: $version"
-          
-          echo "dry_run=$dry_run" >> $GITHUB_OUTPUT
-          echo "crate=$crate" >> $GITHUB_OUTPUT
-          echo "version=$version" >> $GITHUB_OUTPUT
-        
-      - name: parse crate
-        id: parse_crate
-        if: steps.tag.outputs.push_tag == 'yes'
-        run: |
-          ./scripts/parse-crate.sh ${{ steps.parse.outputs.crate }} >> $GITHUB_OUTPUT
-        
+          ./scripts/parse-crate.sh main.log >> $GITHUB_OUTPUT
   release:
     runs-on: "ubuntu-latest"
     needs: parse
@@ -72,6 +53,13 @@ jobs:
         uses: actions/download-artifact@master
         with:
           path: release
+        
+      - name: Sign
+        if: needs.parse.outputs.is_binary == 'true'  
+        uses: ./.github/workflows/action-sign.yml
+        with:
+          path: release
+          runtime: ${{ needs.parse.outputs.runtime }}
       
       - name: Cargo publish
         if: needs.parse.outputs.is_crate == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,79 +83,46 @@ jobs:
           cargo owner --add github:containerd:runwasi-committers ${{ inputs.crate }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
-      - name: Verify version matches
+      - name: Update crate version and make a PR
+        if: ${{ !inputs.dry_run }}
         run: |
-          if [ "$(grep -c "version = \"${{ inputs.version }}\"" crates/${{ inputs.crate }}/Cargo.toml)" -ne 1 ]; then
-            echo "::error::Version in Cargo.toml does not match the version input"
-            exit 1
+          # replace the version inline in the Cargo.toml
+          set -ex
+          git fetch origin
+
+          sed -i -E 's/^version.+=.+".+"/version = "${{ inputs.version }}"/' crates/${{ inputs.crate }}/Cargo.toml
+          git diff
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          
+          if [ "${{ inputs.dry_run }}" = true ]; then
+            TITLE="[dry-run] Release ${{ inputs.crate }} v${{ inputs.version }}"
+          else
+            TITLE="Release ${{ inputs.crate }} v${{ inputs.version }}"
           fi
 
-  build-and-sign:
-    permissions:
-      id-token: write
-    needs:
-      - pre-release
-    strategy:
-      matrix:
-        arch: ["x86_64", "aarch64"]
-        include: 
-          - ${{ needs.pre-release.outputs }}
-    uses: ./.github/workflows/action-build.yml
-    with:
-      os: "ubuntu-22.04"
-      runtime: ${{ matrix.runtime }}
-      target: "${{ matrix.arch }}-unknown-linux-musl"
-      slug: "${{ matrix.arch }}-linux-musl"
-      arch: ${{ matrix.arch }}
-      sign: true
+          git commit --allow-empty -a -F-<<EOF
+          $TITLE
 
-  release:
-    permissions:
-      contents: write
-    needs:
-      - pre-release
-      - build-and-sign
-    strategy:
-      matrix:
-        os: ["ubuntu-latest"]
-        include: 
-          - ${{ needs.pre-release.outputs }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Matrix description
-        run: |
-          echo "::notice::Running job with dry_run: '${{ inputs.dry_run }}', crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
-      - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-      - name: Download artifacts
-        if: ${{ matrix.is_shim == 'true' }}
-        uses: actions/download-artifact@master
-        with:
-          path: release
-      - name: Cargo publish
-        if: ${{ matrix.is_shim  != 'true' }}
-        run: cargo publish ${{ inputs.dry_run && '--dry-run' || '' }} --package ${{ matrix.crate }} --verbose --locked
+          [automatically-tag-and-release-this-commit]
+          EOF
+
+          git push origin HEAD:ci/release-${{ inputs.crate }}-${{ inputs.version }}
+          
+          echo "PR_HEAD=ci/release-${{ inputs.crate }}-${{ inputs.version }}" >> $GITHUB_ENV
+          echo "PR_TITLE=$TITLE" >> $GITHUB_ENV
+          echo "PR_BASE=main" >> $GITHUB_ENV
+          cat > pr-body <<-EOF
+          This is an automated pull request from CI to release
+          ${{ inputs.crate }} v${{ inputs.version }} when merged. The commit
+          message for this PR has a marker that is detected by CI to create
+          tags and publish crate artifacts.
+
+          When first opened this PR will not have CI run because it is generated
+          by a bot. A maintainer should close this PR and then reopen it to
+          trigger CI to execute which will then enable merging this PR.
+          EOF
+      - name: Make a PR
+        run: gh pr create -B "$PR_BASE" -H "$PR_HEAD" --title "$PR_TITLE" --body "$(cat ./pr-body)"
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
-      - name: Tag the the release
-        if: ${{ !inputs.dry_run }}
-        run: |
-          git tag "${{matrix.crate}}/v${{matrix.version}}"
-          git push origin "${{matrix.crate}}/v${{matrix.version}}"
-      - name: Create release
-        if: ${{ !inputs.dry_run }}
-        run: |
-          gh release create 'refs/tags/${{matrix.crate}}/v${{matrix.version}}' --generate-notes
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_NAME: ${{ matrix.crate }}/v${{ matrix.version }}
-      - name: Upload release artifacts
-        if: ${{ matrix.is_shim == 'true' && !inputs.dry_run }}
-        run: |
-          for i in release/*/*; do
-            gh release upload ${RELEASE_NAME} $i
-          done
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_NAME: ${{ matrix.crate }}/v${{ matrix.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
       - name: Update crate version and make a PR
-        if: ${{ !inputs.dry_run }}
         run: |
           # replace the version inline in the Cargo.toml
           set -ex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,24 +45,13 @@ jobs:
           echo "::error::This workflow should not be triggered with workflow_dispatch on a branch other than main"
           exit 1
       - uses: actions/checkout@v4
-      - name: substring runtime
-        id: runtime_sub
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const crate = '${{ inputs.crate }}';
-            const non_shim_crates = ['wasm', 'wasm-test-modules', 'oci-tar-builder'];
-            if non_shim_crates.includes(runtime) {
-              core.setOutput('runtime', 'common');
-              core.setOutput('is_shim', false)
-            } else {
-              const runtime = crate.replace(/^containerd-shim-/, '');
-              core.setOutput('runtime', runtime);
-              core.setOutput('is_shim', true);
-            }
+      - name: parse crate
+        id: parse_crate
+        run: |
+          ./scripts/parse-crate.sh ${{ steps.parse.outputs.crate }} >> $GITHUB_OUTPUT
       ### If we are releasing a crate rather than producing a bin, check for crates.io access
       - name: Check crates.io ownership
-        if: ${{ steps.runtime_sub.outputs.is_shim != 'true' }}
+        if: steps.parse_crate.outputs.is_crate == 'true'
         run: |
           cargo owner --list ${{ inputs.crate }} | grep github:containerd:runwasi-committers || \
           cargo owner --add github:containerd:runwasi-committers ${{ inputs.crate }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,6 @@ jobs:
   pre-release:
     name: pre-release checks
     runs-on: "ubuntu-latest"
-    outputs:
-      crate: ${{ inputs.crate }}
-      runtime: ${{ steps.runtime_sub.outputs.runtime }}
-      version: ${{ inputs.version }}
-      ### is_shim is a string, not a boolean, so use: is_shim == 'true'
-      is_shim: ${{ steps.runtime_sub.outputs.is_shim }}
     steps:
       - name: Fail if branch is not main
         if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main'
@@ -51,15 +45,6 @@ jobs:
           echo "::error::This workflow should not be triggered with workflow_dispatch on a branch other than main"
           exit 1
       - uses: actions/checkout@v4
-      ### Determine the name of the runtime and if it is a binary release or crates.io
-      - name: verify version input
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const version = '${{ inputs.version }}';
-            if(!version.match(/^[0-9]+.[0-9]+.*/)) {
-              core.setFailed(`The version '${version}' does not match regex /^[0-9]+.[0-9]+.*/.`);
-            }
       - name: substring runtime
         id: runtime_sub
         uses: actions/github-script@v7

--- a/main.log
+++ b/main.log
@@ -1,7 +1,0 @@
-commit 2c0eaa5efdc37064480bc0400027eaf54054f137
-Author: jiaxiao zhou <jiazho@microsoft.com>
-Date:   Wed Apr 3 23:35:13 2024 +0000
-
-    remove permission for write contents in build action
-    
-    Signed-off-by: jiaxiao zhou <jiazho@microsoft.com>

--- a/main.log
+++ b/main.log
@@ -1,0 +1,7 @@
+commit 2c0eaa5efdc37064480bc0400027eaf54054f137
+Author: jiaxiao zhou <jiazho@microsoft.com>
+Date:   Wed Apr 3 23:35:13 2024 +0000
+
+    remove permission for write contents in build action
+    
+    Signed-off-by: jiaxiao zhou <jiazho@microsoft.com>

--- a/scripts/parse-crate.sh
+++ b/scripts/parse-crate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+crate_name=$1
+is_binary="false"
+is_crate="false"
+
+# Define ground truth for binary crates
+declare -A binary_map=(
+    ["oci-tar-builder"]=true
+    ["containerd-shim-wasmtime"]=true
+    ["containerd-shim-wasmer"]=true
+    ["containerd-shim-wasmedge"]=true
+)
+
+# Define ground truth for crate items
+declare -A crate_map=(
+    ["oci-tar-builder"]=true
+    ["containerd-shim-wasm"]=true
+    ["containerd-shim-wasm-test-modules"]=true
+)
+
+# Check and assign based on the binary_map
+if [[ "${binary_map[$crate_name]}" == "true" ]]; then
+    is_binary="true"
+fi
+
+# Check and assign based on the crate_map
+if [[ "${crate_map[$crate_name]}" == "true" ]]; then
+    is_crate="true"
+fi
+
+echo "is_binary=$is_binary"
+echo "is_crate=$is_crate"

--- a/scripts/parse-crate.sh
+++ b/scripts/parse-crate.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 
-crate_name=$1
+if [ -z "$1" ]; then
+    echo "Usage: $0 <path-to-main.log>"
+    exit 1
+fi
+
+log_file="$1"
+
+# extract crate and version from log file
+dry_run=false
+crate=$(grep 'Release ' "$log_file" | sed 's/.*Release \([a-zA-Z0-9_-]*\).*/\1/')
+version=$(grep 'Release ' "$log_file" | sed 's/.* v\(.*\)/\1/')
+if grep -q '\[dry-run\]' "$log_file"; then
+    dry_run=true
+fi
+
 is_binary="false"
 is_crate="false"
 
@@ -20,14 +34,27 @@ declare -A crate_map=(
 )
 
 # Check and assign based on the binary_map
-if [[ "${binary_map[$crate_name]}" == "true" ]]; then
+if [[ "${binary_map[$crate]}" == "true" ]]; then
     is_binary="true"
 fi
 
 # Check and assign based on the crate_map
-if [[ "${crate_map[$crate_name]}" == "true" ]]; then
+if [[ "${crate_map[$crate]}" == "true" ]]; then
     is_crate="true"
 fi
 
+# Runtime logic
+declare -a non_shim_crates=("containerd-shim-wasm" "containerd-shim-wasm-test-modules" "oci-tar-builder")
+runtime=""
+
+if printf '%s\n' "${non_shim_crates[@]}" | grep -q "^$crate$"; then
+    runtime="common"
+else
+    runtime="${crate#containerd-shim-}"
+fi
+echo "dry_run=$dry_run"
+echo "crate=$crate"
+echo "version=$version"
 echo "is_binary=$is_binary"
 echo "is_crate=$is_crate"
+echo "runtime=$runtime"


### PR DESCRIPTION
this PR automates the version bump process to
ask the bot to create a PR to bump the respective
crate's version to the given one on behalf of humans.

the PR created by the bot contains magic message that
will be parsed by another workflow `publish` which triggers
on merge to the main branch.

The `publish` workflow parses the commit message to get
crate, version and dry-run information to be able to
publish the crate, release binary and push tags.

the motivation for this commit is to further simplify the
release process

builds on top of #548 
