### PR TITLE
Extend precompile to support a DAG

### DIFF
--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -17,7 +17,7 @@ mod wasm;
 
 pub(crate) use context::WasiContext;
 pub use context::{Entrypoint, RuntimeContext, Source};
-pub use engine::Engine;
+pub use engine::{Engine, PrecompiledLayer};
 pub use instance::Instance;
 pub use path::PathResolve;
 pub use wasm::WasmBinaryType;


### PR DESCRIPTION
~Still WIP while I address some lingering TODOs but wanted to get this up for 👀 before too long.~

This PR effectively breaks the assumption that layers input to precompile map 1:1 with layers returned. This is necessary to support things like component dependencies in the spin shim via composition where there is not a clear mapping of original to precompiled layers. 

I tried to evolve the precompile API in the most straightforward way without requiring shim developers to have to manage a DAG themselves. 

~NOTE: have to update the other shims to conform to the new API which will be straightforward but i'd like to get feedback on this approach here first.~

cc/ @Mossaka @jsturtevant @kate-goldenring 