### PR TITLE
Remove the alpha notice in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 # runwasi
 
-> Warning: Alpha quality software, do not use in production.
-
 This is a project to facilitate running wasm workloads managed by containerd either directly (ie. through ctr) or as directed by Kubelet via the CRI plugin.
 It is intended to be a (rust) library that you can take and integrate with your wasm host.
 Included in the repository is a PoC for running a plain wasi host (ie. no extra host functions except to support wasi system calls).


### PR DESCRIPTION
I believe it is past time to remove the alpha notice in the readme. This PR removes that notice on the readme.