### PR TITLE
add wasm-mico-runtime shim implementation 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-22.04"]
-        runtime: ["common", "wasmtime", "wasmedge", "wasmer"]
+        runtime: ["common", "wasmtime", "wasmedge", "wasmer", "wamr"]
         libc: ["musl", "gnu"]
         arch: ["x86_64", "aarch64"]
     uses: ./.github/workflows/action-build.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest"]
-        runtime: ["common", "wasmtime", "wasmedge", "wasmer"]
+        runtime: ["common", "wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-build.yml
     with:
       os: ${{ matrix.os }}
@@ -78,7 +78,7 @@ jobs:
       matrix:
         # 20.04 uses cgroupv1, 22.04 uses cgroupv2
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-        runtime:  ["wasmtime", "wasmedge", "wasmer"]
+        runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-smoke.yml
     with:
       os: ${{ matrix.os }}
@@ -92,7 +92,7 @@ jobs:
       matrix:
         # 20.04 uses cgroupv1, 22.04 uses cgroupv2
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-        runtime: ["wasmtime", "wasmedge", "wasmer"]
+        runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-kind.yml
     with:
       os: ${{ matrix.os }}
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-22.04"]
-        runtime: ["wasmtime", "wasmedge", "wasmer"]
+        runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-kind.yml
     with:
       os: ${{ matrix.os }}
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04", "ubuntu-22.04"]
-        runtime: ["wasmtime", "wasmedge", "wasmer"]
+        runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-k3s.yml
     with:
       os: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377e4c0ba83e4431b10df45c1d4666f178ea9c552cac93e60c3a88bf32785923"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "ambient-authority"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,15 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-stream"
@@ -274,6 +292,28 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
@@ -284,12 +324,15 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
  "syn 2.0.63",
+ "which",
 ]
 
 [[package]]
@@ -323,6 +366,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "build-time"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1219c19fc29b7bfd74b7968b420aff5bc951cf517800176e795d6b2300dd382"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -364,6 +430,15 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ec6b951b160caa93cc0c7b209e5a3bff7aae9062213451ac99493cd844c239"
 dependencies = [
  "serde",
 ]
@@ -452,6 +527,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -635,6 +733,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "containerd-client"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +819,21 @@ dependencies = [
  "protobuf 3.2.0",
  "ttrpc",
  "ttrpc-codegen",
+]
+
+[[package]]
+name = "containerd-shim-wamr"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "containerd-shim",
+ "containerd-shim-wasm",
+ "log",
+ "oci-spec",
+ "serial_test",
+ "sha256",
+ "ttrpc",
+ "wamr-rust-sdk",
 ]
 
 [[package]]
