### PR TITLE
feat(shim): change the current dir back to bundle path

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/shim/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/cli.rs
@@ -1,4 +1,4 @@
-use std::env::current_dir;
+use std::env::{current_dir, set_current_dir};
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -64,7 +64,14 @@ where
     }
 
     fn wait(&mut self) {
+        let cwd = current_dir().unwrap_or_else(|e| {
+            log::error!("failed to get current working directory: {}", e);
+            std::path::PathBuf::new()
+        });
         self.exit.wait();
+        set_current_dir(cwd).unwrap_or_else(|e| {
+            log::error!("failed to restore current working directory: {}", e);
+        });
     }
 
     fn create_task_service(&self, publisher: RemotePublisher) -> Self::T {


### PR DESCRIPTION
This commit changes the current dir for the shim process back to the bundle path (e.g. `/run/containerd/io.containerd.runtime.v2.task/<ns>/<id>`) after `shim::wait()` finishes.

The motivation for this change is that the `create` request handled by youki's libcontainer will change the current dir to container path (e.g. `/run/containerd/wasmtime/<ns>/<id>`), this path does not contain the `address` file for getting the shim socket address that needs to be deleted by the ttrpc server closes.

So in order to properly delete the socket path, the current directory used by the shim crate has to be the bundle path.

## Perf test regarding the startup of the process BEFORE the change 
- Mean: 1704 milliseconds
- Median: 1693 milliseconds
- Mode: 1831 milliseconds
- Standard Deviation: 48.64 milliseconds
- Minimum Time: 1653 milliseconds
- Maximum Time: 1831 milliseconds

As reported by @rperezvaz at https://cloud-native.slack.com/archives/C04LTPB6Z0V/p1705059273058979

## Perf test regarding the startup of the process AFTER the change
- Mean: 447 milliseconds
- Median: 447 milliseconds
- Mode: 466 milliseconds
- Standard Deviation: 10.63 milliseconds
- Minimum Time: 434 milliseconds
- Maximum Time: 466 milliseconds

## Explanation

The primary reason for the huge start-up time reduction is due to that the shim socket has not been properly cleaned up after the shim get closes and so every time the shim starts, it hangs for 1 whole second to try to reconnect with an existing socket address. See more https://github.com/containerd/rust-extensions/issues/263 and https://github.com/spinkube/containerd-shim-spin/issues/41#issuecomment-2073562299) 

## bpftrace (unchanged)
```
PID 3543236 (containerd): Changing directory to /run/containerd/io.containerd.runtime.v2.task/default/testwasm
Process started: /usr/local/bin/containerd-shim-wasmtime-v1 PID: 3543236
PID 3543245 (containerd-shim): Changing directory to /run/containerd/io.containerd.runtime.v2.task/default/testwasm
Process started: /usr/local/bin/containerd-shim-wasmtime-v1 PID: 3543245
PID 3543245 (client_handler): Changing directory to /run/containerd/wasmtime/default/testwasm
PID 3543245 (client_handler): Changing directory to /run/containerd/wasmtime/default/testwasm
PID 3543245 (client_handler): Changing directory to /run/containerd/wasmtime/default/testwasm
PID 3543271 (youki:[2:INIT]): File unlink in target directory: /run/containerd/io.containerd.runtime.v2.task/default/testwasm/..
PID 3543245 (client_handler): Changing directory to /run/containerd/wasmtime/default/testwasm
PID 3543245 (client_handler): Changing directory to /run/containerd/wasmtime/default/testwasm
PID 3543245 (client_handler): Changing directory to /run/containerd/wasmtime/default/testwasm
PID 3543245 (client_handler): File unlinkat in target directory: /run/containerd/wasmtime/default/testwasm
Process started: /usr/local/bin/containerd-shim-wasmtime-v1 PID: 3543363
PID 569984 (containerd): File unlinkat in target directory: /run/containerd/io.containerd.runtime.v2.task/default/testwasm/..
PID 569984 (containerd): File unlinkat in target directory: /run/containerd/io.containerd.runtime.v2.task/default/testwasm/..
PID 569984 (containerd): File unlinkat in target directory: /run/containerd/io.containerd.runtime.v2.task/default/.testwasm..
PID 569984 (containerd): File unlinkat in target directory: /run/containerd/io.containerd.runtime.v2.task/default/.testwasm..
PID 569984 (containerd): File unlinkat in target directory: .testwasm
PID 569984 (containerd): File unlinkat in target directory: .testwasm
PID 569984 (containerd): File unlinkat in target directory: /run/containerd/io.containerd.runtime.v2.task/default/testwasm/..
PID 569984 (containerd): File unlinkat in target directory: /run/containerd/io.containerd.runtime.v2.task/default/testwasm/..
PID 3543224 (ctr): File unlinkat in target directory: testwasm-stderr
PID 3543224 (ctr): File unlinkat in target directory: testwasm-stdout
PID 3543224 (ctr): File unlinkat in target directory: testwasm-stdin
```

Notice how `libcontainer` handler changes the process's current directory to `/run/containerd/wasmtime/default/testwasm`, and at the end of `delete` request, `libcontainer` cleans up this path, so after the `shim::wait()`, the address path is not longer able to be found by using the current directory because it no longer exists!