### PR TITLE
Increase k8s tests timeout

### DIFF
--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -37,7 +37,7 @@ jobs:
           name: test-img
           path: dist
       - name: run
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: make test/k3s-${{ inputs.runtime }}
       # only runs when the previous step fails
       - name: inspect failed pods

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -43,7 +43,7 @@ jobs:
           name: test-${{ inputs.image }}
           path: dist
       - name: run
-        timeout-minutes: 7
+        timeout-minutes: 10
         run: ${{ inputs.test-command }}
       # only runs when the previous step fails
       - name: inspect failed pods

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ test/k8s/cluster-%: dist/img.tar bin/kind test/k8s/_out/img-%
 .PHONY: test/k8s/deploy-workload-%
 test/k8s/deploy-workload-%: test/k8s/clean test/k8s/cluster-% 
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) apply -f test/k8s/deploy.yaml
-	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=90s
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=180s
 	# verify that we are still running after some time	
 	sleep 5s
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
@@ -254,7 +254,7 @@ test/k8s/deploy-workload-oci-%: test/k8s/clean test/k8s/cluster-% dist/img-oci.t
 	bin/kind load image-archive --name $(KIND_CLUSTER_NAME) dist/img-oci.tar
 	bin/kind load image-archive --name $(KIND_CLUSTER_NAME) dist/img-oci-artifact.tar
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) apply -f test/k8s/deploy.oci.yaml
-	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=90s
+	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=180s
 	# verify that we are still running after some time
 	sleep 5s
 	kubectl --context=kind-$(KIND_CLUSTER_NAME) wait deployment wasi-demo --for condition=Available=True --timeout=5s
@@ -297,7 +297,7 @@ test/k3s-%: dist/img.tar bin/k3s dist-%
 	sudo bin/k3s kubectl get pods --all-namespaces
 	sudo bin/k3s kubectl apply -f test/k8s/deploy.yaml
 	sudo bin/k3s kubectl get pods --all-namespaces
-	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=120s
+	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=180s
 	# verify that we are still running after some time	
 	sleep 5s
 	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=5s
@@ -311,7 +311,7 @@ test/k3s-oci-%: dist/img-oci.tar bin/k3s dist-%
 	sudo bin/k3s kubectl get pods --all-namespaces
 	sudo bin/k3s kubectl apply -f test/k8s/deploy.oci.yaml
 	sudo bin/k3s kubectl get pods --all-namespaces
-	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=120s
+	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=180s
 	# verify that we are still running after some time	
 	sleep 5s
 	sudo bin/k3s kubectl wait deployment wasi-demo --for condition=Available=True --timeout=5s


### PR DESCRIPTION
This PR attempts to fix the CI sporadic failures by increasing the timeout when waiting for the deployment to be available in the k8s tests.