### PR TITLE
tracing: add parameters info to the trace instead of skipping them

### DIFF
--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -159,8 +159,8 @@ fn log_mem() {
 pub fn shim_main<'a, I>(
     name: &str,
     version: &str,
-    revision: impl Into<Option<&'a str>>,
-    shim_version: impl Into<Option<&'a str>>,
+    revision: impl Into<Option<&'a str>> + std::fmt::Debug,
+    shim_version: impl Into<Option<&'a str>> + std::fmt::Debug,
     config: Option<Config>,
 ) where
     I: 'static + Instance + Sync + Send,
@@ -194,12 +194,12 @@ pub fn shim_main<'a, I>(
     log_mem();
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+#[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
 fn shim_main_inner<'a, I>(
     name: &str,
     version: &str,
-    revision: impl Into<Option<&'a str>>,
-    shim_version: impl Into<Option<&'a str>>,
+    revision: impl Into<Option<&'a str>> + std::fmt::Debug,
+    shim_version: impl Into<Option<&'a str>> + std::fmt::Debug,
     config: Option<Config>,
 ) where
     I: 'static + Instance + Sync + Send,

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -10,7 +10,7 @@ use super::error::Error;
 
 /// Generic options builder for creating a wasm instance.
 /// This is passed to the `Instance::new` method.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct InstanceConfig {
     /// Optional stdin named pipe path.
     stdin: PathBuf,
@@ -122,7 +122,7 @@ pub trait Instance: 'static {
 
     /// Waits for the instance to finish and returns its exit code
     /// This is a blocking call.
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), parent = tracing::Span::current(), level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Info"))]
     fn wait(&self) -> (u32, DateTime<Utc>) {
         self.wait_timeout(None).unwrap()
     }

