### PR TITLE
[stress-test] Add support for native containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5925,9 +5925,9 @@ dependencies = [
 
 [[package]]
 name = "trapeze"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2da2a61bcb6db06b2b1e1665a7b7aec6f83e384b544ccf47a039c84b69946f"
+checksum = "35508cc3b25208044772edae64f1aa282e08da46c6a906a37df9cdb02d459daf"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5949,18 +5949,18 @@ dependencies = [
 
 [[package]]
 name = "trapeze-codegen"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f3bfa2fda8c8f5d417fca8030109f5f1b67e91b020bdc34d61a55dcf158f4"
+checksum = "d14d87105c38be204d509e997c5ba53f05bf5f61957d2b4578220aa51eac79a8"
 dependencies = [
  "prost-build 0.13.3",
 ]
 
 [[package]]
 name = "trapeze-macros"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b629c7aad077270c530523c46be16dfba42224824b57b539f9e2674d7e937b2c"
+checksum = "e2a9fd22b2ca0a1103f1cab12fb29becc283be120b3a36581efbc3f9e31044fc"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5227,6 +5227,7 @@ dependencies = [
  "prost-types 0.13.5",
  "serde",
  "serde_json",
+ "sha256",
  "tempfile",
  "tokio",
  "tokio-async-drop",

--- a/crates/stress-test/Cargo.toml
+++ b/crates/stress-test/Cargo.toml
@@ -27,6 +27,7 @@ tonic = "0.12"
 serde_json = { workspace = true }
 serde = { workspace = true }
 futures = "0.3"
+sha256 = { workspace = true }
 
 
 [package.metadata.cargo-machete]

--- a/crates/stress-test/Cargo.toml
+++ b/crates/stress-test/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-trapeze = "0.7"
+trapeze = "0.7.6"
 prost = "0.13"
 prost-types = "0.13"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs", "process", "signal"] }

--- a/crates/stress-test/protos/github.com/containerd/containerd/api/runtime/task/v3/shim.proto
+++ b/crates/stress-test/protos/github.com/containerd/containerd/api/runtime/task/v3/shim.proto
@@ -1,0 +1,48 @@
+/*
+	Copyright The containerd Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+syntax = "proto3";
+
+package containerd.task.v3;
+
+import "google/protobuf/empty.proto";
+import "github.com/containerd/containerd/api/runtime/task/v2/shim.proto";
+
+option go_package = "github.com/containerd/containerd/api/runtime/task/v3;task";
+
+// Shim service is launched for each container and is responsible for owning the IO
+// for the container and its additional processes.  The shim is also the parent of
+// each container and allows reattaching to the IO and receiving the exit status
+// for the container processes.
+service Task {
+	rpc State(containerd.task.v2.StateRequest) returns (containerd.task.v2.StateResponse);
+	rpc Create(containerd.task.v2.CreateTaskRequest) returns (containerd.task.v2.CreateTaskResponse);
+	rpc Start(containerd.task.v2.StartRequest) returns (containerd.task.v2.StartResponse);
+	rpc Delete(containerd.task.v2.DeleteRequest) returns (containerd.task.v2.DeleteResponse);
+	rpc Pids(containerd.task.v2.PidsRequest) returns (containerd.task.v2.PidsResponse);
+	rpc Pause(containerd.task.v2.PauseRequest) returns (google.protobuf.Empty);
+	rpc Resume(containerd.task.v2.ResumeRequest) returns (google.protobuf.Empty);
+	rpc Checkpoint(containerd.task.v2.CheckpointTaskRequest) returns (google.protobuf.Empty);
+	rpc Kill(containerd.task.v2.KillRequest) returns (google.protobuf.Empty);
+	rpc Exec(containerd.task.v2.ExecProcessRequest) returns (google.protobuf.Empty);
+	rpc ResizePty(containerd.task.v2.ResizePtyRequest) returns (google.protobuf.Empty);
+	rpc CloseIO(containerd.task.v2.CloseIORequest) returns (google.protobuf.Empty);
+	rpc Update(containerd.task.v2.UpdateTaskRequest) returns (google.protobuf.Empty);
+	rpc Wait(containerd.task.v2.WaitRequest) returns (containerd.task.v2.WaitResponse);
+	rpc Stats(containerd.task.v2.StatsRequest) returns (containerd.task.v2.StatsResponse);
+	rpc Connect(containerd.task.v2.ConnectRequest) returns (containerd.task.v2.ConnectResponse);
+	rpc Shutdown(containerd.task.v2.ShutdownRequest) returns (google.protobuf.Empty);
+}

--- a/crates/stress-test/src/containerd/client.rs
+++ b/crates/stress-test/src/containerd/client.rs
@@ -360,7 +360,9 @@ impl Client {
         stdout: impl Into<String>,
         stderr: impl Into<String>,
     ) -> Result<()> {
-        self.0.create_task(container_id, mounts, stdout, stderr).await
+        self.0
+            .create_task(container_id, mounts, stdout, stderr)
+            .await
     }
 
     pub async fn start_task(&self, container_id: impl Into<String>) -> Result<()> {
@@ -408,6 +410,9 @@ mod test {
             String::from("sha256:4d851d7c3ef9a3cb8c6553806846038c3c81498e1f6d6dc60bb03291f223b99a"),
         ];
         let chain_id = super::chain_id(diffs);
-        assert_eq!(chain_id, "sha256:0f8505411d5fe958101c5e6b6e31c61262a05f7aff548bf7742ff1ad24d6bf88");
+        assert_eq!(
+            chain_id,
+            "sha256:0f8505411d5fe958101c5e6b6e31c61262a05f7aff548bf7742ff1ad24d6bf88"
+        );
     }
 }

--- a/crates/stress-test/src/containerd/containerd.rs
+++ b/crates/stress-test/src/containerd/containerd.rs
@@ -9,10 +9,8 @@ pub struct Containerd {
 }
 
 impl Containerd {
-    pub async fn new() -> Result<Self> {
-        Ok(Self {
-            containerd: Client::default().await?,
-        })
+    pub async fn new(client: Client) -> Result<Self> {
+        Ok(Self { containerd: client })
     }
 }
 

--- a/crates/stress-test/src/containerd/task.rs
+++ b/crates/stress-test/src/containerd/task.rs
@@ -1,7 +1,7 @@
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use containerd_client::types::Mount;
 use oci_spec::runtime::{ProcessBuilder, RootBuilder, Spec, SpecBuilder, UserBuilder};
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 use tokio_async_drop::tokio_async_drop;
 
 use super::Client;
@@ -99,7 +99,10 @@ impl crate::traits::Task for Task {
         let status = self.containerd.wait_task(&self.id).await?;
         let stdout = std::fs::read_to_string(self.dir.path().join("stdout")).unwrap_or_default();
         let stderr = std::fs::read_to_string(self.dir.path().join("stderr")).unwrap_or_default();
-        ensure!(status == 0, "Exit status {status}, stdout: {stdout:?}, stderr: {stderr:?}");
+        ensure!(
+            status == 0,
+            "Exit status {status}, stdout: {stdout:?}, stderr: {stderr:?}"
+        );
         Ok(())
     }
 

--- a/crates/stress-test/src/containerd/task.rs
+++ b/crates/stress-test/src/containerd/task.rs
@@ -31,15 +31,9 @@ impl Task {
         let runtime = runtime.into();
 
         let id = make_task_id();
-        let entrypoint = containerd.entrypoint(&image).await?;
         let mounts = containerd.get_mounts(&id, &image).await?;
 
-        let mut args: Vec<_> = args.into_iter().map(|arg| arg.into()).collect();
-        if args.is_empty() {
-            args = entrypoint;
-        } else if let Some(argv0) = entrypoint.into_iter().next() {
-            args.insert(0, argv0);
-        }
+        let args: Vec<_> = args.into_iter().map(|arg| arg.into()).collect();
 
         let process = ProcessBuilder::default()
             .user(UserBuilder::default().build().unwrap())

--- a/crates/stress-test/src/mocks/containerd.rs
+++ b/crates/stress-test/src/mocks/containerd.rs
@@ -25,10 +25,9 @@ pub struct Containerd {
 }
 
 impl Containerd {
-    pub async fn new(verbose: bool) -> Result<Self> {
+    pub async fn new(client: containerd::Client, verbose: bool) -> Result<Self> {
         let dir = tempdir()?;
         let socket = dir.path().join("containerd.sock.ttrpc");
-        let containerd = containerd::Client::default().await?;
 
         let _server = Server::new()
             .register(service!(EventsService: Events))
@@ -39,7 +38,7 @@ impl Containerd {
             dir,
             _server,
             verbose,
-            containerd,
+            containerd: client,
         })
     }
 }

--- a/crates/stress-test/src/mocks/mod.rs
+++ b/crates/stress-test/src/mocks/mod.rs
@@ -1,6 +1,7 @@
 mod containerd;
 mod shim;
 mod task;
+mod task_client;
 
 pub use containerd::Containerd;
 pub use shim::Shim;

--- a/crates/stress-test/src/mocks/task.rs
+++ b/crates/stress-test/src/mocks/task.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use nix::NixPath;
 use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder, UserBuilder};
-use tempfile::{tempdir_in, TempDir};
+use tempfile::{TempDir, tempdir_in};
 use tokio::fs::{create_dir_all, write};
 use tokio_async_drop::tokio_async_drop;
 
@@ -48,7 +48,10 @@ impl Task {
             format!("sandbox-{}", std::process::id()),
         )];
 
-        let root = RootBuilder::default().path("rootfs").build()?;
+        let root = RootBuilder::default()
+            .path("rootfs")
+            .readonly(false)
+            .build()?;
 
         let spec = SpecBuilder::default()
             .version("1.1.0")
@@ -106,12 +109,8 @@ impl crate::traits::Task for Task {
     }
 
     async fn wait(&self) -> Result<()> {
-<<<<<<< HEAD
-        self.client
-=======
         let status = self
             .client
->>>>>>> babd163 ([stress-test] fail and print stdout/stderr if container exit status is not 0)
             .wait(WaitRequest {
                 id: self.id.clone(),
                 ..Default::default()

--- a/crates/stress-test/src/mocks/task.rs
+++ b/crates/stress-test/src/mocks/task.rs
@@ -35,14 +35,7 @@ impl Task {
         let mounts = containerd.get_mounts(&id, &image).await?;
         let mounts = map_mounts(mounts);
 
-        let entrypoint = containerd.entrypoint(&image).await?;
-
-        let mut args: Vec<_> = args.into_iter().map(|arg| arg.into()).collect();
-        if args.is_empty() {
-            args = entrypoint;
-        } else if let Some(argv0) = entrypoint.into_iter().next() {
-            args.insert(0, argv0);
-        }
+        let args: Vec<_> = args.into_iter().map(|arg| arg.into()).collect();
 
         let process = ProcessBuilder::default()
             .user(UserBuilder::default().build().unwrap())

--- a/crates/stress-test/src/mocks/task_client.rs
+++ b/crates/stress-test/src/mocks/task_client.rs
@@ -1,0 +1,81 @@
+use anyhow::{Result, bail};
+use trapeze::{Client, Code};
+
+use crate::protos::containerd::task::v2::*;
+use crate::protos::containerd::task::v3::Task as TaskV3;
+
+#[derive(Clone, Copy)]
+enum Version {
+    V2,
+    V3,
+}
+
+#[derive(Clone)]
+pub struct TaskClient {
+    client: Client,
+    version: Version,
+}
+
+macro_rules! multiplex {
+    ($obj:ident.$method:ident ( $req:ident ) $($rest:tt)*) => {{
+        match $obj.version {
+            Version::V2 => {
+                trapeze::as_client!(&$obj.client: Task)
+                    .$method($req)
+                    .await
+            }
+            Version::V3 => {
+                trapeze::as_client!(&$obj.client: TaskV3)
+                    .$method($req)
+                    .await
+            }
+        }
+        Ok(())
+    }};
+}
+
+impl TaskClient {
+    pub async fn connect(address: impl AsRef<str>) -> Result<Self> {
+        let client = Client::connect(address).await?;
+
+        let version = 'v: {
+            let task = trapeze::as_client!(&client: Task);
+            let Err(status) = task.delete(DeleteRequest::default()).await else {
+                bail!("unexpected shim response")
+            };
+            if status.code() != Code::Unimplemented {
+                break 'v Version::V2;
+            }
+            let task = trapeze::as_client!(&client: TaskV3);
+            let Err(status) = task.delete(DeleteRequest::default()).await else {
+                bail!("unexpected shim response")
+            };
+            if status.code() != Code::Unimplemented {
+                break 'v Version::V3;
+            }
+            bail!("unknown task service version")
+        };
+
+        Ok(Self { version, client })
+    }
+
+    pub async fn shutdown(&self, req: ShutdownRequest) -> trapeze::Result<()> {
+        multiplex!(self.shutdown(req))
+    }
+
+    pub async fn create(&self, req: CreateTaskRequest) -> trapeze::Result<CreateTaskResponse> {
+        multiplex!(self.create(req))
+    }
+
+    pub async fn start(&self, req: StartRequest) -> trapeze::Result<StartResponse> {
+        multiplex!(self.start(req))
+    }
+
+    pub async fn wait(&self, req: WaitRequest) -> trapeze::Result<WaitResponse> {
+        multiplex!(self.wait(req))
+    }
+
+    pub async fn delete(&self, req: DeleteRequest) -> trapeze::Result<DeleteResponse> {
+        multiplex!(self.delete(req))
+    }
+}

--- a/crates/stress-test/src/mocks/task_client.rs
+++ b/crates/stress-test/src/mocks/task_client.rs
@@ -30,7 +30,6 @@ macro_rules! multiplex {
                     .await
             }
         }
-        Ok(())
     }};
 }
 

--- a/crates/stress-test/src/protos.rs
+++ b/crates/stress-test/src/protos.rs
@@ -1,6 +1,7 @@
 trapeze::include_protos!(
     [
         "protos/github.com/containerd/containerd/api/runtime/task/v2/shim.proto",
+        "protos/github.com/containerd/containerd/api/runtime/task/v3/shim.proto",
         "protos/github.com/containerd/containerd/api/services/ttrpc/events/v1/events.proto",
     ],
     ["protos"]

--- a/crates/stress-test/src/traits.rs
+++ b/crates/stress-test/src/traits.rs
@@ -20,7 +20,7 @@ pub trait Shim {
 
 #[trait_variant::make(Send)]
 pub trait Task {
-    async fn create(&self, verbose: bool) -> Result<()>;
+    async fn create(&self) -> Result<()>;
     async fn start(&self) -> Result<()>;
     async fn wait(&self) -> Result<()>;
     async fn delete(&self) -> Result<()>;


### PR DESCRIPTION
With this change it is now possible to do something like:
```
sudo ctr images pull ghcr.io/jprendes/wasmtime-distroless/hello:latest
cargo run -p stress-test -- /usr/bin/containerd-shim-runc-v2 --image ghcr.io/jprendes/wasmtime-distroless/hello:latest
```