### PR TITLE
Add graceful server shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "reqwest 0.12.8",
  "serial_test",
  "tokio",
+ "tokio-util",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -4996,6 +4997,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ serial_test = "2"
 tracing = "0.1"
 hyper = "1.5.0"
 tokio = { version = "1.40.0", default-features = false }
+tokio-util = { version = "0.7", default-features = false }
 
 # wasmtime
 wasmtime = { version = "25.0.2", features = ["async"] }

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Result};
 pub use containerd_shim_wasm_test_modules as modules;
-use libc::SIGINT;
+use libc::{SIGINT, SIGTERM};
 use oci_spec::runtime::{
     get_default_namespaces, LinuxBuilder, LinuxNamespace, LinuxNamespaceType, ProcessBuilder,
     RootBuilder, SpecBuilder,
@@ -220,6 +220,12 @@ where
     pub fn ctrl_c(&self) -> Result<&Self> {
         log::info!("sending SIGINT");
         self.instance.kill(SIGINT as u32)?;
+        Ok(self)
+    }
+
+    pub fn terminate(&self) -> Result<&Self> {
+        log::info!("sending SIGTERM");
+        self.instance.kill(SIGTERM as u32)?;
         Ok(self)
     }
 

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -6,10 +6,11 @@ edition.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 containerd-shim-wasm = { workspace = true, features = ["opentelemetry"] }
+libc = { workspace = true }
 log = { workspace = true }
 hyper = { workspace = true }
 tokio = { workspace = true, features = ["signal", "macros"] }
-libc = { workspace = true }
+tokio-util = { workspace = true, features = ["rt"] }
 
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -7,6 +7,7 @@ use containerd_shim_wasm::container::{
     Engine, Entrypoint, Instance, RuntimeContext, Stdio, WasmBinaryType,
 };
 use containerd_shim_wasm::sandbox::WasmLayer;
+use tokio_util::sync::CancellationToken;
 use wasi_preview1::WasiP1Ctx;
 use wasi_preview2::bindings::Command;
 use wasmtime::component::types::ComponentItem;
@@ -55,6 +56,7 @@ impl<'a> ComponentTarget<'a> {
 #[derive(Clone)]
 pub struct WasmtimeEngine<T: WasiConfig> {
     engine: wasmtime::Engine,
+    cancel: CancellationToken,
     config_type: PhantomData<T>,
 }
 
@@ -81,6 +83,7 @@ impl<T: WasiConfig> Default for WasmtimeEngine<T> {
             engine: wasmtime::Engine::new(&config)
                 .context("failed to create wasmtime engine")
                 .unwrap(),
+            cancel: CancellationToken::new(),
             config_type: PhantomData,
         }
     }
@@ -250,7 +253,8 @@ where
                 let instance = ProxyPre::new(pre)?;
 
                 log::info!("starting HTTP server");
-                serve_conn(ctx, instance).await
+                let cancel = self.cancel.clone();
+                serve_conn(ctx, instance, cancel).await
             }
             ComponentTarget::Command => {
                 let wasi_ctx = WasiPreview2Ctx::new(ctx)?;
@@ -302,9 +306,32 @@ where
         log::debug!("loading wasm component");
 
         wasmtime_wasi::runtime::in_tokio(async move {
-            tokio::select! {
-                status = self.execute_component_async(ctx, component, func, stdio) => { status }
-                sig = wait_for_signal() => { sig }
+            let mut done = false;
+            let exec = self.execute_component_async(ctx, component, func, stdio);
+
+            tokio::pin!(exec);
+
+            loop {
+                tokio::select! {
+                    status = &mut exec => {
+                        return status;
+                    }
+                    sig = wait_for_signal() => {
+                        match sig? {
+                            libc::SIGINT if !done => {
+                                // Request graceful shutdown; if successful, the loop will
+                                // exit from the `exec` branch with a status code.
+                                done = true;
+                                self.cancel.cancel();
+                            }
+                            sig => {
+                                // On a second SIGINT or other signal, terminate the process
+                                // without waiting for spawned tasks to finish.
+                                return Ok(128 + sig);
+                            }
+                        }
+                    }
+                }
             }
         })
     }
@@ -397,9 +424,9 @@ async fn wait_for_signal() -> Result<i32> {
         let mut sigterm = signal(SignalKind::terminate())?;
 
         tokio::select! {
-            _ = sigquit.recv() => { Ok(128 + libc::SIGINT) }
-            _ = sigterm.recv() => { Ok(128 + libc::SIGTERM) }
-            _ = tokio::signal::ctrl_c() => { Ok(128 + libc::SIGINT) }
+            _ = sigquit.recv() => { Ok(libc::SIGINT) }
+            _ = sigterm.recv() => { Ok(libc::SIGTERM) }
+            _ = tokio::signal::ctrl_c() => { Ok(libc::SIGINT) }
         }
     }
     #[cfg(not(unix))]

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -306,7 +306,7 @@ where
         log::debug!("loading wasm component");
 
         wasmtime_wasi::runtime::in_tokio(async move {
-            let mut done = false;
+            let mut force_shutdown = false;
             let exec = self.execute_component_async(ctx, component, func, stdio);
 
             tokio::pin!(exec);
@@ -318,10 +318,10 @@ where
                     }
                     sig = wait_for_signal() => {
                         match sig? {
-                            libc::SIGINT if !done => {
+                            libc::SIGINT if !force_shutdown => {
                                 // Request graceful shutdown; if successful, the loop will
                                 // exit from the `exec` branch with a status code.
-                                done = true;
+                                force_shutdown = true;
                                 self.cancel.cancel();
                             }
                             sig => {

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -297,7 +297,7 @@ fn test_wasip2_component_http_proxy() -> anyhow::Result<()> {
     assert_eq!(body, "Hello, this is your first wasi:http/proxy world!\n");
 
     let (exit_code, _, _) = srv.ctrl_c()?.wait(Duration::from_secs(5))?;
-    assert_eq!(exit_code, 128 + 2);
+    assert_eq!(exit_code, 0);
 
     Ok(())
 }


### PR DESCRIPTION
This patch adds graceful shutdown functionality to the Wasmtime shim server loop. The shutdown process works as follows:

- The code that spawns the top-level loop creates a `CancellationToken`, which is shared across all cancellable tasks.
- A tracker is used to manage any tasks spawned within the server loop.
- A signal handler is installed to listen for signals. Upon receiving the first `Interrupt` signal, it calls cancel and waits for the server task to finish gracefully, allowing all spawned tasks to complete.
- On receiving a second `Interrupt` signal, the server loop exits immediately.
- Similarly, upon receiving a `Terminate` signal, the server loop finishes abruptly.
- The return code indicates which of these shutdown scenarios occurred. If the server has finished abruptly the `128 + SIG` will be used. See https://tldp.org/LDP/abs/html/exitcodes.html for more details.
