### PR TITLE
feat(otel): add context propogation from containerd to the shim

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/containerd/client.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/containerd/client.rs
@@ -57,7 +57,7 @@ impl WriteContent {
 // sync wrapper implementation from https://tokio.rs/tokio/topics/bridging
 impl Client {
     // wrapper around connection that will establish a connection and create a client
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub async fn connect(
         address: impl AsRef<Path>,
         namespace: impl Into<String>,
@@ -73,7 +73,7 @@ impl Client {
     }
 
     // wrapper around read that will read the entire content file
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn read_content(&self, digest: impl ToString) -> Result<Vec<u8>> {
         let req = ReadContentRequest {
             digest: digest.to_string(),
@@ -93,7 +93,7 @@ impl Client {
 
     // used in tests to clean up content
     #[allow(dead_code)]
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn delete_content(&self, digest: impl ToString) -> Result<()> {
         let req = DeleteContentRequest {
             digest: digest.to_string(),
@@ -107,7 +107,7 @@ impl Client {
     }
 
     // wrapper around lease that will create a lease and return a guard that will delete the lease when dropped
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn lease(&self, reference: String) -> Result<LeaseGuard> {
         let mut lease_labels = HashMap::new();
         // Unwrap is safe here since 24 hours is a valid time
@@ -136,7 +136,7 @@ impl Client {
         ))
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn save_content(
         &self,
         data: Vec<u8>,
@@ -258,7 +258,7 @@ impl Client {
         Ok(WriteContent { lease, digest })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn get_info(&self, content_digest: &Digest) -> Result<Info> {
         let req = InfoRequest {
             digest: content_digest.to_string(),
@@ -276,7 +276,7 @@ impl Client {
         Ok(info)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn update_info(&self, info: Info) -> Result<Info> {
         let mut req = UpdateRequest {
             info: Some(info.clone()),
@@ -299,7 +299,7 @@ impl Client {
         Ok(info)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn get_image(&self, image_name: impl ToString) -> Result<Image> {
         let name = image_name.to_string();
         let req = GetImageRequest { name };
@@ -319,7 +319,7 @@ impl Client {
         Ok(image)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn extract_image_content_sha(&self, image: &Image) -> Result<String> {
         let digest = image
             .target
@@ -335,7 +335,7 @@ impl Client {
         Ok(digest)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn get_container(&self, container_name: impl ToString) -> Result<Container> {
         let id = container_name.to_string();
         let req = GetContainerRequest { id };
@@ -355,7 +355,7 @@ impl Client {
         Ok(container)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn get_image_manifest_and_digest(
         &self,
         image_name: &str,
@@ -370,7 +370,7 @@ impl Client {
     // load module will query the containerd store to find an image that has an OS of type 'wasm'
     // If found it continues to parse the manifest and return the layers that contains the WASM modules
     // and possibly other configuration layers.
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub async fn load_modules<T: Engine>(
         &self,
         containerd_id: impl ToString,
@@ -508,7 +508,7 @@ impl Client {
         Ok((layers, platform))
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     async fn read_wasm_layer(
         &self,
         original_config: &oci_spec::image::Descriptor,

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -12,7 +12,7 @@ struct Options {
     root: Option<PathBuf>,
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
 pub fn determine_rootdir(
     bundle: impl AsRef<Path>,
     namespace: &str,

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -14,7 +14,7 @@ pub(super) struct InstanceData<T: Instance> {
 }
 
 impl<T: Instance> InstanceData<T> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn new(id: impl AsRef<str>, cfg: InstanceConfig) -> Result<Self> {
         let id = id.as_ref().to_string();
         let instance = T::new(id, &cfg)?;
@@ -26,17 +26,17 @@ impl<T: Instance> InstanceData<T> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn pid(&self) -> Option<u32> {
         self.pid.get().copied()
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn config(&self) -> &InstanceConfig {
         &self.cfg
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn start(&self) -> Result<u32> {
         let mut s = self.state.write().unwrap();
         s.start()?;
@@ -56,7 +56,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn kill(&self, signal: u32) -> Result<()> {
         let mut s = self.state.write().unwrap();
         s.kill()?;
@@ -64,7 +64,7 @@ impl<T: Instance> InstanceData<T> {
         self.instance.kill(signal)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn delete(&self) -> Result<()> {
         let mut s = self.state.write().unwrap();
         s.delete()?;
@@ -79,7 +79,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn wait(&self) -> (u32, DateTime<Utc>) {
         let res = self.instance.wait();
         let mut s = self.state.write().unwrap();
@@ -87,7 +87,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn wait_timeout(&self, t: impl Into<Option<Duration>>) -> Option<(u32, DateTime<Utc>)> {
         let res = self.instance.wait_timeout(t);
         if res.is_some() {

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
@@ -47,7 +47,7 @@ pub struct Local<T: Instance + Send + Sync, E: EventSender = RemoteEventSender> 
 
 impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
     /// Creates a new local task service.
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn new(
         engine: T::Engine,
         events: E,
@@ -68,23 +68,23 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub(super) fn get_instance(&self, id: &str) -> Result<Arc<InstanceData<T>>> {
         let instance = self.instances.read().unwrap().get(id).cloned();
         instance.ok_or_else(|| Error::NotFound(id.to_string()))
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn has_instance(&self, id: &str) -> bool {
         self.instances.read().unwrap().contains_key(id)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn is_empty(&self) -> bool {
         self.instances.read().unwrap().is_empty()
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn instance_config(&self) -> InstanceConfig {
         InstanceConfig::new(&self.namespace, &self.containerd_address)
     }
@@ -92,7 +92,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
 
 // These are the same functions as in Task, but without the TtrcpContext, which is useful for testing
 impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_create(&self, req: CreateTaskRequest) -> Result<CreateTaskResponse> {
         if !req.checkpoint().is_empty() || !req.parent_checkpoint().is_empty() {
             return Err(ShimError::Unimplemented("checkpoint is not supported".to_string()).into());
@@ -178,7 +178,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_start(&self, req: StartRequest) -> Result<StartResponse> {
         if req.exec_id().is_empty().not() {
             return Err(ShimError::Unimplemented("exec is not supported".to_string()).into());
@@ -221,7 +221,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_kill(&self, req: KillRequest) -> Result<Empty> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -230,7 +230,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         Ok(Empty::new())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_delete(&self, req: DeleteRequest) -> Result<DeleteResponse> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -262,7 +262,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_wait(&self, req: WaitRequest) -> Result<WaitResponse> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -279,7 +279,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_state(&self, req: StateRequest) -> Result<StateResponse> {
         if !req.exec_id().is_empty() {
             return Err(Error::InvalidArgument("exec is not supported".to_string()));
@@ -311,7 +311,7 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn task_stats(&self, req: StatsRequest) -> Result<StatsResponse> {
         let i = self.get_instance(req.id())?;
         let pid = i

--- a/crates/containerd-shim-wasm/src/sandbox/shim/otel.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/otel.rs
@@ -430,7 +430,9 @@ mod tests {
 
         let extractor = MetadataExtractor(&metadata);
         assert_eq!(extractor.get("key"), Some("value"));
-        assert_eq!(extractor.keys(), vec!["key", "key2"]);
+        let mut keys = extractor.keys();
+        keys.sort();
+        assert_eq!(keys, vec!["key", "key2"]);
 
         assert_eq!(extractor.get("key2"), Some("value2"));
     }

--- a/crates/containerd-shim-wasm/src/sandbox/shim/otel.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/otel.rs
@@ -26,7 +26,9 @@ use std::collections::HashMap;
 use std::env;
 
 use opentelemetry::global::{self, set_text_map_propagator};
+use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::TraceError;
+use opentelemetry::Context;
 use opentelemetry_otlp::{
     Protocol, SpanExporterBuilder, WithExportConfig, OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT,
 };
@@ -206,6 +208,26 @@ where
             otel_data.builder.name = new_name.into();
         }
     }
+}
+
+/// MetadataExtractor is a wrapper around HashMap<String, Vec<String>> which is the type
+/// as TtrpcContext.meatdata. It implements the Extractor trait from opentelemetry.
+struct MetadataExtractor<'a>(pub &'a HashMap<String, Vec<String>>);
+
+impl Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.first()).map(|s| s.as_str())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+/// extract_context extracts the context from the metadata HashMap.
+pub(crate) fn extract_context(metadata: &HashMap<String, Vec<String>>) -> Context {
+    let extractor = MetadataExtractor(metadata);
+    opentelemetry::global::get_text_map_propagator(|propagator| propagator.extract(&extractor))
 }
 
 #[cfg(test)]
@@ -398,5 +420,18 @@ mod tests {
             let result = Config::build_from_env();
             assert!(result.is_err());
         });
+    }
+
+    #[test]
+    fn test_metadata_extractor() {
+        let mut metadata = HashMap::new();
+        metadata.insert("key".to_string(), vec!["value".to_string()]);
+        metadata.insert("key2".to_string(), vec!["value2".to_string()]);
+
+        let extractor = MetadataExtractor(&metadata);
+        assert_eq!(extractor.get("key"), Some("value"));
+        assert_eq!(extractor.keys(), vec!["key", "key2"]);
+
+        assert_eq!(extractor.get("key2"), Some("value2"));
     }
 }

--- a/crates/containerd-shim-wasm/src/sandbox/shim/task_state.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/task_state.rs
@@ -11,7 +11,7 @@ pub(super) enum TaskState {
 }
 
 impl TaskState {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn start(&mut self) -> Result<()> {
         *self = match self {
             Self::Created => Ok(Self::Starting),
@@ -20,7 +20,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn kill(&mut self) -> Result<()> {
         *self = match self {
             Self::Started => Ok(Self::Started),
@@ -29,7 +29,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn delete(&mut self) -> Result<()> {
         *self = match self {
             Self::Created | Self::Exited => Ok(Self::Deleting),
@@ -38,7 +38,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn started(&mut self) -> Result<()> {
         *self = match self {
             Self::Starting => Ok(Self::Started),
@@ -47,7 +47,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     pub fn stop(&mut self) -> Result<()> {
         *self = match self {
             Self::Started | Self::Starting => Ok(Self::Exited),

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -33,7 +33,7 @@ pub(crate) struct Executor<E: Engine> {
 }
 
 impl<E: Engine> LibcontainerExecutor for Executor<E> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError> {
         // We can handle linux container. We delegate wasm container to the engine.
         match self.inner(spec) {
@@ -42,7 +42,7 @@ impl<E: Engine> LibcontainerExecutor for Executor<E> {
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
     fn exec(&self, spec: &Spec) -> Result<(), LibcontainerExecutorError> {
         // If it looks like a linux container, run it as a linux container.
         // Otherwise, run it as a wasm container

--- a/crates/containerd-shim-wasm/src/sys/unix/metrics.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/metrics.rs
@@ -3,7 +3,7 @@ use containerd_shim::cgroup::collect_metrics;
 use containerd_shim::util::convert_to_any;
 use protobuf::well_known_types::any::Any;
 
-#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
 pub fn get_metrics(pid: u32) -> Result<Any> {
     let metrics = collect_metrics(pid)?;
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -171,7 +171,7 @@ impl Engine for WasmtimeEngine {
                 Some(Module) => PRECOMPILER.precompile_module(&layer.layer)?,
                 Some(Component) => PRECOMPILER.precompile_component(&layer.layer)?,
                 None => {
-                    log::warn!("Unknow WASM binary type");
+                    log::warn!("Unknown WASM binary type");
                     continue;
                 }
             };
@@ -218,12 +218,12 @@ impl WasmtimeEngineImpl {
             let instance: wasmtime::Instance =
                 module_linker.instantiate_async(&mut store, &module).await?;
 
-            log::info!("getting start function");
+            log::debug!("getting start function");
             let start_func = instance
                 .get_func(&mut store, func)
                 .context("module does not have a WASI start function")?;
 
-            log::debug!("running start function {func:?}");
+            log::info!("running start function {func:?}");
 
             start_func
                 .call_async(&mut store, &[], &mut [])

--- a/scripts/verify-jaeger-traces.sh
+++ b/scripts/verify-jaeger-traces.sh
@@ -6,11 +6,11 @@ TRACE_DATA=$(curl -s "http://localhost:16686/api/traces?service=containerd&limit
 
 PREFIX="containerd_shim_wasm::sandbox"
 REQUIRED_OPS=(
-    "${PREFIX}::shim::local::task_create"
-    "${PREFIX}::shim::local::task_wait"
-    "${PREFIX}::shim::local::task_start"
-    "${PREFIX}::shim::local::task_delete"
-    "${PREFIX}::shim::local::task_state"
+    "${PREFIX}::shim::local::create"
+    "${PREFIX}::shim::local::wait"
+    "${PREFIX}::shim::local::start"
+    "${PREFIX}::shim::local::delete"
+    "${PREFIX}::shim::local::state"
     "${PREFIX}::shim::cli::wait"
     "${PREFIX}::shim::local::shutdown"
     "${PREFIX}::cli::shim_main_inner"


### PR DESCRIPTION
this PR converts the TtrpcContext.metadata to the opentelemetry::Context and use it to propogate the parent span information to each TTRPC handler. The result of this change is that we will be able to preserve the context from containerd Task service:

<img width="1436" alt="image" src="https://github.com/user-attachments/assets/8732a199-da4c-4802-bb9e-b9d3038c49a5" />


This PR also marks all the utility functions as "Debug" level tracing instead of "Info". The functions that have "Info" tracing are listed below:

1. **Module: `crates/containerd-shim-wasm/src/sandbox/cli.rs`**
   - `shim_main_inner`

2. **Module: `crates/containerd-shim-wasm/src/sandbox/instance.rs`**
   - `wait`

3. **Module: `crates/containerd-shim-wasm/src/sandbox/shim/cli.rs`**
   - `new`
   - `start_shim`
   - `wait`
   - `create_task_service`
   - `delete_shim`

4. **Module: `crates/containerd-shim-wasm/src/sandbox/shim/local.rs`**
   - `create`
   - `start`
   - `kill`
   - `delete`
   - `wait`
   - `connect`
   - `state`
   - `shutdown`
   - `stats`

5. **Module: `crates/containerd-shim-wasm/src/sys/unix/container/instance.rs`**
   - `new`
   - `start`
   - `kill`
   - `delete`
   - `wait_timeout`