@@ -1175,6 +1308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cvt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1577,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
+name = "embuild"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa4f198bb9152a55c0103efb83fa4edfcbb8625f4c9e94ae8ec8e23827c563"
+dependencies = [
+ "anyhow",
+ "bindgen 0.63.0",
+ "bitflags 1.3.2",
+ "cmake",
+ "filetime",
+ "globwalk",
+ "home",
+ "log",
+ "remove_dir_all",
+ "serde",
+ "serde_json",
+ "shlex",
+ "strum",
+ "tempfile",
+ "thiserror",
+ "which",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1686,26 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "esp-idf-sys"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e148f97c04ed3e9181a08bcdc9560a515aad939b0ba7f50a0022e294665e0af"
+dependencies = [
+ "anyhow",
+ "bindgen 0.63.0",
+ "build-time",
+ "cargo_metadata",
+ "const_format",
+ "embuild",
+ "envy",
+ "libc",
+ "regex",
+ "serde",
+ "strum",
+ "which",
 ]
 
 [[package]]
@@ -1621,6 +1816,20 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fs_at"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982f82cc75107eef84f417ad6c53ae89bf65b561937ca4a3b3b0fd04d0aa2425"
+dependencies = [
+ "aligned",
+ "cfg-if 1.0.0",
+ "cvt",
+ "libc",
+ "nix 0.26.4",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1829,6 +2038,30 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "go-flag"
@@ -2112,6 +2345,22 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2638,6 +2887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5831952a9476f2fed74b77d74182fa5ddc4d21c72ec45a333b250e3ed0272804"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +3111,12 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3471,6 +3735,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23895cfadc1917fed9c6ed76a8c2903615fa3704f7493ff82b364c6540acc02b"
+dependencies = [
+ "aligned",
+ "cfg-if 1.0.0",
+ "cvt",
+ "fs_at",
+ "lazy_static",
+ "libc",
+ "normpath",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4040,6 +4320,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "syn"
@@ -4844,6 +5146,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wamr-rust-sdk"
+version = "1.0.0"
+source = "git+https://github.com/bytecodealliance/wamr-rust-sdk?branch=main#10550adc902f49c868b281599d4e37fc7a6fcb6a"
+dependencies = [
+ "esp-idf-sys",
+ "wamr-sys",
+]
+
+[[package]]
+name = "wamr-sys"
+version = "1.0.0"
+source = "git+https://github.com/bytecodealliance/wamr-rust-sdk?branch=main#10550adc902f49c868b281599d4e37fc7a6fcb6a"
+dependencies = [
+ "bindgen 0.69.4",
+ "cc",
+ "cmake",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,7 +5332,7 @@ version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d8e2276d63bb6f0c36871218643d193d2da6da3db36c1c1227547da465ed58"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.4",
  "cfg-if 1.0.0",
  "cmake",
  "flate2",
@@ -5808,6 +6129,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5822,6 +6152,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5857,6 +6202,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -5875,6 +6226,12 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -5890,6 +6247,12 @@ name = "windows_i686_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5917,6 +6280,12 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -5935,6 +6304,12 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -5944,6 +6319,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5962,6 +6343,12 @@ name = "windows_x86_64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "wamr-rust-sdk"
 version = "1.0.0"
-source = "git+https://github.com/bytecodealliance/wamr-rust-sdk?branch=main#10550adc902f49c868b281599d4e37fc7a6fcb6a"
+source = "git+https://github.com/macko99/wamr-rust-sdk?branch=main#b89f685eba764fd784be103a7659fe19bb215482"
 dependencies = [
  "esp-idf-sys",
  "wamr-sys",
@@ -5157,7 +5157,7 @@ dependencies = [
 [[package]]
 name = "wamr-sys"
 version = "1.0.0"
-source = "git+https://github.com/bytecodealliance/wamr-rust-sdk?branch=main#10550adc902f49c868b281599d4e37fc7a6fcb6a"
+source = "git+https://github.com/macko99/wamr-rust-sdk?branch=main#b89f685eba764fd784be103a7659fe19bb215482"
 dependencies = [
  "bindgen 0.69.4",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/containerd-shim-wasmedge",
     "crates/containerd-shim-wasmtime",
     "crates/containerd-shim-wasmer",
+    "crates/containerd-shim-wamr",
     "benches/containerd-shim-benchmarks",
 ]
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INSTALL ?= install
 CARGO ?= cargo
 LN ?= ln -sf
 TEST_IMG_NAME ?= wasmtest:latest
-RUNTIMES ?= wasmedge wasmtime wasmer
+RUNTIMES ?= wasmedge wasmtime wasmer wamr
 CONTAINERD_NAMESPACE ?= default
 RUSTC ?= rustc
 

--- a/crates/containerd-shim-wamr/Cargo.toml
+++ b/crates/containerd-shim-wamr/Cargo.toml
@@ -13,7 +13,7 @@ oci-spec = { workspace = true, features = ["runtime"] }
 ttrpc = { workspace = true }
 sha256 = { workspace = true }
 
-wamr-rust-sdk = { git = "https://github.com/bytecodealliance/wamr-rust-sdk", branch = "main" }
+wamr-rust-sdk = { git = "https://github.com/macko99/wamr-rust-sdk", branch = "main" }
 
 [dev-dependencies]
 containerd-shim-wasm = { workspace = true, features = ["testing"] }

--- a/crates/containerd-shim-wamr/Cargo.toml
+++ b/crates/containerd-shim-wamr/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "containerd-shim-wamr"
+version.workspace = true
+edition.workspace = true
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { workspace = true }
+containerd-shim = { workspace = true }
+containerd-shim-wasm = { workspace = true }
+log = { workspace = true }
+oci-spec = { workspace = true, features = ["runtime"] }
+ttrpc = { workspace = true }
+sha256 = { workspace = true }
+
+wamr-rust-sdk = { git = "https://github.com/bytecodealliance/wamr-rust-sdk", branch = "main" }
+
+[dev-dependencies]
+containerd-shim-wasm = { workspace = true, features = ["testing"] }
+serial_test = { workspace = true }
+
+[[bin]]
+name = "containerd-shim-wamr-v1"
+path = "src/main.rs"

--- a/crates/containerd-shim-wamr/src/instance.rs
+++ b/crates/containerd-shim-wamr/src/instance.rs
@@ -1,0 +1,120 @@
+use anyhow::{Context, Result};
+use containerd_shim_wasm::container::{
+    Engine, Entrypoint, Instance, RuntimeContext, Stdio
+};
+use wamr_rust_sdk::function::Function;
+use wamr_rust_sdk::instance::Instance as WamrInstnace;
+use wamr_rust_sdk::module::Module;
+use wamr_rust_sdk::runtime::Runtime;
+
+// use wamr_rust_sdk::value::WasmValue;
+use wamr_rust_sdk::wasi_context::WasiCtxBuilder;
+// use wamr_rust_sdk::RuntimeError;
+
+pub type WamrInstance = Instance<WamrEngine>;
+
+pub struct WamrEngine {
+    runtime: Runtime,
+}
+
+unsafe impl Send for WamrEngine {}
+unsafe impl Sync for WamrEngine {}
+
+// TODO: wasmr_rust_sdk::runtime::Runtime should implement Clone
+
+impl Default for WamrEngine {
+    fn default() -> Self {
+        log::info!("Create a WAMR runtime");
+        let runtime = Runtime::new().unwrap();
+        Self { runtime }
+    }
+}
+
+impl Clone for WamrEngine {
+    fn clone(&self) -> Self {
+        log::info!("Clone a WAMR runtime");
+        let runtime = Runtime::new().unwrap();
+        Self { runtime }
+    }
+}
+
+impl Engine for WamrEngine {
+    fn name() -> &'static str {
+        "wamr"
+    }
+
+    fn run_wasi(&self, ctx: &impl RuntimeContext, stdio: Stdio) -> Result<i32> {
+        let args = ctx.args();
+        let envs: Vec<_> = std::env::vars().map(|(k, v)| format!("{k}={v}")).collect();
+        let Entrypoint {
+            source,
+            func,
+            arg0: _,
+            name,
+        } = ctx.entrypoint();
+
+        let wasm_bytes = source
+            .as_bytes()
+            .context("Failed to get bytes from source")?;
+
+        // log the source content
+        log::info!("Wasm source: {source:?}");
+        //and bytes
+        // log::info!("Wasm bytes: {wasm_bytes:?}");
+
+        log::info!("Create a WAMR module");
+
+        // TODO: error handling isn't ideal
+
+        let mut module = Module::from_buf(&self.runtime, &wasm_bytes, "main").map_err(|e| {
+            anyhow::Error::msg(format!("Failed to create module from bytes: {:?}", e))
+        })?;
+
+        log::info!("Create a WAMR vec_of_strs");
+
+        //log envs
+        log::info!("envs: {envs:?}");
+
+        let vec_of_strs: Vec<&str> = envs.iter().map(|s| s.as_str()).collect();
+
+        log::info!("Create a WAMR wasi_ctx");
+
+        let wasi_ctx = WasiCtxBuilder::new()
+        // .set_pre_open_path(vec!["/"], vec!["/"])
+        // .set_env_vars(vec_of_strs)
+        .build();
+
+        log::info!("Create a WAMR set_wasi_context");
+
+        module.set_wasi_context(wasi_ctx);
+        // module.set_wasi_arg_pre_open_path(vec![String::from("/")], vec![String::from("/")]);
+        // module.set_wasi_arg_env_vars(envs);
+
+        // TODO: no way to set args in wamr?
+        // TODO: no way to register a named module with bytes?
+
+        log::info!("Create a WAMR instance");
+
+        let instance = WamrInstnace::new(&self.runtime, &module, 1024 * 64)
+            .map_err(|e| anyhow::Error::msg(format!("Failed to create instance: {:?}", e)))?;
+
+        // TODO: bug: failed at line above saying: `thread signal env initialized failed`
+
+        log::info!("redirect stdio");
+        stdio.redirect()?;
+
+        log::info!("Running {func:?}");
+        let function = Function::find_export_func(&instance, "main")
+            .map_err(|e| anyhow::Error::msg(format!("Failed to find function: {:?}", e)))?;
+        let status = function
+            .call(&instance, &Vec::new())
+            .map(|_| 0)
+            .or_else(|err| {
+                log::error!("Error: {:?}", err);
+                Err(err)
+            })
+            .map_err(|e| anyhow::Error::msg(format!("Failed to call function: {:?}", e)))?;
+
+        Ok(status)
+    }
+}

--- a/crates/containerd-shim-wamr/src/lib.rs
+++ b/crates/containerd-shim-wamr/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod instance;
+
+pub use instance::WamrInstance;

--- a/crates/containerd-shim-wamr/src/main.rs
+++ b/crates/containerd-shim-wamr/src/main.rs
@@ -1,0 +1,6 @@
+use containerd_shim_wamr::WamrInstance;
+use containerd_shim_wasm::sandbox::cli::{revision, shim_main, version};
+
+fn main() {
+    shim_main::<WamrInstance>("wamr", version!(), revision!(), "v1", None);
+}

--- a/crates/containerd-shim-wamr/src/test.rs
+++ b/crates/containerd-shim-wamr/src/test.rs
@@ -1,0 +1,1 @@
+// TODO: add tests


### PR DESCRIPTION
this is an updated [PR](https://github.com/containerd/runwasi/pull/508) using  adding addtional shim implementation: Wamr using latest [wamr-rust-sdk](https://github.com/bytecodealliance/wamr-rust-sdk). 

It is still not working, the shim exits with one of the errors:
-"thread signal env initialized failed"
-without any error
-"error running start function: Failed to create instance: InstantiationFailure("error while pre-opening mapped directory: invalid map" 
-"Running "_start"" then "Error: ExecutionError("Exception: unreachable")"

My module has only the main function defined.
I have tried disabling hardware  checks in WAMR since I'm working on the VM, [commit](https://github.com/macko99/wamr-rust-sdk/commit/b89f685eba764fd784be103a7659fe19bb215482)

FYI @squillace @0xE282B0 @lum1n0us @Mossaka