### PR TITLE
chore: switch to wasm32-wasip1 target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6626,6 +6626,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.6.0",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -176,35 +176,35 @@ test-image/oci: dist/img-oci.tar dist/img-oci-artifact.tar
 
 .PHONY: test-image/clean
 test-image/clean:
-	rm -rf target/wasm32-wasi/$(OPT_PROFILE)/
+	rm -rf target/wasm32-wasip1/$(OPT_PROFILE)/
 
 .PHONY: test-image/oci/clean
 test-image/oci/clean:
-	rm -rf target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar
-	rm -rf target/wasm32-wasi/$(OPT_PROFILE)/img-oci-artifact.tar
+	rm -rf target/wasm32-wasip1/$(OPT_PROFILE)/img-oci.tar
+	rm -rf target/wasm32-wasip1/$(OPT_PROFILE)/img-oci-artifact.tar
 
 .PHONY: demo-app
-demo-app: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
+demo-app: target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm
 
-.PHONY: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
-target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm:
-	rustup target add wasm32-wasi
+.PHONY: target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm
+target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm:
+	rustup target add wasm32-wasip1
 	cd crates/wasi-demo-app && cargo build $(RELEASE_FLAG)
 
-target/wasm32-wasi/$(OPT_PROFILE)/img.tar: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
+target/wasm32-wasip1/$(OPT_PROFILE)/img.tar: target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm
 	cd crates/wasi-demo-app && cargo build $(RELEASE_FLAG) --features oci-v1-tar
 
 .PHONY: dist/img.tar
 dist/img.tar:
 	@mkdir -p "dist/"
-	[ -f $(PWD)/dist/img.tar ] || $(MAKE) target/wasm32-wasi/$(OPT_PROFILE)/img.tar
-	[ -f $(PWD)/dist/img.tar ] || cp target/wasm32-wasi/$(OPT_PROFILE)/img.tar "$@"
+	[ -f $(PWD)/dist/img.tar ] || $(MAKE) target/wasm32-wasip1/$(OPT_PROFILE)/img.tar
+	[ -f $(PWD)/dist/img.tar ] || cp target/wasm32-wasip1/$(OPT_PROFILE)/img.tar "$@"
 
-dist/img-oci.tar: target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar 
+dist/img-oci.tar: target/wasm32-wasip1/$(OPT_PROFILE)/img-oci.tar 
 	@mkdir -p "dist/"
 	cp "$<" "$@"
 
-dist/img-oci-artifact.tar: target/wasm32-wasi/$(OPT_PROFILE)/img-oci-artifact.tar
+dist/img-oci-artifact.tar: target/wasm32-wasip1/$(OPT_PROFILE)/img-oci-artifact.tar
 	@mkdir -p "dist/"
 	cp "$<" "$@"
 
@@ -218,14 +218,14 @@ load/oci: dist/img-oci.tar dist/img-oci-artifact.tar
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import --all-platforms $<
 	sudo ctr -n $(CONTAINERD_NAMESPACE) image import --all-platforms dist/img-oci-artifact.tar
 
-target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
+target/wasm32-wasip1/$(OPT_PROFILE)/img-oci.tar: target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm
 	mkdir -p ${CURDIR}/bin/$(OPT_PROFILE)/
-	cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm -o target/wasm32-wasi/$(OPT_PROFILE)/img-oci.tar
+	cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm -o target/wasm32-wasip1/$(OPT_PROFILE)/img-oci.tar
 
 .PHONY:
-target/wasm32-wasi/$(OPT_PROFILE)/img-oci-artifact.tar: target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm
+target/wasm32-wasip1/$(OPT_PROFILE)/img-oci-artifact.tar: target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm
 	mkdir -p ${CURDIR}/bin/$(OPT_PROFILE)/
-	cargo run --bin oci-tar-builder -- --name wasi-demo-oci-artifact --as-artifact --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasi/$(OPT_PROFILE)/wasi-demo-app.wasm -o target/wasm32-wasi/$(OPT_PROFILE)/img-oci-artifact.tar
+	cargo run --bin oci-tar-builder -- --name wasi-demo-oci-artifact --as-artifact --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasip1/$(OPT_PROFILE)/wasi-demo-app.wasm -o target/wasm32-wasip1/$(OPT_PROFILE)/img-oci-artifact.tar
 
 bin/kind: test/k8s/Dockerfile
 	$(DOCKER_BUILD) --output=bin/ -f test/k8s/Dockerfile --target=kind .

--- a/crates/containerd-shim-wasm-test-modules/build.rs
+++ b/crates/containerd-shim-wasm-test-modules/build.rs
@@ -64,7 +64,7 @@ fn compile_rust(src: impl AsRef<Path>) -> Result<PathBuf> {
     let dst = output_for(src)?;
 
     Command::new(rustc)
-        .arg("--target=wasm32-wasi")
+        .arg("--target=wasm32-wasip1")
         .arg("-Copt-level=z")
         .arg("-Cstrip=symbols")
         .arg("-o")

--- a/crates/oci-tar-builder/README.md
+++ b/crates/oci-tar-builder/README.md
@@ -25,7 +25,7 @@ There is an experimental executable that uses the library and can package a wasm
 To generate the package and import to a registry using a tool such as [regctl](https://github.com/regclient/regclient/blob/main/docs/install.md).  To [run a local image registry](https://www.docker.com/blog/how-to-use-your-own-registry-2/) use `docker run -d -p 5000:5000 --name registry registry:2.7`
 
 ```
-cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasi/debug/wasi-demo-app.wasm -o ./dist/img-oci.tar
+cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --module ./target/wasm32-wasip1/debug/wasi-demo-app.wasm -o ./dist/img-oci.tar
 regctl image import localhost:5000/wasi-demo-oci:latest ./dist/img-oci.tar        
 ```
 
@@ -63,8 +63,8 @@ In order to be compatible with Docker, since Docker does not currently support t
 The CNCF wg-wasm has published and [OCI artifact format](https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/) for packaging wasm modules and components.  The artifact can be produced locally by running the `--as-artifact` flag:
 
 ```
-cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --as-artifact --module ./target/wasm32-wasi/debug/wasi-demo-app.wasm -o target/wasm32-wasi/debug/img-oci-artifact.tar
-regctl image import localhost:5000/wasi-artifact:latest target/wasm32-wasi/debug/img-oci-artifact.tar
+cargo run --bin oci-tar-builder -- --name wasi-demo-oci --repo ghcr.io/containerd/runwasi --tag latest --as-artifact --module ./target/wasm32-wasip1/debug/wasi-demo-app.wasm -o target/wasm32-wasip1/debug/img-oci-artifact.tar
+regctl image import localhost:5000/wasi-artifact:latest target/wasm32-wasip1/debug/img-oci-artifact.tar
 ```
 
 The manifest will follow the guidance:

--- a/crates/wasi-demo-app/.cargo/config.toml
+++ b/crates/wasi-demo-app/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-target = ["wasm32-wasi"]
+target = ["wasm32-wasip1"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel="1.81.0"
 profile="default"
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]


### PR DESCRIPTION
Rust 1.81.0 now issues a warning for the usage of wasm32-wasi target and suggests users to switch to wasm32-wasip1 target. Since we have bumped the minimal rustc version to 1.81.0 in rust-toolchain.toml, we should switch to this new target.

This commit does a whole replace of 'wasm32-wasi -> wasm32-wasip1'.