### PR TITLE
ci(*): update checkout to v4 and add gh action to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: cargo
     directory: "/"
     schedule:

--- a/.github/workflows/action-fmt.yml
+++ b/.github/workflows/action-fmt.yml
@@ -17,7 +17,7 @@ jobs:
     name: lint on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy

--- a/.github/workflows/action-test-image.yml
+++ b/.github/workflows/action-test-image.yml
@@ -14,7 +14,7 @@ jobs:
     name: build test ${{ inputs.image }}
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         run: make dist/${{ inputs.image }}.tar
       - name: Upload artifacts

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -17,7 +17,7 @@ jobs:
     name: e2e k3s test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup build env
         run: ./scripts/setup-linux.sh
         shell: bash

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -23,7 +23,7 @@ jobs:
     name: e2e kind test on ${{ inputs.os }} with ${{ inputs.image }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup build env
         run: ./scripts/setup-linux.sh
         shell: bash

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -17,7 +17,7 @@ jobs:
     name: smoke test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup build env
         run: ./scripts/setup-linux.sh
         shell: bash


### PR DESCRIPTION
this commit updates the checkout workflow to v4 and add a new rule to dependabot to bump github action versions

closes #558  #557 