### PR TITLE
fix(ci): fix http latency benchmark on PR

### DIFF
--- a/.github/actions/run-hey-load-test/action.yml
+++ b/.github/actions/run-hey-load-test/action.yml
@@ -55,6 +55,12 @@ runs:
     # 
     # The workaround is to use the `external-data-json-path` option to tell the action to not 
     # attempt to update the local `gh-pages` branch.
+    - name: Download previous benchmark data
+      if : ${{ github.event_name != 'schedule' }}
+      uses: actions/cache@v4
+      with:
+        path: ./cache
+        key: ${{ runner.os }}-benchmark
     - name: Report Latency results
       if : ${{ github.event_name != 'schedule' }}
       uses: benchmark-action/github-action-benchmark@v1.20.4


### PR DESCRIPTION
The HTTP latency benchmark on PR is not working as expected. It gives a warning saying ./cache/latency_results.json is not found. This commit adds a step to download the cache file from previous run as an attempt to fix the issue.