### PR TITLE
.github/workflows/action-test-smoke: Add a step to verify the jeager

### DIFF
--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           name: test-img
           path: dist
-      - name: enable OTLP
+      - name: Enable OTLP
         if: ${{ inputs.runtime == 'wasmtime' }}
         run: |
-          sudo ./scripts/setup-otel.sh
-      - name: run
+          sudo ./scripts/setup-jeager-and-otel.sh
+      - name: Run wasi-demo-app using ctr
         timeout-minutes: 5
         run: |
           ls -alh dist
@@ -48,3 +48,8 @@ jobs:
           make load
           sudo cp -f dist/bin/* /usr/local/bin
           sudo ctr run --rm --runtime=io.containerd.${{ inputs.runtime }}.v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm /wasi-demo-app.wasm echo 'hello'
+      - name: Verify Jaeger traces
+        if: ${{ inputs.runtime == 'wasmtime' }}
+        run: |
+          sleep 5
+          sudo ./scripts/verify-jaeger-traces.sh

--- a/scripts/setup-jeager-and-otel.sh
+++ b/scripts/setup-jeager-and-otel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 # start jeager endpoint 
 docker run -d -p16686:16686 -p4317:4317 -p4318:4318 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:latest
@@ -11,7 +12,8 @@ mkdir -p /etc/systemd/system/containerd.service.d
 cat <<EOF > /etc/systemd/system/containerd.service.d/override.conf
 [Service]
 Environment="OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318"
-Environment="OTEL_SERVICE_NAME=wasmtime"
+Environment="OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf"
+Environment="OTEL_SERVICE_NAME=containerd"
 EOF
 
 systemctl daemon-reload

--- a/scripts/verify-jaeger-traces.sh
+++ b/scripts/verify-jaeger-traces.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TRACE_DATA=$(curl -s "http://localhost:16686/api/traces?service=containerd&limit=0" \
+    | jq '[ .data[].spans[].operationName ]')
+
+REQUIRED_OPS=("task_create" "task_wait" "task_start" "task_delete" "task_state" "wait" "shutdown" "shim_main_inner")
+
+for op in "${REQUIRED_OPS[@]}"; do
+  COUNT=$(echo "$TRACE_DATA" | jq --arg op "$op" '[ .[] | select(. == $op) ] | length')
+  if [ "$COUNT" -eq 0 ]; then
+    echo "Operation '$op' not found in Jaeger!"
+    exit 1
+  fi
+done
+
+echo "All required operations found in Jaeger!"


### PR DESCRIPTION
Add a GitHub Action step to verify that Jeager actually receives the expected emitted traces, rather than just hoping they made it.

It uses Jeager API to fetch the traces, and note that the limit=0 so that we can get all the operations.

This is to prevent #787 from happening without getting notices. 