### PR TITLE
Release containerd-shim-wasm: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "containerd-shim-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "caps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = "1.0"
 cap-std = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 containerd-shim = "0.7.1"
-containerd-shim-wasm = { path = "crates/containerd-shim-wasm", version = "0.6.0" }
+containerd-shim-wasm = { path = "crates/containerd-shim-wasm", version = "0.7.0" }
 containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-modules", version = "0.4.0"}
 oci-tar-builder = { path = "crates/oci-tar-builder", version = "0.4.0" }
 crossbeam = { version = "0.8.4", default-features = false }

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "containerd-shim-wasm"
 description = "Library for building containerd shims for wasm"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"


### PR DESCRIPTION
Bump version to 0.7.0 for containerd-shim-wasm to include the latest features and bug fixes.