### PR TITLE
[chore] minor cleanup

### DIFF
--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 - Added test for signal handling issue [#755](https://github.com/containerd/runwasi/issues/755) ([#756](https://github.com/containerd/runwasi/pull/756))
 
+### Changed
+- Reuse and synchronise access to `Container` object instead of reloading form disk ([#763](https://github.com/containerd/runwasi/pull/763))
+
+### Removed
+- Removed `containerd_shim_wasm::sandbox::instance_utils::get_instance_root` and `containerd_shim_wasm::sandbox::instance_utils::instance_exists` functions ([#763](https://github.com/containerd/runwasi/pull/763))
+
 ## [v0.8.0] — 2024-12-04
 
 ### Added

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock, RwLock};
+use std::sync::{OnceLock, RwLock};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -10,7 +10,7 @@ pub(super) struct InstanceData<T: Instance> {
     pub instance: T,
     cfg: InstanceConfig<T::Engine>,
     pid: OnceLock<u32>,
-    state: Arc<RwLock<TaskState>>,
+    state: RwLock<TaskState>,
 }
 
 impl<T: Instance> InstanceData<T> {
@@ -22,7 +22,7 @@ impl<T: Instance> InstanceData<T> {
             instance,
             cfg,
             pid: OnceLock::default(),
-            state: Arc::new(RwLock::new(TaskState::Created)),
+            state: RwLock::new(TaskState::Created),
         })
     }
 


### PR DESCRIPTION
This PR reuses the container returned by `libcontainer` instead of reloading it from disk every time.

Note: some of the functions removed here were part of the public API, probably incorrectly so.