### PR TITLE
Makefile: Define `RUSTC` to avoid "rustc: not found" during `sudo make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,12 @@ LN ?= ln -sf
 TEST_IMG_NAME ?= wasmtest:latest
 RUNTIMES ?= wasmedge wasmtime wasmer
 CONTAINERD_NAMESPACE ?= default
+RUSTC ?= rustc
 
 # We have a bit of fancy logic here to determine the target 
 # since we support building for gnu and musl
 # TARGET must evenutually match one of the values in the cross.toml
-HOST_TARGET = $(shell rustc --version -v | sed -En 's/host: (.*)/\1/p')
+HOST_TARGET = $(shell $(RUSTC) --version -v | sed -En 's/host: (.*)/\1/p')
 
 # if TARGET is not set and we are using cross
 # default to musl to facilitate easier use shim on other distros becuase of the static build


### PR DESCRIPTION
Through the [Demo](https://github.com/containerd/runwasi/blob/73df3507171080f5146e5464f29f2aca29dd9ce6/README.md?plain=1#L199) in the README, the following error happened.

```bash
# Make sure rustc is installed.
ls -la $(which rustc)
-rwxr-xr-x 14 ubuntu ubuntu 15428432 May  4 11:05 /home/ubuntu/.cargo/bin/rustc
rustc --version
rustc 1.75.0 (82e1608df 2023-12-21)

# Cannot run rustc as root.
sudo rustc --version
sudo: rustc: command not found

sudo make --trace install
/bin/sh: 1: rustc: not found
/bin/sh: 1: rustc: not found
/bin/sh: 1: rustc: not found
/bin/sh: 1: rustc: not found
Makefile:76: target 'build-wasmedge' does not exist
cargo build --target= --target-dir=./target/ -p containerd-shim-wasmedge
/bin/sh: 1: rustc: not found
/bin/sh: 1: rustc: not found
/bin/sh: 1: rustc: not found
make: cargo: No such file or directory
make: *** [Makefile:76: build-wasmedge] Error 127
```

I would like to define `RUSTC` variable in Makefile, then run this command.

```bash
sudo CARGO=~/.cargo/bin/cargo RUSTC=~/.cargo/bin/rustc make --trace install
Makefile:76: target 'build-wasmedge' does not exist
/home/ubuntu/.cargo/bin/cargo build --target=x86_64-unknown-linux-gnu --target-dir=./target/ -p containerd-shim-wasmedge
    Updating crates.io index
  Downloaded anstream v0.6.11
  Downloaded cgroups-rs v0.3.4
  Downloaded async-stream v0.3.5
...skip...
Makefile:138: update target 'install-wasmer' due to: build-wasmer
mkdir -p /usr/local/bin
install ./target//x86_64-unknown-linux-gnu/debug/containerd-shim-wasmer-v1 /usr/local/bin/
ln -sf ./containerd-shim-wasmer-v1 /usr/local/bin/containerd-shim-wasmerd-v1
ln -sf ./containerd-shim-wasmer-v1 /usr/local/bin/containerd-wasmerd

# Make sure binaries exist in /usr/loca/bin/
ls -la /usr/local/bin/containerd*wasm*
-rwxr-xr-x 1 root root 410800840 May  5 00:02 /usr/local/bin/containerd-shim-wasmedge-v1
lrwxrwxrwx 1 root root        29 May  5 00:02 /usr/local/bin/containerd-shim-wasmedged-v1 -> ./containerd-shim-wasmedge-v1
-rwxr-xr-x 1 root root 618126120 May  5 00:05 /usr/local/bin/containerd-shim-wasmer-v1
lrwxrwxrwx 1 root root        27 May  5 00:05 /usr/local/bin/containerd-shim-wasmerd-v1 -> ./containerd-shim-wasmer-v1
-rwxr-xr-x 1 root root 581308584 May  5 00:03 /usr/local/bin/containerd-shim-wasmtime-v1
lrwxrwxrwx 1 root root        29 May  5 00:03 /usr/local/bin/containerd-shim-wasmtimed-v1 -> ./containerd-shim-wasmtime-v1
lrwxrwxrwx 1 root root        29 May  5 00:02 /usr/local/bin/containerd-wasmedged -> ./containerd-shim-wasmedge-v1
lrwxrwxrwx 1 root root        27 May  5 00:05 /usr/local/bin/containerd-wasmerd -> ./containerd-shim-wasmer-v1
lrwxrwxrwx 1 root root        29 May  5 00:03 /usr/local/bin/containerd-wasmtimed -> ./containerd-shim-wasmtime-v1
```
