### PR TITLE
feat(shims): enable opentelemetry for shims

### DIFF
--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -37,7 +37,6 @@ jobs:
           name: test-img
           path: dist
       - name: Enable OTLP
-        if: ${{ inputs.runtime == 'wasmtime' }}
         run: |
           sudo ./scripts/setup-jeager-and-otel.sh
       - name: Run wasi-demo-app using ctr
@@ -49,7 +48,6 @@ jobs:
           sudo cp -f dist/bin/* /usr/local/bin
           sudo ctr run --rm --runtime=io.containerd.${{ inputs.runtime }}.v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm /wasi-demo-app.wasm echo 'hello'
       - name: Verify Jaeger traces
-        if: ${{ inputs.runtime == 'wasmtime' }}
         run: |
           sleep 5
           sudo ./scripts/verify-jaeger-traces.sh

--- a/crates/containerd-shim-wamr/Cargo.toml
+++ b/crates/containerd-shim-wamr/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-containerd-shim-wasm = { workspace = true }
+containerd-shim-wasm = { workspace = true, features = ["opentelemetry"] }
 log = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-containerd-shim-wasm = { workspace = true }
+containerd-shim-wasm = { workspace = true, features = ["opentelemetry"] }
 log = { workspace = true }
 
 # may need to bump wasmedge version in scripts/setup-windows.sh

--- a/crates/containerd-shim-wasmer/Cargo.toml
+++ b/crates/containerd-shim-wasmer/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-containerd-shim-wasm = { workspace = true }
+containerd-shim-wasm = { workspace = true, features = ["opentelemetry"] }
 log = { workspace = true }
 tokio = { workspace = true }
 


### PR DESCRIPTION
Currently, only the wasmtime shim enables the otel tracing. This PR enables the otel tracing for all shims.