### PR TITLE
Remove dependency on prost-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "prost-types 0.12.6",
  "protobuf 3.2.0",
  "rand",
  "serde",

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -34,7 +34,6 @@ tokio = { version = "1.38.1", features = [ "full" ] }
 futures = { version = "0.3.30" }
 wasmparser = "0.214.0"
 tokio-stream = { version = "0.1" }
-prost-types = "0.12" # should match version in containerd-shim
 sha256 = { workspace = true }
 
 # tracing


### PR DESCRIPTION
This change removes the dependency on `prost-types`, which otherwise needs to be kept in sync with the version in `containerd-client` (see for example  https://github.com/containerd/runwasi/pull/651)