### PR TITLE
Use async pid fd instead of blocking waitid to wait for a child process to exit

### DIFF
--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -98,6 +98,8 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
         let pid = self.container.pid()?;
 
         // Use a pidfd FD so that we can wait for the process to exit asynchronously.
+        // This should be created BEFORE calling container.start() to ensure we never
+        // miss the SIGCHLD event.
         let pidfd = PidFd::new(pid)?;
 
         self.container.start()?;

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -6,9 +6,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
-use nix::errno::Errno;
-use nix::sys::wait::{Id as WaitID, WaitPidFlag, WaitStatus, waitid};
-use nix::unistd::Pid;
+use nix::sys::wait::WaitStatus;
 use oci_spec::image::Platform;
 
 use super::container::Container;
@@ -20,6 +18,7 @@ use crate::sandbox::{
     Error as SandboxError, Instance as SandboxInstance, InstanceConfig, containerd,
 };
 use crate::sys::container::executor::Executor;
+use crate::sys::pid_fd::PidFd;
 use crate::sys::stdio::open;
 
 const DEFAULT_CONTAINER_ROOT_DIR: &str = "/run/containerd";
@@ -97,6 +96,10 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
         let guard = self.exit_code.clone().set_guard_with(|| (137, Utc::now()));
 
         let pid = self.container.pid()?;
+
+        // Use a pidfd FD so that we can wait for the process to exit asynchronously.
+        let pidfd = PidFd::new(pid)?;
+
         self.container.start()?;
 
         let exit_code = self.exit_code.clone();
@@ -104,13 +107,12 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
             // move the exit code guard into this thread
             let _guard = guard;
 
-            let status = match waitid(WaitID::Pid(Pid::from_raw(pid)), WaitPidFlag::WEXITED) {
+            let status = match pidfd.wait().block_on() {
                 Ok(WaitStatus::Exited(_, status)) => status,
-                Ok(WaitStatus::Signaled(_, sig, _)) => sig as i32,
-                Ok(_) => 0,
-                Err(Errno::ECHILD) => {
-                    log::info!("no child process");
-                    0
+                Ok(WaitStatus::Signaled(_, sig, _)) => 128 + sig as i32,
+                Ok(res) => {
+                    log::error!("waitpid unexpected result: {res:?}");
+                    137
                 }
                 Err(e) => {
                     log::error!("waitpid failed: {e}");
@@ -120,7 +122,7 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
             let _ = exit_code.set((status, Utc::now()));
         });
 
-        Ok(pid as u32)
+        Ok(pid as _)
     }
 
     /// Send a signal to the instance

--- a/crates/containerd-shim-wasm/src/sys/unix/mod.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/mod.rs
@@ -1,3 +1,5 @@
 pub mod container;
 pub mod metrics;
 pub mod stdio;
+
+mod pid_fd;

--- a/crates/containerd-shim-wasm/src/sys/unix/pid_fd.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/pid_fd.rs
@@ -1,0 +1,44 @@
+use std::os::fd::{AsFd, FromRawFd as _, OwnedFd, RawFd};
+
+use libc::pid_t;
+use nix::sys::wait::{waitid, Id, WaitPidFlag, WaitStatus};
+use tokio::io::unix::AsyncFd;
+
+pub(super) struct PidFd {
+    fd: OwnedFd,
+}
+
+impl PidFd {
+    pub(super) fn new(pid: impl Into<pid_t>) -> anyhow::Result<Self> {
+        use libc::{syscall, SYS_pidfd_open, PIDFD_NONBLOCK};
+        let pidfd = unsafe { syscall(SYS_pidfd_open, pid.into(), PIDFD_NONBLOCK) };
+        if pidfd == -1 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let fd = unsafe { OwnedFd::from_raw_fd(pidfd as RawFd) };
+        Ok(Self { fd })
+    }
+
+    pub(super) async fn wait(self) -> std::io::Result<WaitStatus> {
+        let fd = AsyncFd::new(self.fd)?;
+        loop {
+            // Check with non-blocking waitid before awaiting on fd.
+            // On some platforms, the readiness detecting mechanism relies on
+            // edge-triggered notifications.
+            // This means that we could miss a notification if the process exits
+            // before we create the AsyncFd.
+            // See https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html
+            match waitid(
+                Id::PIDFd(fd.as_fd()),
+                WaitPidFlag::WEXITED | WaitPidFlag::WNOHANG,
+            )? {
+                WaitStatus::StillAlive => {
+                    let _ = fd.readable().await?;
+                }
+                status => {
+                    return Ok(status);
+                }
+            }
+        }
+    }
+}

--- a/crates/stress-test/src/containerd/client.rs
+++ b/crates/stress-test/src/containerd/client.rs
@@ -393,7 +393,7 @@ impl Clone for Client {
 }
 
 fn chain_id(digests: Vec<String>) -> String {
-    let mut chain_id = digests.get(0).cloned().unwrap_or_default();
+    let mut chain_id = digests.first().cloned().unwrap_or_default();
     for digest in digests.iter().skip(1) {
         chain_id = sha256::digest(format!("{chain_id} {digest}"));
         chain_id = format!("sha256:{chain_id}");


### PR DESCRIPTION
This PR replaces the blocking waitid call with an async implementation based on pid fd.
There's a race condition where containerd-shim reaps child processes.
If the child process has already been reaped, query containerd-shim to get the process status.

Note that this race condition is already present in the current implementation, but runwasi's waitid is very likely to win the race, the introduction of async evens out the odds between runwasi and containerd-shim.

This PR is in preparation to move the whole shim implementation to async.