### PR TITLE
benchmark: fix the CI failure

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,7 @@ jobs:
         run: git submodule update --init --recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          target: wasm32-wasi
+          rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - name: Setup build env
         run: |
           os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
the setup-rust-toolchain should respect the rust-toolchains.toml and disable the warnings flag to make it behave the same as other CI actions we have.