### PR TITLE
docs: improve the docs for containerd-shim-wasm crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ impl Engine for MyEngine {
 }
 
 fn main() {
-    shim::run::<ShimCli<Instance<Engine>>>("io.containerd.myshim.v1", opts);
+    shim::run::<ShimCli<Instance<MyEngine>>>("io.containerd.myshim.v1", opts);
 }
 ```
 

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Removed
+- `containerd_shim_wasm::container::PathResolve` is now a private module ([#837](https://github.com/containerd/runwasi/pull/837))
+
 ## [v0.9.0] - 2025-01-27
 
 ### Added

--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -8,6 +8,8 @@ use oci_spec::runtime::Spec;
 use crate::container::path::PathResolve;
 use crate::sandbox::oci::WasmLayer;
 
+/// The `RuntimeContext` trait provides access to the runtime context that includes
+/// the arguments, environment variables, and entrypoint for the container.
 pub trait RuntimeContext {
     // ctx.args() returns arguments from the runtime spec process field, including the
     // path to the entrypoint executable.

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -7,6 +7,9 @@ use super::Source;
 use crate::container::{PathResolve, RuntimeContext};
 use crate::sandbox::oci::WasmLayer;
 
+/// The `Engine` trait provides a simplified API for running WebAssembly containers.
+///
+/// It handles the lifecycle of the container and OCI spec details for you.
 pub trait Engine: Clone + Send + Sync + 'static {
     /// The name to use for this engine
     fn name() -> &'static str;

--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use context::WasiContext;
 pub use context::{Entrypoint, RuntimeContext, Source};
 pub use engine::Engine;
 pub use instance::Instance;
-pub use path::PathResolve;
+pub(crate) use path::PathResolve;
 pub use wasm::WasmBinaryType;
 
 use crate::sys::container::instance;

--- a/crates/containerd-shim-wasm/src/container/path.rs
+++ b/crates/containerd-shim-wasm/src/container/path.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+/// PathResolve allows to resolve a file path in a set of directories.
 pub trait PathResolve {
     // Resolve the path of a file give a set of directories as the `which` unix
     // command would do with components of the `PATH` environment variable, and

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -1,3 +1,84 @@
+//! Command line interface for the containerd shim.
+//!
+//! The CLI provides the interface between containerd and the Wasm runtime.
+//! It handles commands like start and delete from containerd's shim API.
+//!
+//! ## Usage
+//!
+//! The shim binary should be named `containerd-shim-<engine>-v1` and installed in $PATH.
+//! containerd will call the shim with various commands.
+//!
+//! ## Configuration
+//!
+//! The shim can be configured using the [`Config`] struct:
+//!
+//! ```rust, no_run
+//! use containerd_shim_wasm::Config;
+//!
+//! let config = Config {
+//!     // Disable automatic logger setup
+//!     no_setup_logger: false,
+//!     // Set default log level
+//!     default_log_level: "info".to_string(),
+//!     // Disable child process reaping
+//!     no_reaper: false,
+//!     // Disable subreaper setting
+//!     no_sub_reaper: false,
+//! };
+//! ```
+//!
+//! ## Version Information
+//!
+//! The module provides two macros for version information:
+//!
+//! - [`version!()`] - Returns the crate version from Cargo.toml
+//! - [`revision!()`] - Returns the Git revision hash, if available
+//!
+//! ## Example usage:
+//!
+//! ```rust, no_run
+//! use containerd_shim_wasm::{
+//!     container::{Instance, Engine, RuntimeContext},
+//!     sandbox::cli::{revision, shim_main, version},
+//!     Config,
+//! };
+//! use anyhow::Result;
+//!
+//! #[derive(Clone, Default)]
+//! struct MyEngine;
+//!
+//! impl Engine for MyEngine {
+//!     fn name() -> &'static str {
+//!         "my-engine"
+//!     }
+//!
+//!     fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+//!         Ok(0)
+//!     }
+//! }
+//!
+//! let config = Config {
+//!     default_log_level: "error".to_string(),
+//!     ..Default::default()
+//! };
+//!
+//! shim_main::<Instance<MyEngine>>(
+//!     "my-engine",
+//!     version!(),
+//!     revision!(),
+//!     "v1",
+//!     Some(config),
+//! );
+//! ```
+//!
+//! When the `opentelemetry` feature is enabled, additional runtime config
+//! is available through environment variables:
+//!
+//! - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: Enable OpenTelemetry tracing
+//! - `OTEL_EXPORTER_OTLP_ENDPOINT`: Enable OpenTelemetry tracing as above
+//! - `OTEL_SDK_DISABLED`: Disable OpenTelemetry SDK
+//!
+
 use std::path::PathBuf;
 
 use containerd_shim::{parse, run, Config};
