### PR TITLE
Revert "fix: Corrected description of containerd_address from GRPC to ttrpc"

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -22,7 +22,7 @@ pub struct InstanceConfig {
     bundle: PathBuf,
     /// Namespace for containerd
     namespace: String,
-    /// ttrpc address back to main containerd
+    // /// GRPC address back to main containerd
     containerd_address: String,
 }
 

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -22,7 +22,7 @@ pub struct InstanceConfig {
     bundle: PathBuf,
     /// Namespace for containerd
     namespace: String,
-    // /// GRPC address back to main containerd
+    /// GRPC address back to main containerd
     containerd_address: String,
 }
 


### PR DESCRIPTION
https://github.com/containerd/runwasi/pull/850#discussion_r1955399701

Revert the merge commit.
However, I will fix the doc comment.