### PR TITLE
Make `precompile` and `can_precompile` not take self

### DIFF
--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -63,7 +63,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// The cached, precompiled layers will be reloaded on subsequent runs.
     /// The runtime is expected to return the same number of layers passed in, if the layer cannot be precompiled it should return `None` for that layer.
     /// In some edge cases it is possible that the layers may already be precompiled and None should be returned in this case.
-    fn precompile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<Vec<u8>>>> {
+    fn precompile(_layers: &[WasmLayer]) -> Result<Vec<Option<Vec<u8>>>> {
         bail!("precompile not supported");
     }
 
@@ -78,7 +78,7 @@ pub trait Engine: Clone + Send + Sync + 'static {
     /// "runwasi.io/precompiled/<Engine.name()>/<unique_string>"
     ///
     /// When it returns None the runtime will not be asked to precompile the module.  This is the default value.
-    fn can_precompile(&self) -> Option<String> {
+    fn can_precompile() -> Option<String> {
         None
     }
 }

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -48,7 +48,7 @@ impl<E: Engine> SandboxInstance for Instance<E> {
 
         // check if container is OCI image with wasm layers and attempt to read the module
         let (modules, platform) = containerd::Client::connect(cfg.get_containerd_address().as_str(), &namespace).block_on()?
-            .load_modules(&id, &engine)
+            .load_modules::<Self::Engine>(&id)
             .block_on()
             .unwrap_or_else(|e| {
                 log::warn!("Error obtaining wasm layers for container {id}.  Will attempt to use files inside container image. Error: {e}");

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -555,7 +555,7 @@ pub mod oci_helpers {
     pub fn get_content_label() -> Result<(String, String)> {
         let mut grep = Command::new("grep")
             .arg("-ohE")
-            .arg("runwasi.io/precompiled/[[:alpha:]]*/[0-9]+=.*")
+            .arg("runwasi.io/precompiled/[[:alpha:]]*/[[:xdigit:]]+=.*")
             .stdout(Stdio::piped())
             .stdin(Stdio::piped())
             .spawn()?;


### PR DESCRIPTION
This PR makes it so that `precompile` and `can_precompile` do not take self.

The main intention is that ideally we would not need an engine to precompile.
If a runtime can precompile without instantiating the wasm runtime, that would be ideal.

This would allow us to move all engine creation inside of the zygote process.

This makes tests a bit more finicky, as configuring the fake engine is not as simple.

However, the non-test code changes are rather straight forward.

This is marked as draft as I'm still exploring options.