### PR TITLE
re-export containerd_shim::Config for runwasi consumers

### DIFF
--- a/crates/containerd-shim-wasm/src/lib.rs
+++ b/crates/containerd-shim-wasm/src/lib.rs
@@ -12,3 +12,5 @@ pub(crate) mod sys;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
+
+pub use containerd_shim::Config;


### PR DESCRIPTION
fixes https://github.com/containerd/runwasi/issues/708