### PR TITLE
containerd-shim-wasm/CHANGELOG: add initial draft of changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,8 @@ Most features will likely have most of the code in the `containerd-shim-wasm` pr
 
 A tip for developing a new feature is to implement it and test it with one runtime you are familiar with then add it to all the runtimes.  This makes it easier to test and iterate before making changes across all the runtimes.
 
+Any changes made to the `containerd-shim-wasm` crate needs to be documented in the [CHANGELOG.md](./crates/containerd-shim-wasm/CHANGELOG.md) file following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
 ## Adding new shims
 
 We welcome new shims, though you can also host them in your own repositories as well and use the `coantainerd-shim-wasm` crate.  We recognize that the project is moving fast and having them in this repository can reduce the need for changes as well for discoverability.  

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- OpenTelemetry Tracing Support ([#582](https://github.com/containerd/runwasi/pull/582), [#653](https://github.com/containerd/runwasi/pull/653))
+- Enabled async, networking, and IP name lookup in Wasmtime ([#589](https://github.com/containerd/runwasi/pull/589))
+- Re-enabled Benchmarking with cargo bench ([#612](https://github.com/containerd/runwasi/pull/612))
+- Support for Generating New Artifact Types ([#631](https://github.com/containerd/runwasi/pull/631))
+- End-to-End Tests for Wasm OCI Artifacts ([#661](https://github.com/containerd/runwasi/pull/661))
+
+### Changed
+- Made `tracing::instrument` macro optional ([#592](https://github.com/containerd/runwasi/pull/592))
+- Upgraded youki Libcontainer to v0.3.3 ([#601](https://github.com/containerd/runwasi/pull/601))
+- Configured dependabot to group patch updates ([#641](https://github.com/containerd/runwasi/pull/641))
+- Improved `PathResolve` logic using RPITIT ([#654](https://github.com/containerd/runwasi/pull/654))
+- Improved error messages in `Executor::exec` ([#655](https://github.com/containerd/runwasi/pull/655))
+- Improved the getting started guide and Makefile for Windows ([#665](https://github.com/containerd/runwasi/pull/665))
+- Modified behavior so that container environment variables are exclusively passed to WASI modules, enhancing security and isolation. ([#668](https://github.com/containerd/runwasi/pull/668))
+
+### Fixed
+- Corrected syntax errors in release scripts ([#603](https://github.com/containerd/runwasi/pull/603), [#604](https://github.com/containerd/runwasi/pull/604))
+- Resolved CI failures in benchmark tests ([#669](https://github.com/containerd/runwasi/pull/669))
+
+### Deprecated
+- Deprecated 'Shared' mode removed ([#671](https://github.com/containerd/runwasi/pull/671))
+
+### Removed
+- Removed dependency on `prost-types` ([#656](https://github.com/containerd/runwasi/pull/656))
+
+[Unreleased]: <https://github.com/containerd/runwasi/compare/containerd-shim-wasm/v0.6.0..HEAD>

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -5,15 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
-- OpenTelemetry Tracing Support ([#582](https://github.com/containerd/runwasi/pull/582), [#653](https://github.com/containerd/runwasi/pull/653))
+- OpenTelemetry tracing support ([#582](https://github.com/containerd/runwasi/pull/582), [#653](https://github.com/containerd/runwasi/pull/653))
 - Enabled async, networking, and IP name lookup in Wasmtime ([#589](https://github.com/containerd/runwasi/pull/589))
-- Re-enabled Benchmarking with cargo bench ([#612](https://github.com/containerd/runwasi/pull/612))
-- Support for Generating New Artifact Types ([#631](https://github.com/containerd/runwasi/pull/631))
-- End-to-End Tests for Wasm OCI Artifacts ([#661](https://github.com/containerd/runwasi/pull/661))
+- Re-enabled benchmarking with cargo bench ([#612](https://github.com/containerd/runwasi/pull/612))
+- Support for generating new artifact types ([#631](https://github.com/containerd/runwasi/pull/631))
+- End-to-end tests for Wasm OCI artifacts ([#661](https://github.com/containerd/runwasi/pull/661))
 
 ### Changed
 - Made `tracing::instrument` macro optional ([#592](https://github.com/containerd/runwasi/pull/592))
-- Upgraded youki Libcontainer to v0.3.3 ([#601](https://github.com/containerd/runwasi/pull/601))
+- Upgraded youki Libcontainer to v0.3.3 that reduce startup time by 1s ([#601](https://github.com/containerd/runwasi/pull/601))
 - Configured dependabot to group patch updates ([#641](https://github.com/containerd/runwasi/pull/641))
 - Improved `PathResolve` logic using RPITIT ([#654](https://github.com/containerd/runwasi/pull/654))
 - Improved error messages in `Executor::exec` ([#655](https://github.com/containerd/runwasi/pull/655))
@@ -23,10 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 - Corrected syntax errors in release scripts ([#603](https://github.com/containerd/runwasi/pull/603), [#604](https://github.com/containerd/runwasi/pull/604))
 - Resolved CI failures in benchmark tests ([#669](https://github.com/containerd/runwasi/pull/669))
-- [#680](https://github.com/containerd/runwasi/pull/680): fixed a failed test `test_envs_not_present` and renamed it to `test_envs_return_default_only`
+- Fixed a failed test `test_envs_not_present` and renamed it to `test_envs_return_default_only` [#680](https://github.com/containerd/runwasi/pull/680)
+- Fixed the setup environment by adding openssl dependency to the Dockerfile [#680](https://github.com/containerd/runwasi/pull/680)
 
 ### Deprecated
-- Deprecated 'Shared' mode removed ([#671](https://github.com/containerd/runwasi/pull/671))
+- Deprecated the 'Shared' mode ([#671](https://github.com/containerd/runwasi/pull/671))
 
 ### Removed
 - Removed dependency on `prost-types` ([#656](https://github.com/containerd/runwasi/pull/656))

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 - Corrected syntax errors in release scripts ([#603](https://github.com/containerd/runwasi/pull/603), [#604](https://github.com/containerd/runwasi/pull/604))
 - Resolved CI failures in benchmark tests ([#669](https://github.com/containerd/runwasi/pull/669))
+- [#680](https://github.com/containerd/runwasi/pull/680): fixed a failed test `test_envs_not_present` and renamed it to `test_envs_return_default_only`
 
 ### Deprecated
 - Deprecated 'Shared' mode removed ([#671](https://github.com/containerd/runwasi/pull/671))


### PR DESCRIPTION
add a draft of the changelog for containerd-shim-wasm following the https://keepachangelog.com/en/1.1.0/ format. The changelog starts from the `containerd-shim-wasm/v0.6.0` to HEAD. it is expected that the future PRs will update the changelog with the changes made in the PRs.