### PR TITLE
release: batch-bump minor version of shims and core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "caps",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmedge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "containerd-shim",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasmtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "containerd-shim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0"
 cap-std = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 containerd-shim = "0.7.1"
-containerd-shim-wasm = { path = "crates/containerd-shim-wasm", version = "0.5.0" }
+containerd-shim-wasm = { path = "crates/containerd-shim-wasm", version = "0.6.0" }
 containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules", version = "0.4.0"}
 oci-tar-builder = { path = "crates/oci-tar-builder", version = "0.4.0" }
 crossbeam = { version = "0.8.4", default-features = false }

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd-shim-wasm"
 description = "Library for building containerd shims for wasm"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-wasmedge"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 
 [dependencies]

--- a/crates/containerd-shim-wasmer/Cargo.toml
+++ b/crates/containerd-shim-wasmer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-wasmer"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 
 [dependencies]

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "containerd-shim-wasmtime"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
#601 is a major improvement over the start up performance of the shims, and this PR bumps the minor change of the core crate and all shims as a preparation for new releases.