### PR TITLE
Fix exit code in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ RUNTIMES ?= wasmedge wasmtime wasmer wamr
 CONTAINERD_NAMESPACE ?= default
 RUSTC ?= rustc
 
+SHELL=/bin/bash -o pipefail
+
 # We have a bit of fancy logic here to determine the target 
 # since we support building for gnu and musl
 # TARGET must eventually match one of the values in the cross.toml

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -293,7 +293,7 @@ fn test_wasip2_component_http_proxy() -> anyhow::Result<()> {
 #[serial]
 fn test_wasip2_component_http_proxy_force_shutdown() -> anyhow::Result<()> {
     let srv = WasiTest::<WasiInstance>::builder()?
-        .with_wasm(FAULTY_WASI_HTTP)?
+        .with_wasm(HELLO_WASI_HTTP)?
         .with_host_network()
         .build()?;
 


### PR DESCRIPTION
CI is not capturing failures to build tests, this PR intends to fix that as the wasmtime tests are currently failing to build.