### PR TITLE
Use Zygote process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "protobuf 3.2.0",
  "rand",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha256",
  "temp-env",
@@ -940,6 +941,7 @@ dependencies = [
  "wasmparser 0.220.0",
  "wat",
  "windows-sys 0.59.0",
+ "zygote",
 ]
 
 [[package]]
@@ -4515,6 +4517,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rust-criu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4835,6 +4859,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7741,4 +7774,17 @@ checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zygote"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e95c06f0156974c3cbdac79e5454938c1d301fca4224f5e17f8020cf011a0"
+dependencies = [
+ "libc",
+ "nix 0.29.0",
+ "rmp-serde",
+ "serde",
+ "thiserror 2.0.11",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3972,7 +3972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -7778,9 +7778,9 @@ dependencies = [
 
 [[package]]
 name = "zygote"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e95c06f0156974c3cbdac79e5454938c1d301fca4224f5e17f8020cf011a0"
+checksum = "8b78cf6140893151497b58da3c52d4e4dda37be26273b4acefe92a6f294d7cb6"
 dependencies = [
  "libc",
  "nix 0.29.0",

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -64,7 +64,7 @@ tracing-opentelemetry = { version = "0.24", optional = true }
 
 
 [target.'cfg(unix)'.dependencies]
-zygote = { version = "0.1.1" }
+zygote = { version = "0.1.2" }
 caps = "0.5"
 # this must match the version pulled by libcontainer
 dbus = { version = "0", features = ["vendored"] }

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -33,6 +33,7 @@ futures = { version = "0.3.30" }
 wasmparser = { version = "0.220.0" }
 tokio-stream = { version = "0.1" }
 sha256 = { workspace = true }
+serde_bytes = "0.11"
 
 # tracing
 # note: it's important to keep the version of tracing in sync with tracing-subscriber
@@ -63,6 +64,7 @@ tracing-opentelemetry = { version = "0.24", optional = true }
 
 
 [target.'cfg(unix)'.dependencies]
+zygote = { version = "0.1.1" }
 caps = "0.5"
 # this must match the version pulled by libcontainer
 dbus = { version = "0", features = ["vendored"] }
@@ -108,3 +110,7 @@ opentelemetry = [
     "dep:tracing-opentelemetry",
 ]
 tracing = ["dep:tracing", "dep:tracing-subscriber"]
+
+[package.metadata.cargo-machete]
+# used as part of a derive macro
+ignored = ["serde_bytes"]

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -47,6 +47,9 @@ pub fn shim_main<'a, I>(
     I: 'static + Instance + Sync + Send,
     I::Engine: Default,
 {
+    #[cfg(unix)]
+    zygote::Zygote::init();
+
     #[cfg(feature = "opentelemetry")]
     if otel_traces_enabled() {
         // opentelemetry uses tokio, so we need to initialize a runtime

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -4,12 +4,13 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use super::error::Error;
 
 /// Generic options builder for creating a wasm instance.
 /// This is passed to the `Instance::new` method.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct InstanceConfig {
     /// Optional stdin named pipe path.
     stdin: PathBuf,

--- a/crates/containerd-shim-wasm/src/sandbox/oci.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/oci.rs
@@ -8,12 +8,14 @@ use std::process;
 
 use anyhow::Context;
 use oci_spec::image::Descriptor;
+use serde::{Deserialize, Serialize};
 
 use super::error::Result;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WasmLayer {
     pub config: Descriptor,
+    #[serde(with = "serde_bytes")]
     pub layer: Vec<u8>,
 }
 

--- a/crates/containerd-shim-wasm/src/test/signals.rs
+++ b/crates/containerd-shim-wasm/src/test/signals.rs
@@ -19,35 +19,20 @@
 //! remove the ignore attribute from the test.
 
 use std::future::pending;
+use std::io::{stderr, Write as _};
 use std::sync::mpsc::channel;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
 
 use anyhow::{bail, Result};
 use containerd_shim_wasm_test_modules::HELLO_WORLD;
-use tokio::sync::Notify;
 
 use crate::container::{Engine, Instance, RuntimeContext};
 use crate::testing::WasiTest;
 
 #[derive(Clone, Default)]
 pub struct SomeEngine;
-
-async fn ctrl_c(use_libc: bool) {
-    static CANCELLATION: LazyLock<Notify> = LazyLock::new(|| Notify::new());
-
-    fn on_ctr_c(_: libc::c_int) {
-        CANCELLATION.notify_waiters();
-    }
-
-    if use_libc {
-        unsafe { libc::signal(libc::SIGINT, on_ctr_c as _) };
-        CANCELLATION.notified().await;
-    } else {
-        let _ = tokio::signal::ctrl_c().await;
-    }
-}
 
 impl Engine for SomeEngine {
     fn name() -> &'static str {
@@ -61,16 +46,16 @@ impl Engine for SomeEngine {
             .build()?
             .block_on(async move {
                 use tokio::time::sleep;
-                let use_libc = std::env::var("USE_LIBC").unwrap_or_default();
-                let use_libc = !use_libc.is_empty() && use_libc != "0";
                 let signal = async {
                     println!("{name}> waiting for signal!");
-                    ctrl_c(use_libc).await;
+                    let _ = tokio::signal::ctrl_c().await;
                     println!("{name}> received signal, bye!");
                 };
                 let task = async {
                     sleep(Duration::from_millis(10)).await;
-                    eprintln!("{name}> ready");
+                    // use writeln to avoid output capturing from the
+                    // testing framework
+                    let _ = writeln!(stderr(), "{name}> ready");
                     pending().await
                 };
                 tokio::select! {
@@ -92,8 +77,9 @@ impl Drop for KillGuard {
 }
 
 #[test]
-#[ignore = "this currently fails due to tokio's global state"]
 fn test_handling_signals() -> Result<()> {
+    zygote::Zygote::global();
+
     // use a thread scope to ensure we join all threads at the end
     std::thread::scope(|s| -> Result<()> {
         let mut containers = vec![];
@@ -108,7 +94,7 @@ fn test_handling_signals() -> Result<()> {
             containers.push(Arc::new(container));
         }
 
-        let guard: Vec<_> = containers.iter().cloned().map(KillGuard).collect();
+        let _guard: Vec<_> = containers.iter().cloned().map(KillGuard).collect();
 
         for container in containers.iter() {
             container.start()?;
@@ -147,8 +133,6 @@ fn test_handling_signals() -> Result<()> {
             println!("shim> received exit from container test-{id} (expected test-{i})");
             assert_eq!(id, i);
         }
-
-        drop(guard);
 
         Ok(())
     })

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -48,6 +48,8 @@ where
     WasiInstance::Engine: Default + Send + Sync + Clone,
 {
     pub fn new() -> Result<Self> {
+        zygote::Zygote::init();
+
         // start logging
         // to enable logging run `export RUST_LOG=trace` and append cargo command with
         // --show-output before running test


### PR DESCRIPTION
This PR introduces a zygote process (a very small process cloned early on during shim startup), from which new containers are created. This effectively decouples the global state of the shim from the state of the container process.

Fixes #755 and #357 