### PR TITLE
Remove `Engine` from `InstanceConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pub trait Instance {
     type Engine: Send + Sync + Clone;
 
     /// Create a new instance
-    fn new(id: String, cfg: Option<&InstanceConfig<Self::E>>) -> Self;
+    fn new(id: String, cfg: &InstanceConfig) -> Self;
     /// Start the instance
     /// The returned value should be a unique ID (such as a PID) for the instance.
     /// Nothing internally should be using this ID, but it is returned to containerd where a user may want to use it.

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -10,9 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 - Reuse and synchronise access to `Container` object instead of reloading form disk ([#763](https://github.com/containerd/runwasi/pull/763))
 - Remove custom stdio redicrection: The `run_wasi` method doesn't receive the `Stdio` object anymore, and redirection is done before the method is called ([#788](https://github.com/containerd/runwasi/pull/788))
+- Require `Engine` generic in `Instance` to implement `Default` ([#774](https://github.com/containerd/runwasi/pull/774))
+- The method `Instance::new` now takes an `&InstanceConfig` instead of `Option<&InstanceConfig>` ([#774](https://github.com/containerd/runwasi/pull/774))
 
 ### Removed
 - Removed `containerd_shim_wasm::sandbox::instance_utils::get_instance_root` and `containerd_shim_wasm::sandbox::instance_utils::instance_exists` functions ([#763](https://github.com/containerd/runwasi/pull/763))
+- Removed `Engine` generic from `InstanceConfig` ([#774](https://github.com/containerd/runwasi/pull/774))
 
 ## [v0.8.0] — 2024-12-04
 

--- a/crates/containerd-shim-wasm/README.md
+++ b/crates/containerd-shim-wasm/README.md
@@ -21,7 +21,7 @@ struct MyInstance {
 impl Instance for MyInstance {
     type Engine = ();
 
-   fn new(_id: String, _cfg: Option<&InstanceConfig<Self::Engine>>) -> Result<Self, Error> {
+   fn new(_id: String, _cfg: &InstanceConfig) -> Result<Self, Error> {
        todo!();
     }
     fn start(&self) -> Result<u32, Error> {

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -103,7 +103,7 @@ pub trait Instance: 'static {
     type Engine: Send + Sync + Clone;
 
     /// Create a new instance
-    fn new(id: String, cfg: Option<&InstanceConfig>) -> Result<Self, Error>
+    fn new(id: String, cfg: &InstanceConfig) -> Result<Self, Error>
     where
         Self: Sized;
 

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -10,10 +10,7 @@ use super::error::Error;
 /// Generic options builder for creating a wasm instance.
 /// This is passed to the `Instance::new` method.
 #[derive(Clone)]
-pub struct InstanceConfig<Engine: Send + Sync + Clone> {
-    /// The WASI engine to use.
-    /// This should be cheap to clone.
-    engine: Engine,
+pub struct InstanceConfig {
     /// Optional stdin named pipe path.
     stdin: PathBuf,
     /// Optional stdout named pipe path.
@@ -28,16 +25,11 @@ pub struct InstanceConfig<Engine: Send + Sync + Clone> {
     containerd_address: String,
 }
 
-impl<Engine: Send + Sync + Clone> InstanceConfig<Engine> {
-    pub fn new(
-        engine: Engine,
-        namespace: impl AsRef<str>,
-        containerd_address: impl AsRef<str>,
-    ) -> Self {
+impl InstanceConfig {
+    pub fn new(namespace: impl AsRef<str>, containerd_address: impl AsRef<str>) -> Self {
         let namespace = namespace.as_ref().to_string();
         let containerd_address = containerd_address.as_ref().to_string();
         Self {
-            engine,
             namespace,
             containerd_address,
             stdin: PathBuf::default(),
@@ -91,11 +83,6 @@ impl<Engine: Send + Sync + Clone> InstanceConfig<Engine> {
         &self.bundle
     }
 
-    /// get the wasm engine for the instance
-    pub fn get_engine(&self) -> Engine {
-        self.engine.clone()
-    }
-
     /// get the namespace for the instance
     pub fn get_namespace(&self) -> String {
         self.namespace.clone()
@@ -116,7 +103,7 @@ pub trait Instance: 'static {
     type Engine: Send + Sync + Clone;
 
     /// Create a new instance
-    fn new(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Result<Self, Error>
+    fn new(id: String, cfg: Option<&InstanceConfig>) -> Result<Self, Error>
     where
         Self: Sized;
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -17,7 +17,7 @@ impl<T: Instance> InstanceData<T> {
     #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
     pub fn new(id: impl AsRef<str>, cfg: InstanceConfig) -> Result<Self> {
         let id = id.as_ref().to_string();
-        let instance = T::new(id, Some(&cfg))?;
+        let instance = T::new(id, &cfg)?;
         Ok(Self {
             instance,
             cfg,

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -8,14 +8,14 @@ use crate::sandbox::{Instance, InstanceConfig, Result};
 
 pub(super) struct InstanceData<T: Instance> {
     pub instance: T,
-    cfg: InstanceConfig<T::Engine>,
+    cfg: InstanceConfig,
     pid: OnceLock<u32>,
     state: RwLock<TaskState>,
 }
 
 impl<T: Instance> InstanceData<T> {
     #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
-    pub fn new(id: impl AsRef<str>, cfg: InstanceConfig<T::Engine>) -> Result<Self> {
+    pub fn new(id: impl AsRef<str>, cfg: InstanceConfig) -> Result<Self> {
         let id = id.as_ref().to_string();
         let instance = T::new(id, Some(&cfg))?;
         Ok(Self {
@@ -32,7 +32,7 @@ impl<T: Instance> InstanceData<T> {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
-    pub fn config(&self) -> &InstanceConfig<T::Engine> {
+    pub fn config(&self) -> &InstanceConfig {
         &self.cfg
     }
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
@@ -83,12 +83,8 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
-    fn instance_config(&self) -> InstanceConfig<T::Engine> {
-        InstanceConfig::new(
-            self.engine.clone(),
-            &self.namespace,
-            &self.containerd_address,
-        )
+    fn instance_config(&self) -> InstanceConfig {
+        InstanceConfig::new(&self.namespace, &self.containerd_address)
     }
 }
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
@@ -24,7 +24,7 @@ pub struct InstanceStub {
 
 impl Instance for InstanceStub {
     type Engine = ();
-    fn new(_id: String, _cfg: Option<&InstanceConfig<Self::Engine>>) -> Result<Self, Error> {
+    fn new(_id: String, _cfg: Option<&InstanceConfig>) -> Result<Self, Error> {
         Ok(InstanceStub {
             exit_code: WaitableCell::new(),
         })

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
@@ -24,7 +24,7 @@ pub struct InstanceStub {
 
 impl Instance for InstanceStub {
     type Engine = ();
-    fn new(_id: String, _cfg: Option<&InstanceConfig>) -> Result<Self, Error> {
+    fn new(_id: String, _cfg: &InstanceConfig) -> Result<Self, Error> {
         Ok(InstanceStub {
             exit_code: WaitableCell::new(),
         })

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -34,13 +34,13 @@ pub struct Instance<E: Engine> {
     _phantom: PhantomData<E>,
 }
 
-impl<E: Engine> SandboxInstance for Instance<E> {
+impl<E: Engine + Default> SandboxInstance for Instance<E> {
     type Engine = E;
 
     #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
-    fn new(id: String, cfg: Option<&InstanceConfig<Self::Engine>>) -> Result<Self, SandboxError> {
+    fn new(id: String, cfg: Option<&InstanceConfig>) -> Result<Self, SandboxError> {
         let cfg = cfg.context("missing configuration")?;
-        let engine = cfg.get_engine();
+        let engine = Self::Engine::default();
         let bundle = cfg.get_bundle().to_path_buf();
         let namespace = cfg.get_namespace();
         let rootdir = Path::new(DEFAULT_CONTAINER_ROOT_DIR).join(E::name());

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -38,8 +38,7 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
     type Engine = E;
 
     #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
-    fn new(id: String, cfg: Option<&InstanceConfig>) -> Result<Self, SandboxError> {
-        let cfg = cfg.context("missing configuration")?;
+    fn new(id: String, cfg: &InstanceConfig) -> Result<Self, SandboxError> {
         let engine = Self::Engine::default();
         let bundle = cfg.get_bundle().to_path_buf();
         let namespace = cfg.get_namespace();

--- a/crates/containerd-shim-wasm/src/sys/windows/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/windows/container/instance.rs
@@ -11,7 +11,7 @@ pub struct Instance<E: Engine>(PhantomData<E>);
 impl<E: Engine> SandboxInstance for Instance<E> {
     type Engine = E;
 
-    fn new(_id: String, _cfg: Option<&InstanceConfig<Self::Engine>>) -> Result<Self, SandboxError> {
+    fn new(_id: String, _cfg: &InstanceConfig) -> Result<Self, SandboxError> {
         todo!();
     }
 

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -212,11 +212,7 @@ where
 
         log::info!("building wasi test: {}", dir.display());
 
-        let mut cfg = InstanceConfig::new(
-            WasiInstance::Engine::default(),
-            TEST_NAMESPACE,
-            "/run/containerd/containerd.sock",
-        );
+        let mut cfg = InstanceConfig::new(TEST_NAMESPACE, "/run/containerd/containerd.sock");
         cfg.set_bundle(dir)
             .set_stdout(dir.join("stdout"))
             .set_stderr(dir.join("stderr"))

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -218,7 +218,7 @@ where
             .set_stderr(dir.join("stderr"))
             .set_stdin(dir.join("stdin"));
 
-        let instance = WasiInstance::new(self.container_name, Some(&cfg))?;
+        let instance = WasiInstance::new(self.container_name, &cfg)?;
         Ok(WasiTest { instance, tempdir })
     }
 }


### PR DESCRIPTION
This PR removes the `Engine` generic from `InstanceConfig`.
As we move away from reusing one engine for all containers, we don't need to pass the engine around anymore.

This is a breaking change.