### PR TITLE
feat(*): use published images instead of locally built ones

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,5 +7,5 @@ runs:
     - name: Build and pull
       shell: bash
       run: |
-        make OPT_PROFILE=release build install
-        sudo make pull
+        set -euxo pipefail
+        make OPT_PROFILE=release build install pull

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,11 @@
+name: Build artifacts and pull images
+description: 'Build artifacts and pull images'
+
+runs:
+  using: composite
+  steps:
+    - name: Build and pull
+      shell: bash
+      run: |
+        make OPT_PROFILE=release build install
+        sudo make pull

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,9 @@
+name: Setup Environment
+description: 'Common environment setup'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup OS dependencies
+      shell: bash
+      run: ./scripts/setup-$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]').sh

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -41,11 +41,7 @@ jobs:
         run: |
           echo "::notice::Running job with os: '${{ inputs.os }}', arch: '${{ inputs.arch }}', slug: '${{ inputs.slug }}', runtime: '${{ inputs.runtime }}', target: '${{ inputs.target }}'"
       - uses: actions/checkout@v4
-      - name: Setup build env
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-        shell: bash
+      - uses: ./.github/actions/setup-env
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         env:
           RUST_CACHE_KEY_OS: rust-cache-${{ inputs.os }}-${{ inputs.slug }}

