### PR TITLE
rust-toolchain: bump rust to 1.81.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel="1.82.0"
+channel="1.81.0"
 profile="default"
 targets = ["wasm32-wasi"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel="1.79.0"
+channel="1.82.0"
 profile="default"
 targets = ["wasm32-wasi"]


### PR DESCRIPTION
bumps rust compiler to the latest version