### PR TITLE
Updated Scripts for setup new dev environment

### DIFF
--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -426,7 +426,7 @@ mod tests {
     }
 
     #[test]
-    fn test_envs_not_present() -> Result<()> {
+    fn test_envs_return_default_only() -> Result<()> {
         let spec = SpecBuilder::default()
             .root(RootBuilder::default().path("rootfs").build()?)
             .process(ProcessBuilder::default().cwd("/").build()?)

--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -439,7 +439,7 @@ mod tests {
         };
 
         let envs = ctx.envs();
-        assert_eq!(envs.len(), 0);
+        assert_eq!(envs.len(), 2);
 
         Ok(())
     }

--- a/cross/Dockerfile.gnu
+++ b/cross/Dockerfile.gnu
@@ -5,4 +5,4 @@ FROM $CROSS_BASE_IMAGE
 ARG CROSS_DEB_ARCH
 RUN dpkg --add-architecture ${CROSS_DEB_ARCH} && \
     apt-get -y update && \
-    apt-get install -y pkg-config protobuf-compiler libseccomp-dev:${CROSS_DEB_ARCH} libzstd-dev:${CROSS_DEB_ARCH}
+    apt-get install -y pkg-config protobuf-compiler libseccomp-dev:${CROSS_DEB_ARCH} libzstd-dev:${CROSS_DEB_ARCH} libssl-dev

--- a/cross/Dockerfile.musl
+++ b/cross/Dockerfile.musl
@@ -6,7 +6,7 @@ ENV MARCH=${CROSS_CMAKE_SYSTEM_PROCESSOR}
 RUN apk-init ${MARCH} ${CROSS_SYSROOT}
 
 # configure libsecccomp-rs to use static linking
-RUN apk-${MARCH} add libseccomp-static libseccomp-dev libssl-dev
+RUN apk-${MARCH} add libseccomp-static libseccomp-dev openssl-dev
 ENV LIBSECCOMP_LINK_TYPE="static"
 ENV LIBSECCOMP_LIB_PATH="${CROSS_SYSROOT}/lib"
 

--- a/cross/Dockerfile.musl
+++ b/cross/Dockerfile.musl
@@ -6,7 +6,7 @@ ENV MARCH=${CROSS_CMAKE_SYSTEM_PROCESSOR}
 RUN apk-init ${MARCH} ${CROSS_SYSROOT}
 
 # configure libsecccomp-rs to use static linking
-RUN apk-${MARCH} add libseccomp-static libseccomp-dev
+RUN apk-${MARCH} add libseccomp-static libseccomp-dev libssl-dev
 ENV LIBSECCOMP_LINK_TYPE="static"
 ENV LIBSECCOMP_LIB_PATH="${CROSS_SYSROOT}/lib"
 

--- a/scripts/setup-containerd.sh
+++ b/scripts/setup-containerd.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Define variables
+CONTAINERD_VERSION="1.7.22"
+RUNC_VERSION="1.1.14"
+CNI_PLUGINS_VERSION="1.5.1"
+
+# Change to arm64 if running on apple silicon
+CHIPSET="arm64"
+
+# Define URLs
+CONTAINERD_URL="https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${CHIPSET}.tar.gz"
+RUNC_URL="https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.${CHIPSET}"
+CNI_PLUGINS_URL="https://github.com/containernetworking/plugins/releases/download/v${CNI_PLUGINS_VERSION}/cni-plugins-linux-${CHIPSET}-v${CNI_PLUGINS_VERSION}.tgz"
+CONTAINERD_SERVICE_URL="https://raw.githubusercontent.com/containerd/containerd/main/containerd.service"
+
+# Install containerd
+curl -LO $CONTAINERD_URL
+sudo tar -C /usr/local -xzvf containerd-${CONTAINERD_VERSION}-linux-${CHIPSET}.tar.gz
+rm -f containerd-${CONTAINERD_VERSION}-linux-${CHIPSET}.tar.gz
+
+# Install runc
+curl -LO $RUNC_URL
+sudo install -m 755 runc.${CHIPSET} /usr/local/sbin/runc
+rm -f runc.${CHIPSET}
+
+# Install CNI plugins
+curl -LO $CNI_PLUGINS_URL
+sudo mkdir -p /opt/cni/bin
+sudo tar -C /opt/cni/bin -xzvf cni-plugins-linux-${CHIPSET}-v${CNI_PLUGINS_VERSION}.tgz
+rm -f cni-plugins-linux-${CHIPSET}-v${CNI_PLUGINS_VERSION}.tgz
+
+# Create containerd default configuration
+sudo mkdir -p /etc/containerd
+containerd config default | sudo tee /etc/containerd/config.toml
+
+# Modify the containerd config for systemd cgroup
+sudo sed -i 's/SystemdCgroup = false/SystemdCgroup = true/g' /etc/containerd/config.toml
+
+# Download and install the systemd service for containerd
+sudo curl -L $CONTAINERD_SERVICE_URL -o /etc/systemd/system/containerd.service
+
+# Reload systemd daemon and start containerd
+sudo systemctl daemon-reload
+sudo systemctl start containerd
+sudo systemctl enable containerd
+
+echo "containerd setup completed successfully!"

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo apt -y update
-sudo apt install -y pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev libzstd-dev protobuf-compiler
+sudo apt install -y pkg-config libsystemd-dev libdbus-glib-1-dev build-essential libelf-dev libseccomp-dev libclang-dev libzstd-dev protobuf-compiler libssl-dev
 
 if [ ! -z "$CI" ] && ! mount | grep cgroup; then
     echo "cgroup is not mounted" 1>&2


### PR DESCRIPTION
I setup a new dev environment and wanted to get the project running on my OSX machine. I installed a fresh Linux VM and was able to run `make build` and `make test` with this setup.

I encountered one test failure. I don't believe this failure would only impact me as the oci_spec default for environment variables sets 2 environment variables. So I set the 
```rust
impl Default for Process {
    fn default() -> Self {
        Process {
....
            // Sets linux default enviroment for binaries and default xterm emulator
            env: vec![
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".into(),
                "TERM=xterm".into(),
            ]
```