### PR TITLE
benches: add a new wasi-demo-{app, oci} benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash
         run: |
           make build
-          sudo make install
+          make install
           make test-image
           make load
       - name: Run Benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,6 +21,13 @@ jobs:
           os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
           ./scripts/setup-$os.sh
         shell: bash
+      - name: Build and load shims and wasi-demo-app
+        shell: bash
+        run: |
+          make build
+          sudo make install
+          make test-image
+          make load
       - name: Run Benchmarks
         run: |
           set -o pipefail

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,6 +28,8 @@ jobs:
           make install
           make test-image
           make load
+          make test-image/oci
+          make load/oci
       - name: Run Benchmarks
         run: |
           set -o pipefail

--- a/benches/containerd-shim-benchmarks/Cargo.toml
+++ b/benches/containerd-shim-benchmarks/Cargo.toml
@@ -19,3 +19,7 @@ harness = false
 [[bench]]
 name = "wasmedge-benchmarks"
 harness = false
+
+[[bench]]
+name = "wasi-demo-app-benchmarks"
+harness = false

--- a/benches/containerd-shim-benchmarks/README.md
+++ b/benches/containerd-shim-benchmarks/README.md
@@ -14,6 +14,8 @@ Then, build and load the wasi-demo-app:
 ```bash
 make test-image
 make load
+make test-image/oci
+make load/oci
 ```
 
 To run all benchmarks:

--- a/benches/containerd-shim-benchmarks/README.md
+++ b/benches/containerd-shim-benchmarks/README.md
@@ -1,0 +1,24 @@
+# Containerd Shim Benchmarks
+
+This directory contains benchmarks for testing various aspects of the containerd shims:
+
+## Running the Benchmarks
+
+First, build and install the shims:
+```bash
+make build
+sudo make install
+```
+
+Then, build and load the wasi-demo-app:
+```bash
+make test-image
+make load
+```
+
+To run all benchmarks:
+```bash
+cargo bench -p containerd-shim-benchmarks
+```
+
+Note: The benchmarks require sudo access to run containerd commands. Make sure you have the necessary permissions configured.

--- a/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
+++ b/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
@@ -81,7 +81,9 @@ fn benchmark_image(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(10);
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(3));
     targets = benchmark_image
 }
 

--- a/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
+++ b/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
@@ -32,7 +32,6 @@ fn run_container(runtime: &str) -> Duration {
 
 fn benchmark_startup(c: &mut Criterion) {
     let mut group = c.benchmark_group("wasi-demo-app");
-    group.sample_size(10); // Adjust sample size as needed
     
     group.bench_function("wasmtime", |b| {
         b.iter(|| run_container("wasmtime"));

--- a/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
+++ b/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
@@ -1,0 +1,62 @@
+use std::process::Command;
+use std::time::{Duration, Instant};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn run_container(runtime: &str) -> Duration {
+    let start = Instant::now();
+    
+    let output = Command::new("sudo")
+        .args([
+            "ctr",
+            "run",
+            "--rm",
+            &format!("--runtime=io.containerd.{}.v1", runtime),
+            "ghcr.io/containerd/runwasi/wasi-demo-app:latest",
+            "testwasm",
+            "/wasi-demo-app.wasm",
+            "echo",
+            "hello"
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    if !output.status.success() {
+        panic!("Container failed to run: {}", String::from_utf8_lossy(&output.stderr));
+    } else {
+        let stdout_str = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout_str.contains("hello"));
+    }
+
+    start.elapsed()
+}
+
+fn benchmark_startup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wasi-demo-app");
+    group.sample_size(10); // Adjust sample size as needed
+    
+    group.bench_function("wasmtime", |b| {
+        b.iter(|| run_container("wasmtime"));
+    });
+
+    group.bench_function("wasmedge", |b| {
+        b.iter(|| run_container("wasmedge"));
+    });
+
+    group.bench_function("wasmer", |b| {
+        b.iter(|| run_container("wasmer"));
+    });
+
+    group.bench_function("wamr", |b| {
+        b.iter(|| run_container("wamr"));
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_startup
+}
+
+criterion_main!(benches); 


### PR DESCRIPTION
This commit adds a new benchmark for running the shims end-to-end on wasi-demo-{app, oci} to print 'hello'.