### PR TITLE
feat(tracing): add tracing instruments to containerd-shim-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
  "ttrpc",
  "ttrpc-codegen",
  "wasmparser 0.206.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ ttrpc = "0.8.0"
 wat = "1.206"
 windows-sys = "0.52"
 serial_test = "2"
+tracing = "0.1"
 
 [profile.release]
 panic = "abort"

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -36,6 +36,7 @@ wasmparser = "0.206.0"
 tokio-stream = { version = "0.1" }
 prost-types = "0.12" # should match version in containerd-shim
 sha256 = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 caps = "0.5"

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 
 use containerd_shim::{parse, run, Config};
+use tracing::{instrument, Span};
 use ttrpc::Server;
 
 use crate::sandbox::manager::Shim;
@@ -36,6 +37,7 @@ macro_rules! revision {
     };
 }
 
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 pub fn shim_main<'a, I>(
     name: &str,
     version: &str,

--- a/crates/containerd-shim-wasm/src/sandbox/containerd/client.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/containerd/client.rs
@@ -24,6 +24,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Code, Request};
+use tracing::{instrument, Span};
 
 use super::lease::LeaseGuard;
 use crate::container::Engine;
@@ -53,6 +54,7 @@ pub(crate) struct WriteContent {
 // sync wrapper implementation from https://tokio.rs/tokio/topics/bridging
 impl Client {
     // wrapper around connection that will establish a connection and create a client
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     pub fn connect(
         address: impl AsRef<Path> + ToString,
         namespace: impl ToString,
@@ -74,6 +76,7 @@ impl Client {
     }
 
     // wrapper around read that will read the entire content file
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn read_content(&self, digest: impl ToString) -> Result<Vec<u8>> {
         self.rt.block_on(async {
             let req = ReadContentRequest {
@@ -95,6 +98,7 @@ impl Client {
 
     // used in tests to clean up content
     #[allow(dead_code)]
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn delete_content(&self, digest: impl ToString) -> Result<()> {
         self.rt.block_on(async {
             let req = DeleteContentRequest {
@@ -110,6 +114,7 @@ impl Client {
     }
 
     // wrapper around lease that will create a lease and return a guard that will delete the lease when dropped
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn lease(&self, reference: String) -> Result<LeaseGuard> {
         self.rt.block_on(async {
             let mut lease_labels = HashMap::new();
@@ -141,6 +146,7 @@ impl Client {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn save_content(
         &self,
         data: Vec<u8>,
@@ -266,6 +272,7 @@ impl Client {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn get_info(&self, content_digest: &str) -> Result<Info> {
         self.rt.block_on(async {
             let req = InfoRequest {
@@ -288,6 +295,7 @@ impl Client {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn update_info(&self, info: Info) -> Result<Info> {
         self.rt.block_on(async {
             let req = UpdateRequest {
@@ -313,6 +321,7 @@ impl Client {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn get_image(&self, image_name: impl ToString) -> Result<Image> {
         self.rt.block_on(async {
             let name = image_name.to_string();
@@ -334,6 +343,7 @@ impl Client {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn extract_image_content_sha(&self, image: &Image) -> Result<String> {
         let digest = image
             .target
@@ -349,6 +359,7 @@ impl Client {
         Ok(digest)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn get_container(&self, container_name: impl ToString) -> Result<Container> {
         self.rt.block_on(async {
             let id = container_name.to_string();
@@ -370,6 +381,7 @@ impl Client {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn get_image_manifest_and_digest(&self, image_name: &str) -> Result<(ImageManifest, String)> {
         let image = self.get_image(image_name)?;
         let image_digest = self.extract_image_content_sha(&image)?;
@@ -380,6 +392,7 @@ impl Client {
     // load module will query the containerd store to find an image that has an OS of type 'wasm'
     // If found it continues to parse the manifest and return the layers that contains the WASM modules
     // and possibly other configuration layers.
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     pub fn load_modules<T: Engine>(
         &self,
         containerd_id: impl ToString,
@@ -510,6 +523,7 @@ impl Client {
         Ok((layers, platform))
     }
 
+    #[instrument(skip_all, parent = Span::current(), level = "Info")]
     fn read_wasm_layer(
         &self,
         original_config: &oci_spec::image::Descriptor,

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use tracing::{instrument, Span};
 
 use super::error::Error;
 use super::sync::WaitableCell;
@@ -136,6 +137,7 @@ pub trait Instance: 'static {
 
     /// Waits for the instance to finish and retunrs its exit code
     /// This is a blocking call.
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn wait(&self) -> (u32, DateTime<Utc>) {
         self.wait_timeout(None).unwrap()
     }

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -5,12 +5,14 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use tracing::{instrument, Span};
 
 use super::Error;
 
 /// Return the root path for the instance.
 ///
 /// The root path is the path to the directory containing the container's state.
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 pub fn get_instance_root<P: AsRef<Path>>(
     root_path: P,
     instance_id: &str,
@@ -25,6 +27,7 @@ pub fn get_instance_root<P: AsRef<Path>>(
 /// Checks if the container exists.
 ///
 /// The root path is the path to the directory containing the container's state.
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 pub fn instance_exists<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<bool> {
     let instance_root = construct_instance_root(root_path, container_id)?;
     Ok(instance_root.exists())
@@ -35,6 +38,7 @@ struct Options {
     root: Option<PathBuf>,
 }
 
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 pub fn determine_rootdir(
     bundle: impl AsRef<Path>,
     namespace: &str,
@@ -53,6 +57,7 @@ pub fn determine_rootdir(
     Ok(path)
 }
 
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 fn construct_instance_root<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<PathBuf> {
     let root_path = root_path.as_ref().canonicalize().with_context(|| {
         format!(

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use tracing::{instrument, Span};
 
 use crate::sandbox::instance::Nop;
 use crate::sandbox::shim::instance_option::InstanceOption;
@@ -16,6 +17,7 @@ pub(super) struct InstanceData<T: Instance> {
 }
 
 impl<T: Instance> InstanceData<T> {
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn new_instance(id: impl AsRef<str>, cfg: InstanceConfig<T::Engine>) -> Result<Self> {
         let id = id.as_ref().to_string();
         let instance = InstanceOption::Instance(T::new(id, Some(&cfg))?);
@@ -27,6 +29,7 @@ impl<T: Instance> InstanceData<T> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn new_base(id: impl AsRef<str>, cfg: InstanceConfig<T::Engine>) -> Result<Self> {
         let id = id.as_ref().to_string();
         let instance = InstanceOption::Nop(Nop::new(id, None)?);
@@ -38,14 +41,17 @@ impl<T: Instance> InstanceData<T> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn pid(&self) -> Option<u32> {
         self.pid.get().copied()
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn config(&self) -> &InstanceConfig<T::Engine> {
         &self.cfg
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn start(&self) -> Result<u32> {
         let mut s = self.state.write().unwrap();
         s.start()?;
@@ -65,6 +71,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn kill(&self, signal: u32) -> Result<()> {
         let mut s = self.state.write().unwrap();
         s.kill()?;
@@ -72,6 +79,7 @@ impl<T: Instance> InstanceData<T> {
         self.instance.kill(signal)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn delete(&self) -> Result<()> {
         let mut s = self.state.write().unwrap();
         s.delete()?;
@@ -86,6 +94,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn wait(&self) -> (u32, DateTime<Utc>) {
         let res = self.instance.wait();
         let mut s = self.state.write().unwrap();
@@ -93,6 +102,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn wait_timeout(&self, t: impl Into<Option<Duration>>) -> Option<(u32, DateTime<Utc>)> {
         let res = self.instance.wait_timeout(t);
         if res.is_some() {

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_option.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_option.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use tracing::{instrument, Span};
 
 use crate::sandbox::instance::Nop;
 use crate::sandbox::{Instance, InstanceConfig, Result};
@@ -13,11 +14,13 @@ pub(super) enum InstanceOption<I: Instance> {
 impl<I: Instance> Instance for InstanceOption<I> {
     type Engine = ();
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn new(_id: String, _cfg: Option<&InstanceConfig<Self::Engine>>) -> Result<Self> {
         // this is never called
         unimplemented!();
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn start(&self) -> Result<u32> {
         match self {
             Self::Instance(i) => i.start(),
@@ -25,6 +28,7 @@ impl<I: Instance> Instance for InstanceOption<I> {
         }
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn kill(&self, signal: u32) -> Result<()> {
         match self {
             Self::Instance(i) => i.kill(signal),
@@ -32,6 +36,7 @@ impl<I: Instance> Instance for InstanceOption<I> {
         }
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn delete(&self) -> Result<()> {
         match self {
             Self::Instance(i) => i.delete(),
@@ -39,6 +44,7 @@ impl<I: Instance> Instance for InstanceOption<I> {
         }
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn wait_timeout(&self, t: impl Into<Option<Duration>>) -> Option<(u32, DateTime<Utc>)> {
         match self {
             Self::Instance(i) => i.wait_timeout(t),

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
@@ -21,6 +21,7 @@ use containerd_shim::util::IntoOption;
 use containerd_shim::{DeleteResponse, ExitSignal, TtrpcContext, TtrpcResult};
 use log::debug;
 use oci_spec::runtime::Spec;
+use tracing::{instrument, Span};
 
 use crate::sandbox::instance::{Instance, InstanceConfig};
 use crate::sandbox::shim::events::{EventSender, RemoteEventSender, ToTimestamp};
@@ -46,6 +47,7 @@ pub struct Local<T: Instance + Send + Sync, E: EventSender = RemoteEventSender> 
 
 impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
     /// Creates a new local task service.
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn new(
         engine: T::Engine,
         events: E,
@@ -66,19 +68,23 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         }
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub(super) fn get_instance(&self, id: &str) -> Result<Arc<InstanceData<T>>> {
         let instance = self.instances.read().unwrap().get(id).cloned();
         instance.ok_or_else(|| Error::NotFound(id.to_string()))
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn has_instance(&self, id: &str) -> bool {
         self.instances.read().unwrap().contains_key(id)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn is_empty(&self) -> bool {
         self.instances.read().unwrap().is_empty()
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn instance_config(&self) -> InstanceConfig<T::Engine> {
         InstanceConfig::new(
             self.engine.clone(),
@@ -88,6 +94,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
     }
 }
 
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 fn is_cri_container(spec: &Spec) -> bool {
     spec.annotations()
         .as_ref()
@@ -96,6 +103,7 @@ fn is_cri_container(spec: &Spec) -> bool {
 
 // These are the same functions as in Task, but without the TtrcpContext, which is useful for testing
 impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_create(&self, req: CreateTaskRequest) -> Result<CreateTaskResponse> {
         if !req.checkpoint().is_empty() || !req.parent_checkpoint().is_empty() {
             return Err(ShimError::Unimplemented("checkpoint is not supported".to_string()).into());
@@ -187,6 +195,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_start(&self, req: StartRequest) -> Result<StartResponse> {
         if req.exec_id().is_empty().not() {
             return Err(ShimError::Unimplemented("exec is not supported".to_string()).into());
@@ -229,6 +238,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_kill(&self, req: KillRequest) -> Result<Empty> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -237,6 +247,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         Ok(Empty::new())
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_delete(&self, req: DeleteRequest) -> Result<DeleteResponse> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -268,6 +279,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_wait(&self, req: WaitRequest) -> Result<WaitResponse> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -276,6 +288,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         let i = self.get_instance(req.id())?;
         let (exit_code, timestamp) = i.wait();
 
+        debug!("wait finishes");
         Ok(WaitResponse {
             exit_status: exit_code,
             exited_at: Some(timestamp.to_timestamp()).into(),
@@ -283,6 +296,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_state(&self, req: StateRequest) -> Result<StateResponse> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -314,6 +328,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn task_stats(&self, req: StatsRequest) -> Result<StatsResponse> {
         let i = self.get_instance(req.id())?;
         let pid = i
@@ -331,6 +346,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
 
 impl<T: Instance + Sync + Send> SandboxService for Local<T, RemoteEventSender> {
     type Instance = T;
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn new(
         namespace: String,
         containerd_address: String,
@@ -345,31 +361,37 @@ impl<T: Instance + Sync + Send> SandboxService for Local<T, RemoteEventSender> {
 }
 
 impl<T: Instance + Sync + Send, E: EventSender> Task for Local<T, E> {
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn create(&self, _: &TtrpcContext, req: CreateTaskRequest) -> TtrpcResult<CreateTaskResponse> {
         debug!("create: {:?}", req);
         Ok(self.task_create(req)?)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn start(&self, _: &TtrpcContext, req: StartRequest) -> TtrpcResult<StartResponse> {
         debug!("start: {:?}", req);
         Ok(self.task_start(req)?)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn kill(&self, _: &TtrpcContext, req: KillRequest) -> TtrpcResult<Empty> {
         debug!("kill: {:?}", req);
         Ok(self.task_kill(req)?)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn delete(&self, _: &TtrpcContext, req: DeleteRequest) -> TtrpcResult<DeleteResponse> {
         debug!("delete: {:?}", req);
         Ok(self.task_delete(req)?)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn wait(&self, _: &TtrpcContext, req: WaitRequest) -> TtrpcResult<WaitResponse> {
         debug!("wait: {:?}", req);
         Ok(self.task_wait(req)?)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn connect(&self, _: &TtrpcContext, req: ConnectRequest) -> TtrpcResult<ConnectResponse> {
         debug!("connect: {:?}", req);
         let i = self.get_instance(req.id())?;
@@ -382,11 +404,13 @@ impl<T: Instance + Sync + Send, E: EventSender> Task for Local<T, E> {
         })
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn state(&self, _: &TtrpcContext, req: StateRequest) -> TtrpcResult<StateResponse> {
         debug!("state: {:?}", req);
         Ok(self.task_state(req)?)
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn shutdown(&self, _: &TtrpcContext, _: ShutdownRequest) -> TtrpcResult<Empty> {
         debug!("shutdown");
         if self.is_empty() {
@@ -395,8 +419,9 @@ impl<T: Instance + Sync + Send, E: EventSender> Task for Local<T, E> {
         Ok(Empty::new())
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn stats(&self, _ctx: &TtrpcContext, req: StatsRequest) -> TtrpcResult<StatsResponse> {
-        log::info!("stats: {:?}", req);
+        debug!("stats: {:?}", req);
         Ok(self.task_stats(req)?)
     }
 }

--- a/crates/containerd-shim-wasm/src/sandbox/shim/task_state.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/task_state.rs
@@ -1,3 +1,5 @@
+use tracing::{instrument, Span};
+
 use crate::sandbox::Error::FailedPrecondition;
 use crate::sandbox::Result;
 
@@ -11,6 +13,7 @@ pub(super) enum TaskState {
 }
 
 impl TaskState {
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn start(&mut self) -> Result<()> {
         *self = match self {
             Self::Created => Ok(Self::Starting),
@@ -19,6 +22,7 @@ impl TaskState {
         Ok(())
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn kill(&mut self) -> Result<()> {
         *self = match self {
             Self::Started => Ok(Self::Started),
@@ -27,6 +31,7 @@ impl TaskState {
         Ok(())
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn delete(&mut self) -> Result<()> {
         *self = match self {
             Self::Created | Self::Exited => Ok(Self::Deleting),
@@ -35,6 +40,7 @@ impl TaskState {
         Ok(())
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn started(&mut self) -> Result<()> {
         *self = match self {
             Self::Starting => Ok(Self::Started),
@@ -43,6 +49,7 @@ impl TaskState {
         Ok(())
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     pub fn stop(&mut self) -> Result<()> {
         *self = match self {
             Self::Started | Self::Starting => Ok(Self::Exited),

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -12,6 +12,7 @@ use libcontainer::workload::{
 };
 use oci_spec::image::Platform;
 use oci_spec::runtime::Spec;
+use tracing::{instrument, Span};
 
 use crate::container::{Engine, PathResolve, RuntimeContext, Source, Stdio, WasiContext};
 use crate::sandbox::oci::WasmLayer;
@@ -33,6 +34,7 @@ pub(crate) struct Executor<E: Engine> {
 }
 
 impl<E: Engine> LibcontainerExecutor for Executor<E> {
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError> {
         // We can handle linux container. We delegate wasm container to the engine.
         match self.inner(spec) {
@@ -41,6 +43,7 @@ impl<E: Engine> LibcontainerExecutor for Executor<E> {
         }
     }
 
+    #[instrument(skip_all, parent = Span::current(), level= "Info")]
     fn exec(&self, spec: &Spec) -> Result<(), LibcontainerExecutorError> {
         // If it looks like a linux container, run it as a linux container.
         // Otherwise, run it as a wasm container

--- a/crates/containerd-shim-wasm/src/sys/unix/metrics.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/metrics.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use containerd_shim::cgroup::collect_metrics;
 use containerd_shim::util::convert_to_any;
 use protobuf::well_known_types::any::Any;
+use tracing::{instrument, Span};
 
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 pub fn get_metrics(pid: u32) -> Result<Any> {
     let metrics = collect_metrics(pid)?;
 

--- a/crates/containerd-shim-wasm/src/sys/unix/networking.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/networking.rs
@@ -5,7 +5,9 @@ use containerd_shim::error::Error as ShimError;
 use containerd_shim::{self as shim};
 use nix::sched::{setns, unshare, CloneFlags};
 use oci_spec::runtime;
+use tracing::{instrument, Span};
 
+#[instrument(skip_all, parent = Span::current(), level= "Info")]
 pub fn setup_namespaces(spec: &runtime::Spec) -> Result<()> {
     let namespaces = spec
         .linux()


### PR DESCRIPTION
this commit adds tracing instrument macros to functions in the containerd-shim-wasm crate to capture spans of each function including its parameters and results.

these spans can be in turn be collected using tracing-opentelemetry and opentelemetry SDK at the shim binary level and output to collectors like Jeager endpoint.

Demo: https://github.com/Mossaka/runwasi/tree/otel-wasmtime