--- a/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance_utils.rs
@@ -19,11 +19,11 @@ struct Options {
 /// file. Otherwise, the root directory is determined by joining the `rootdir` and `namespace`.
 ///
 /// The default root directory is `/run/containerd/<wasm engine name>/<namespace>`.
-#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+#[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
 pub fn determine_rootdir(
-    bundle: impl AsRef<Path>,
+    bundle: impl AsRef<Path> + std::fmt::Debug,
     namespace: &str,
-    rootdir: impl AsRef<Path>,
+    rootdir: impl AsRef<Path> + std::fmt::Debug,
 ) -> Result<PathBuf, Error> {
     let file = match File::open(bundle.as_ref().join("options.json")) {
         Ok(f) => f,

--- a/crates/containerd-shim-wasm/src/sandbox/shim/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/cli.rs
@@ -44,7 +44,7 @@ where
 {
     type T = Local<I>;
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
     fn new(_runtime_id: &str, args: &Flags, _config: &mut shim::Config) -> Self {
         Cli {
             engine: Default::default(),
@@ -55,7 +55,7 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
     fn start_shim(&mut self, opts: containerd_shim::StartOpts) -> shim::Result<String> {
         let dir = current_dir().map_err(|err| ShimError::Other(err.to_string()))?;
         let spec = Spec::load(dir.join("config.json")).map_err(|err| {
@@ -76,12 +76,15 @@ where
         Ok(address)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
     fn wait(&mut self) {
         self.exit.wait();
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip(publisher), level = "Info")
+    )]
     fn create_task_service(&self, publisher: RemotePublisher) -> Self::T {
         let events = RemoteEventSender::new(&self.namespace, publisher);
         let exit = self.exit.clone();
@@ -95,7 +98,7 @@ where
         )
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Info"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
     fn delete_shim(&mut self) -> shim::Result<api::DeleteResponse> {
         Ok(api::DeleteResponse {
             exit_status: 137,

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -14,8 +14,8 @@ pub(super) struct InstanceData<T: Instance> {
 }
 
 impl<T: Instance> InstanceData<T> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
-    pub fn new(id: impl AsRef<str>, cfg: InstanceConfig) -> Result<Self> {
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
+    pub fn new(id: impl AsRef<str> + std::fmt::Debug, cfg: InstanceConfig) -> Result<Self> {
         let id = id.as_ref().to_string();
         let instance = T::new(id, &cfg)?;
         Ok(Self {
@@ -26,17 +26,17 @@ impl<T: Instance> InstanceData<T> {
         })
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn pid(&self) -> Option<u32> {
         self.pid.get().copied()
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn config(&self) -> &InstanceConfig {
         &self.cfg
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn start(&self) -> Result<u32> {
         let mut s = self.state.write().unwrap();
         s.start()?;
@@ -56,7 +56,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn kill(&self, signal: u32) -> Result<()> {
         let mut s = self.state.write().unwrap();
         s.kill()?;
@@ -64,7 +64,7 @@ impl<T: Instance> InstanceData<T> {
         self.instance.kill(signal)
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn delete(&self) -> Result<()> {
         let mut s = self.state.write().unwrap();
         s.delete()?;
@@ -79,7 +79,7 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn wait(&self) -> (u32, DateTime<Utc>) {
         let res = self.instance.wait();
         let mut s = self.state.write().unwrap();
@@ -87,8 +87,11 @@ impl<T: Instance> InstanceData<T> {
         res
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
-    pub fn wait_timeout(&self, t: impl Into<Option<Duration>>) -> Option<(u32, DateTime<Utc>)> {
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
+    pub fn wait_timeout(
+        &self,
+        t: impl Into<Option<Duration>> + std::fmt::Debug,
+    ) -> Option<(u32, DateTime<Utc>)> {
         let res = self.instance.wait_timeout(t);
         if res.is_some() {
             let mut s = self.state.write().unwrap();

--- a/crates/containerd-shim-wasm/src/sandbox/shim/task_state.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/task_state.rs
@@ -11,7 +11,7 @@ pub(super) enum TaskState {
 }
 
 impl TaskState {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
     pub fn start(&mut self) -> Result<()> {
         *self = match self {
             Self::Created => Ok(Self::Starting),
@@ -20,7 +20,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
     pub fn kill(&mut self) -> Result<()> {
         *self = match self {
             Self::Started => Ok(Self::Started),
@@ -29,7 +29,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
     pub fn delete(&mut self) -> Result<()> {
         *self = match self {
             Self::Created | Self::Exited => Ok(Self::Deleting),
@@ -38,7 +38,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
     pub fn started(&mut self) -> Result<()> {
         *self = match self {
             Self::Starting => Ok(Self::Started),
@@ -47,7 +47,7 @@ impl TaskState {
         Ok(())
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
     pub fn stop(&mut self) -> Result<()> {
         *self = match self {
             Self::Started | Self::Starting => Ok(Self::Exited),

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -33,7 +33,7 @@ pub(crate) struct Executor<E: Engine> {
 }
 
 impl<E: Engine> LibcontainerExecutor for Executor<E> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError> {
         // We can handle linux container. We delegate wasm container to the engine.
         match self.inner(spec) {
@@ -42,7 +42,7 @@ impl<E: Engine> LibcontainerExecutor for Executor<E> {
         }
     }
 
-    #[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     fn exec(&self, spec: &Spec) -> Result<(), LibcontainerExecutorError> {
         // If it looks like a linux container, run it as a linux container.
         // Otherwise, run it as a wasm container

--- a/crates/containerd-shim-wasm/src/sys/unix/metrics.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/metrics.rs
@@ -3,7 +3,7 @@ use containerd_shim::cgroup::collect_metrics;
 use containerd_shim::util::convert_to_any;
 use protobuf::well_known_types::any::Any;
 
-#[cfg_attr(feature = "tracing", tracing::instrument(parent = tracing::Span::current(), skip_all, level = "Debug"))]
+#[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
 pub fn get_metrics(pid: u32) -> Result<Any> {
     let metrics = collect_metrics(pid)?;
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -53,7 +53,7 @@ impl<'a> ComponentTarget<'a> {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct WasmtimeEngine;
 
 static PRECOMPILER: LazyLock<wasmtime::Engine> = LazyLock::new(|| {


### PR DESCRIPTION
this commit also removes 'parent = ...' since it's already in the default

---

![image](https://github.com/user-attachments/assets/14fefaeb-247b-4e6c-92a2-051c7af2411c)

Notice how `version`, `revision`, and `name` are now included in the tags. 