### PR TITLE
scripts, .github/workflows: add script to extract changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           git push origin "${{matrix.crate}}/v${{matrix.version}}"
       - name: Extract release notes
         if: ${{ matrix.crate == 'containerd-shim-wasm' &&  !inputs.dry_run }}
-        run: 
+        run: |
           cd $GITHUB_WORKSPACE
           ./scripts/extract-changelog.sh ${{matrix.version}} > RELEASE_NOTES.md
           cat RELEASE_NOTES.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
             --title "${{matrix.crate}}/v${{matrix.version}}" \
             --notes-file RELEASE_NOTES.md \
             --verify-tag \
-            $PRERELEASE_ARGS \
+            $PRERELEASE_ARGS
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NAME: ${{ matrix.crate }}/v${{ matrix.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,10 +159,15 @@ jobs:
           else
             PRERELEASE_ARGS=""
           fi  
+          
+          NOTES_ARG=""
+          if [[ -f RELEASE_NOTES.md ]]; then
+            NOTES_ARG="--notes-file RELEASE_NOTES.md"
+          fi
         
-          gh release create 'refs/tags/${{matrix.crate}}/v${{matrix.version}}' \
+          gh release create "refs/tags/${{matrix.crate}}/v${{matrix.version}}" \
             --title "${{matrix.crate}}/v${{matrix.version}}" \
-            --notes-file RELEASE_NOTES.md \
+            $NOTES_ARG \
             --verify-tag \
             $PRERELEASE_ARGS
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
         if: ${{ matrix.crate == 'containerd-shim-wasm' &&  !inputs.dry_run }}
         run: |
           cd $GITHUB_WORKSPACE
-          ./scripts/extract-changelog.sh ${{matrix.version}} > RELEASE_NOTES.md
+          ./scripts/extract-changelog.sh v${{matrix.version}} > RELEASE_NOTES.md
           cat RELEASE_NOTES.md
       - name: Create release
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,10 +144,27 @@ jobs:
         run: |
           git tag "${{matrix.crate}}/v${{matrix.version}}"
           git push origin "${{matrix.crate}}/v${{matrix.version}}"
+      - name: Extract release notes
+        if: ${{ matrix.crate == 'containerd-shim-wasm' &&  !inputs.dry_run }}
+        run: 
+          cd $GITHUB_WORKSPACE
+          ./scripts/extract-changelog.sh ${{matrix.version}} > RELEASE_NOTES.md
+          cat RELEASE_NOTES.md
       - name: Create release
         if: ${{ !inputs.dry_run }}
         run: |
-          gh release create 'refs/tags/${{matrix.crate}}/v${{matrix.version}}' --generate-notes
+          TAG_NAME=${{matrix.version}}
+          if [[ "$TAG_NAME" =~ .+-pre.* ]]; then
+            PRERELEASE_ARGS="--prerelease --latest=false"
+          else
+            PRERELEASE_ARGS=""
+          fi  
+        
+          gh release create 'refs/tags/${{matrix.crate}}/v${{matrix.version}}' \
+            --title "${{matrix.crate}}/v${{matrix.version}}" \
+            --notes-file RELEASE_NOTES.md \
+            --verify-tag \
+            $PRERELEASE_ARGS \
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NAME: ${{ matrix.crate }}/v${{ matrix.version }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@ Must release the creates in this order due to dependencies:
 
 ## Release Steps
 
-1. Open a PR to bump crate versions and dependency versions in `Cargo.toml` for that crate
+1. Open a PR to bump crate versions and dependency versions in `Cargo.toml` for that crate, and change the "Unreleased" section in the `CHANGELOG.md` to the new version.
 2. PR can be merged after 2 LGTMs
 3. Run the release workflow for the dependent crate. (e.g. `containerd-shim-wasm/v0.2.0` where `crate=containerd-shim-wasm` and `version=0.2.0`)
 4. Wait for the release workflow to complete

--- a/scripts/extract-changelog.sh
+++ b/scripts/extract-changelog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Inspired by https://stackoverflow.com/questions/40450238/parse-a-changelog-and-extract-changes-for-a-version
+# This script will extract the changelog for a specific version from the CHANGELOG.md file
+# Usage: ./extract-changelog.sh <version>
+version=$1
+
+awk -v ver="$version" '
+/^## \[.*\]/ {
+  if (p) exit
+  if ($0 ~ "^## \\[" ver "\\]") { p=1; next }
+}
+p' crates/containerd-shim-wasm/CHANGELOG.md


### PR DESCRIPTION
the release workflow will use the script to extract the changelog and uses it to create a release note. It also uses tag name to determine if the release is pre-release or not.

Verified that release works in a forked repo: https://github.com/Mossaka/runwasi/actions/runs/11243618268