@@ -12,6 +93,7 @@ pub mod r#impl {
 
 pub use crate::{revision, version};
 
+/// Get the crate version from Cargo.toml.
 #[macro_export]
 macro_rules! version {
     () => {
@@ -19,6 +101,7 @@ macro_rules! version {
     };
 }
 
+/// Get the Git revision hash, if available.
 #[macro_export]
 macro_rules! revision {
     () => {

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -1,4 +1,5 @@
 //! Common utilities for the containerd shims.
+
 use std::fs::File;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -12,6 +13,12 @@ struct Options {
     root: Option<PathBuf>,
 }
 
+/// Determine the root directory for the container runtime.
+///
+/// If the `bundle` directory contains an `options.json` file, the root directory is read from the
+/// file. Otherwise, the root directory is determined by joining the `rootdir` and `namespace`.
+///
+/// The default root directory is `/run/containerd/<wasm engine name>/<namespace>`.
 #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
 pub fn determine_rootdir(
     bundle: impl AsRef<Path>,

--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -1,4 +1,76 @@
-//! Abstracts the sandboxing environment and execution context for a container.
+//! This module provides abstractions for managing WebAssembly containers in a sandboxed environment.
+//!
+//! This module gives you complete control over the container lifecycle and sandboxing,
+//! compared to the higher-level container module. It's useful when you need:
+//!
+//! - Custom sandboxing requirements
+//! - Direct control over container lifecycle
+//! - Support MacOS or Windows
+//!
+//! There are also some downsides to using this module:
+//!
+//! - No precompilation out-of-the-box
+//! - Does not support for native Linux containers out-of-the-box
+//! - Requires manual handling of cgroup setup
+//!
+//! ## Key Components
+//!
+//! - [`Instance`]: Core trait for implementing container lifecycle management
+//! - [`ShimCli`]: Command-line interface implementation for containerd shims
+//! - [`WasmLayer`]: Represents WebAssembly layers in OCI containers
+//!
+//! ## Example Usage
+//!
+//! ```rust,no_run
+//! use containerd_shim_wasm::sandbox::{Instance, InstanceConfig, Error};
+//! use containerd_shim_wasm::container::{Engine, RuntimeContext};
+//! use chrono::{DateTime, Utc};
+//! use std::time::Duration;
+//! use anyhow::Result;
+//!
+//! #[derive(Clone, Default)]
+//! struct MyEngine;
+//!
+//! impl Engine for MyEngine {
+//!     fn name() -> &'static str {
+//!         "my-engine"
+//!     }
+//!
+//!     fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+//!         Ok(0)
+//!     }
+//! }
+//!
+//! struct MyInstance {
+//!     engine: MyEngine,
+//! }
+//!
+//! impl Instance for MyInstance {
+//!     type Engine = MyEngine;
+//!
+//!     fn new(id: String, cfg: &InstanceConfig) -> Result<Self, Error> {
+//!         Ok(MyInstance { engine: MyEngine })
+//!     }
+//!
+//!     fn start(&self) -> Result<u32, Error> {
+//!         Ok(1)
+//!     }
+//!
+//!     fn kill(&self, signal: u32) -> Result<(), Error> {
+//!         Ok(())
+//!     }
+//!
+//!     fn delete(&self) -> Result<(), Error> {
+//!         Ok(())
+//!     }
+//!
+//!     fn wait_timeout(&self, t: impl Into<Option<Duration>>) -> Option<(u32, DateTime<Utc>)> {
+//!         Some((0, Utc::now()))
+//!     }
+//! }
+//! ```
+//!
+//! For simpler use cases, consider using the [`crate::container`] module instead.
 
 pub mod cli;
 pub mod error;

--- a/crates/containerd-shim-wasm/src/sandbox/sync.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/sync.rs
@@ -1,3 +1,5 @@
+//! Synchronization primitives (e.g. `WaitableCell`) for the sandbox.
+
 use std::cell::OnceCell;
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;


### PR DESCRIPTION
Note that breaking change is in this PR that PathResolve is made to be `crate public` instead of `public`.

```
pub(crate) use path::PathResolve;
```

Closes #823 