### PR TITLE
ci: Add oci and oci-artifact images to stress test

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -127,25 +127,26 @@ jobs:
       - uses: ./.github/actions/setup-env
       - name: Setup build profile
         shell: bash
-        run: echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
+        run: |
+          echo "OPT_PROFILE=release" >> ${GITHUB_ENV}
+          echo "STRESS_TEST_COUNT=1000" >> ${GITHUB_ENV}
+          echo "STRESS_TEST_TIMEOUT=10s" >> ${GITHUB_ENV}
       - uses: ./.github/actions/build
       - name: Run Stress Tests
         shell: bash
         run: |
           set -euxo pipefail
           for RUNTIME in wasmtime wasmedge wasmer wamr; do
-            # Run containerd stress test
-            make test/stress-c8d-$RUNTIME \
-              STRESS_TEST_COUNT=1000 \
-              STRESS_TEST_TIMEOUT=10s \
-              STRESS_TEST_JSON=stress-bench-c8d-$RUNTIME.json \
-              STRESS_TEST_IMAGE=ghcr.io/containerd/runwasi/wasi-demo-app:latest
-            
+            # Run containerd stress tests with different images
+            for IMAGE_TYPE in app oci oci-artifact; do
+              make test/stress-c8d-$RUNTIME \
+                STRESS_TEST_JSON=stress-bench-c8d-${IMAGE_TYPE}-${RUNTIME}.json \
+                STRESS_TEST_IMAGE=ghcr.io/containerd/runwasi/wasi-demo-${IMAGE_TYPE}:latest
+            done
+
             # Run non-containerd stress test
-            make OPT_PROFILE=release test/stress-$RUNTIME \
-              STRESS_TEST_COUNT=1000 \
-              STRESS_TEST_TIMEOUT=10s \
-              STRESS_TEST_JSON=stress-bench-$RUNTIME.json \
+            make test/stress-$RUNTIME \
+              STRESS_TEST_JSON=stress-bench-${RUNTIME}.json \
               STRESS_TEST_IMAGE=ghcr.io/containerd/runwasi/wasi-demo-app:latest
           done
           cat stress-bench-*.json | jq -s 'flatten(1)' > stress-bench.json

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -138,7 +138,7 @@ jobs:
           set -euxo pipefail
           for RUNTIME in wasmtime wasmedge wasmer wamr; do
             # Run containerd stress tests with different images
-            for IMAGE_TYPE in app oci oci-artifact; do
+            for IMAGE_TYPE in app oci; do
               make test/stress-c8d-$RUNTIME \
                 STRESS_TEST_JSON=stress-bench-c8d-${IMAGE_TYPE}-${RUNTIME}.json \
                 STRESS_TEST_IMAGE=ghcr.io/containerd/runwasi/wasi-demo-${IMAGE_TYPE}:latest

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-doc:
 test/stress-%: dist-%
 	# Do not use trace logging as that negatively impacts performance.
 	# Do not use cross (always use cargo) to avoid the qemu environment.
-	cargo run -p stress-test $(TARGET_FLAG) -- \
+	cargo run -p stress-test $(TARGET_FLAG) $(RELEASE_FLAG) -- \
 		$(PWD)/dist/bin/containerd-shim-$*-v1 \
 		--count=$(STRESS_TEST_COUNT) \
 		--parallel=$(STRESS_TEST_PARALLEL) \
@@ -160,7 +160,7 @@ test/stress-%: dist-%
 test/stress-c8d-%: dist-%
 	# Do not use trace logging as that negatively impacts performance.
 	# Do not use cross (always use cargo) to avoid the qemu environment.
-	cargo run -p stress-test $(TARGET_FLAG) -- \
+	cargo run -p stress-test $(TARGET_FLAG) $(RELEASE_FLAG) -- \
 		--containerd \
 		$(PWD)/dist/bin/containerd-shim-$*-v1 \
 		--count=$(STRESS_TEST_COUNT) \

--- a/crates/stress-test/src/main.rs
+++ b/crates/stress-test/src/main.rs
@@ -257,12 +257,17 @@ async fn run_stress_test(cli: Cli, c8d: impl Containerd) -> Result<()> {
 
     let shim = get_runtime(&shim_path).unwrap_or("unknown");
     let containerd_shim = if containerd { "containerd" } else { "mock" };
+    let image = match image.as_str() {
+        "ghcr.io/containerd/runwasi/wasi-demo-oci:latest" => "oci",
+        "ghcr.io/containerd/runwasi/wasi-demo-app:latest" => "app",
+        "ghcr.io/containerd/runwasi/wasi-demo-oci-artifact:latest" => "oci-artifact",
+        others => others,
+    };
 
     if let Some(json_output) = json_output {
         let results = vec![BenchmarkResult {
             name: format!(
-                "Stress Test Tasks Throughput with {} service - {}",
-                containerd_shim, shim
+                "Stress Test Throughput with {containerd_shim} service - {shim} ({image})",
             ),
             unit: "tasks/s".to_string(),
             value: throuput,


### PR DESCRIPTION
In addition, this commit adds a release flag to stress test CLI in Makefile.
