### PR TITLE
Add e2e tests for Wasm OCI artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,3 +262,15 @@ sudo ctr run --rm --runtime=io.containerd.wasmtime.v1 ghcr.io/containerd/runwasi
 hello
 exiting 
 ```
+
+### Demo 3 using Wasm OCI Artifact
+
+The [CNCF tag-runtime wasm working group](https://tag-runtime.cncf.io/wgs/wasm/charter/) has a [OCI Artifact format for Wasm](https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/).  This is a new Artifact type that enable the usage across projects beyond just runwasi, see the https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/#implementations
+
+```
+make test-image/oci
+make load/oci
+make test/k8s-oci-wasmtime
+```
+
+> note: We are using a kubernetes cluster to run here since containerd's ctr has a bug that results in ctr: `unknown image config media type application/vnd.wasm.config.v0+json`

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -51,7 +51,10 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// Runtimes can override this to support other layer types
     /// such as lays that contain runtime specific configuration
     fn supported_layers_types() -> &'static [&'static str] {
-        &["application/vnd.bytecodealliance.wasm.component.layer.v0+wasm"]
+        &[
+            "application/vnd.bytecodealliance.wasm.component.layer.v0+wasm",
+            "application/wasm",
+        ]
     }
 
     /// Precompile passes supported OCI layers to engine for compilation

--- a/test/k8s/deploy.oci.yaml
+++ b/test/k8s/deploy.oci.yaml
@@ -25,6 +25,10 @@ spec:
         - name: demo
           image: ghcr.io/containerd/runwasi/wasi-demo-oci:latest
           imagePullPolicy: Never
+        - name: demo-artifact
+          image: ghcr.io/containerd/runwasi/wasi-demo-oci-artifact:latest
+          imagePullPolicy: Never
+          command: ["wasi-demo.wasm"]
         - name: nginx
           image: docker.io/nginx:latest
           ports:


### PR DESCRIPTION
This is a follow up to https://github.com/containerd/runwasi/pull/631 and adds tests to test the artifact type defined at https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/

This mostly worked out of the box. A couple minor notes that will be working to resolve upstream:

- Using the containerd CRI interface works with this, containenrd [CTR has a bug](https://github.com/containerd/containerd/issues/10179#issuecomment-2278801199) in it that blocks this being used. 
- The pod spec also needs a command specified otherwise the pod will not start.