### PR TITLE
[chore] revert to versioned release of youki's libcontainer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,8 +2730,9 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libcgroups"
-version = "0.4.1"
-source = "git+https://github.com/youki-dev/youki.git#8e855e00973f70fd1e8c94e66905bf144894a45e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3dffc7eec78b2c157d4045579fbb73329fcfa84708474a227f201c954cea717"
 dependencies = [
  "fixedbitset 0.5.7",
  "nix 0.28.0",
@@ -2744,8 +2745,9 @@ dependencies = [
 
 [[package]]
 name = "libcontainer"
-version = "0.4.1"
-source = "git+https://github.com/youki-dev/youki.git#8e855e00973f70fd1e8c94e66905bf144894a45e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fa6d64595be2725bca367640cece757a1869b473ae7d28a6c3d8e348d2d36f"
 dependencies = [
  "caps",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ containerd-shim-wasm-test-modules = { path = "crates/containerd-shim-wasm-test-m
 oci-tar-builder = { path = "crates/oci-tar-builder", version = "0.4.0" }
 env_logger = "0.11"
 libc = "0.2.169"
-libcontainer = { git = "https://github.com/youki-dev/youki.git", default-features = false }
+libcontainer = { version = "0.5", default-features = false }
 log = "0.4"
 nix = "0.29"
 oci-spec = { version = "0.7.1", features = ["runtime"] }


### PR DESCRIPTION
Youki released v0.5 of libcontainer.
This PR moves us back to release versions instead of git dependencies.