--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -22,11 +22,7 @@ jobs:
         with:
           components: rustfmt, clippy
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup build env
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-        shell: bash
+      - uses: ./.github/actions/setup-env
       - run: 
           # needed to run rustfmt in nightly toolchain
           rustup toolchain install nightly --component rustfmt

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-        shell: bash
+      - uses: ./.github/actions/setup-env
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -24,9 +24,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-        shell: bash
+      - uses: ./.github/actions/setup-env
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -43,7 +43,7 @@ jobs:
           ls -alh dist
           ls -alh dist/bin
           sudo cp -f dist/bin/* /usr/local/bin
-          sudo make pull-app
+          make pull-app
           sudo ctr run --rm --runtime=io.containerd.${{ inputs.runtime }}.v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm /wasi-demo-app.wasm echo 'hello'
       - name: Verify Jaeger traces
         run: |

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
-        shell: bash
+      - uses: ./.github/actions/setup-env
       - name: Download artifacts
         uses: actions/download-artifact@master
         with:

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -44,8 +44,8 @@ jobs:
         run: |
           ls -alh dist
           ls -alh dist/bin
-          make load
           sudo cp -f dist/bin/* /usr/local/bin
+          sudo make pull-app
           sudo ctr run --rm --runtime=io.containerd.${{ inputs.runtime }}.v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm /wasi-demo-app.wasm echo 'hello'
       - name: Verify Jaeger traces
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Build and load shims and wasi-demo-app
         shell: bash
         run: |
-          make OPT_PROFILE=release build install pull
+          make OPT_PROFILE=release build install 
+          sudo make pull
       - name: Run Benchmarks
         shell: bash
         run: |
@@ -69,7 +70,8 @@ jobs:
       - name: Build and load shims and wasi-demo-app
         shell: bash
         run: |
-          make OPT_PROFILE=release build install pull          
+          make OPT_PROFILE=release build install
+          sudo make pull          
       - name: Run Benchmarks
         shell: bash
         run: |
@@ -113,7 +115,8 @@ jobs:
       - name: Build and load shims and wasi-demo-app
         shell: bash
         run: |
-          make OPT_PROFILE=release build install pull
+          make OPT_PROFILE=release build install
+          sudo make pull
       - name: Start wasmtime shim
         shell: bash
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build and load shims and wasi-demo-app
         shell: bash
         run: |
-          make OPT_PROFILE=release build install test-image load test-image/oci load/oci
+          make OPT_PROFILE=release build install pull
       - name: Run Benchmarks
         shell: bash
         run: |
@@ -69,7 +69,7 @@ jobs:
       - name: Build and load shims and wasi-demo-app
         shell: bash
         run: |
-          make OPT_PROFILE=release build install test-image load test-image/oci load/oci
+          make OPT_PROFILE=release build install pull          
       - name: Run Benchmarks
         shell: bash
         run: |
@@ -113,7 +113,7 @@ jobs:
       - name: Build and load shims and wasi-demo-app
         shell: bash
         run: |
-          make OPT_PROFILE=release build install test-image/http load/http
+          make OPT_PROFILE=release build install pull
       - name: Start wasmtime shim
         shell: bash
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,16 +20,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup build environment
-        shell: bash
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-      - name: Build and load shims and wasi-demo-app
-        shell: bash
-        run: |
-          make OPT_PROFILE=release build install 
-          sudo make pull
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build
       - name: Run Benchmarks
         shell: bash
         run: |
@@ -62,16 +54,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup build environment
-        shell: bash
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-      - name: Build and load shims and wasi-demo-app
-        shell: bash
-        run: |
-          make OPT_PROFILE=release build install
-          sudo make pull          
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build
       - name: Run Benchmarks
         shell: bash
         run: |
@@ -107,16 +91,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
-      - name: Setup build environment
-        shell: bash
-        run: |
-          os=$(echo "$RUNNER_OS" | tr '[:upper:]' '[:lower:]')
-          ./scripts/setup-$os.sh
-      - name: Build and load shims and wasi-demo-app
-        shell: bash
-        run: |
-          make OPT_PROFILE=release build install
-          sudo make pull
+      - uses: ./.github/actions/setup-env
+      - uses: ./.github/actions/build
       - name: Start wasmtime shim
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Setup build env
-      run: ./scripts/setup-linux.sh
-      shell: bash
+    - uses: ./.github/actions/setup-env
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: Swatinem/rust-cache@v2
     - name: Check documentation

--- a/.github/workflows/release-wasi-demo-app.yml
+++ b/.github/workflows/release-wasi-demo-app.yml
@@ -31,8 +31,7 @@ jobs:
       wasi_http: ${{ steps.get_digests.outputs.wasi_http }}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
+      - uses: ./.github/actions/setup-env
       - name: Install Rust and wasm32-wasi target
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,7 @@ jobs:
         run: |
           echo "::notice::Running job with dry_run: '${{ inputs.dry_run }}', crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
       - uses: actions/checkout@v4
-      - name: Setup build env
-        run: ./scripts/setup-linux.sh
+      - uses: ./.github/actions/setup-env
       - name: Download artifacts
         if: ${{ matrix.is_shim == 'true' }}
         uses: actions/download-artifact@master

--- a/Makefile
+++ b/Makefile
@@ -220,16 +220,16 @@ pull: pull-app pull-oci pull-oci-artifact pull-http
 	echo "Pulled all images"
 
 pull-app:
-	ctr image pull ghcr.io/containerd/runwasi/wasi-demo-app:latest
+	sudo ctr image pull ghcr.io/containerd/runwasi/wasi-demo-app:latest
 
 pull-oci:
-	ctr image pull ghcr.io/containerd/runwasi/wasi-demo-oci:latest
+	sudo ctr image pull ghcr.io/containerd/runwasi/wasi-demo-oci:latest
 
 pull-oci-artifact:
-	ctr image pull ghcr.io/containerd/runwasi/wasi-demo-oci-artifact:latest
+	sudo ctr image pull ghcr.io/containerd/runwasi/wasi-demo-oci-artifact:latest
 
 pull-http:
-	ctr image pull ghcr.io/containerd/runwasi/wasi-http:latest
+	sudo ctr image pull ghcr.io/containerd/runwasi/wasi-http:latest
 
 docker/load: dist/img.tar
 	docker load -i $<

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ sudo make install
 Pull the test image:
 
 ```
-sudo make pull-app
+make pull-app
 ```
 
 ### Demo 1 using container image that contains a Wasm module.
@@ -187,7 +187,7 @@ To learn more about this approach checkout the [design document](https://docs.go
 Pull the OCI image with WASM layers image:
 
 ```
-sudo make pull
+make pull
 ```
 
 Run the image with `sudo ctr run --rm --runtime=io.containerd.[ wasmedge | wasmtime | wasmer | wamr ].v1 ghcr.io/containerd/runwasi/wasi-demo-oci:latest testwasmoci`

--- a/README.md
+++ b/README.md
@@ -146,11 +146,10 @@ sudo make install
 
 > Note: `make build` will only build one binary. The `make install` command copies the binary to $PATH and uses symlinks to create all the component described above.
 
-Build the test image and load it into containerd:
+Pull the test image:
 
 ```
-make test-image
-make load
+sudo make pull-app
 ```
 
 ### Demo 1 using container image that contains a Wasm module.
@@ -185,11 +184,10 @@ To learn more about this approach checkout the [design document](https://docs.go
 
 > **Note**: This requires containerd 1.7.7+ and 1.6.25+.  If you do not have these patches for both `containerd` and `ctr` you will end up with an error message such as `mismatched image rootfs and manifest layers` at the import and run steps. Latest versions of k3s and kind have the necessary containerd versions.
 
-Build and import the OCI image with WASM layers image:
+Pull the OCI image with WASM layers image:
 
 ```
-make test-image/oci
-make load/oci
+sudo make pull
 ```
 
 Run the image with `sudo ctr run --rm --runtime=io.containerd.[ wasmedge | wasmtime | wasmer | wamr ].v1 ghcr.io/containerd/runwasi/wasi-demo-oci:latest testwasmoci`
@@ -205,8 +203,6 @@ exiting
 The [CNCF tag-runtime wasm working group](https://tag-runtime.cncf.io/wgs/wasm/charter/) has a [OCI Artifact format for Wasm](https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/).  This is a new Artifact type that enable the usage across projects beyond just runwasi, see the https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/#implementations
 
 ```
-make test-image/oci
-make load/oci
 make test/k8s-oci-wasmtime
 ```
 

--- a/benches/containerd-shim-benchmarks/README.md
+++ b/benches/containerd-shim-benchmarks/README.md
@@ -10,12 +10,9 @@ make build
 sudo make install
 ```
 
-Then, build and load the wasi-demo-app:
+Then, pull the wasi-demo-app:
 ```bash
-make test-image
-make load
-make test-image/oci
-make load/oci
+sudo make pull
 ```
 
 To run all benchmarks:

--- a/benches/containerd-shim-benchmarks/README.md
+++ b/benches/containerd-shim-benchmarks/README.md
@@ -12,7 +12,7 @@ sudo make install
 
 Then, pull the wasi-demo-app:
 ```bash
-sudo make pull
+make pull
 ```
 
 To run all benchmarks:

--- a/crates/containerd-shim-wasmtime/README.md
+++ b/crates/containerd-shim-wasmtime/README.md
@@ -60,7 +60,7 @@ cargo run --bin oci-tar-builder -- \
 - Pull the image:
 
 ```shell
-sudo make pull-http
+make pull-http
 ```
 
 - Run the image:

--- a/crates/containerd-shim-wasmtime/README.md
+++ b/crates/containerd-shim-wasmtime/README.md
@@ -57,10 +57,10 @@ cargo run --bin oci-tar-builder -- \
     -o ./dist/wasi-http-img-oci.tar
 ```
 
-- Import the image:
+- Pull the image:
 
 ```shell
-sudo ctr image import --all-platforms ./dist/wasi-http-img-oci.tar
+sudo make pull-http
 ```
 
 - Run the image:

--- a/docs/windows-getting-started.md
+++ b/docs/windows-getting-started.md
@@ -15,8 +15,7 @@ To finish off installing pre-requisites, install Rust following [this](https://w
 After following these steps and navigating to the runwasi directory in your terminal:
 - run `make build`,
 - run `make install`,
-- run `make test-image`, and
-- run `make load`.
+- run `sudo make pull-app`.
 
 After this, you can execute an example, like: `ctr run --rm --runtime=io.containerd.wasmtime.v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm`.
 

--- a/docs/windows-getting-started.md
+++ b/docs/windows-getting-started.md
@@ -15,7 +15,7 @@ To finish off installing pre-requisites, install Rust following [this](https://w
 After following these steps and navigating to the runwasi directory in your terminal:
 - run `make build`,
 - run `make install`,
-- run `sudo make pull-app`.
+- run `make pull-app`.
 
 After this, you can execute an example, like: `ctr run --rm --runtime=io.containerd.wasmtime.v1 ghcr.io/containerd/runwasi/wasi-demo-app:latest testwasm`.
 

--- a/test/k3s/bootstrap.sh
+++ b/test/k3s/bootstrap.sh
@@ -16,6 +16,5 @@ EOF
 systemctl daemon-reload
 systemctl restart k3s-runwasi
 while ! bin/k3s ctr version; do sleep 1; done
-bin/k3s ctr image import --all-platforms $2
 while [ "$(bin/k3s kubectl get pods --all-namespaces --no-headers | wc -l)" == "0" ]; do sleep 1; done
 while [ "$(bin/k3s kubectl get pods --all-namespaces --no-headers | grep -vE "Completed|Running" | wc -l)" != "0" ]; do sleep 1; done

--- a/test/k8s/deploy.oci.yaml
+++ b/test/k8s/deploy.oci.yaml
@@ -24,10 +24,8 @@ spec:
       containers:
         - name: demo
           image: ghcr.io/containerd/runwasi/wasi-demo-oci:latest
-          imagePullPolicy: Never
         - name: demo-artifact
           image: ghcr.io/containerd/runwasi/wasi-demo-oci-artifact:latest
-          imagePullPolicy: Never
           command: ["wasi-demo.wasm"]
         - name: nginx
           image: docker.io/nginx:latest

--- a/test/k8s/deploy.yaml
+++ b/test/k8s/deploy.yaml
@@ -24,7 +24,6 @@ spec:
       containers:
       - name: demo
         image: ghcr.io/containerd/runwasi/wasi-demo-app:latest
-        imagePullPolicy: Never
       - name: nginx
         image: docker.io/nginx:latest
         ports:


### PR DESCRIPTION
- Replaced `make load` with `sudo make pull`
- Updated documents to pull images from `ghcr.io` instead of building them locally