### PR TITLE
chore: bump rust version to 1.85.0 and edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 version = "0.4.0"
 license = "Apache-2.0"
 readme = "README.md"

--- a/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
+++ b/benches/containerd-shim-benchmarks/benches/wasi-demo-app-benchmarks.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 use std::time::{Duration, Instant};
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 struct TestCase<'a> {
     image: &'a str,

--- a/crates/containerd-shim-wamr/src/tests.rs
+++ b/crates/containerd-shim-wamr/src/tests.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
+use containerd_shim_wasm::testing::WasiTest;
 //use containerd_shim_wasm::sandbox::Instance;
 use containerd_shim_wasm::testing::modules::*;
-use containerd_shim_wasm::testing::WasiTest;
 use serial_test::serial;
 
 use crate::instance::WamrInstance as WasiInstance;

--- a/crates/containerd-shim-wasm-test-modules/build.rs
+++ b/crates/containerd-shim-wasm-test-modules/build.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use lazy_static::lazy_static;
 
 fn env_path(key: impl AsRef<str>) -> Result<PathBuf> {

--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use oci_spec::image::Platform;
 use oci_spec::runtime::Spec;
 

--- a/crates/containerd-shim-wasm/src/container/engine.rs
+++ b/crates/containerd-shim-wasm/src/container/engine.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Read;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 use super::Source;
 use crate::container::{PathResolve, RuntimeContext};

--- a/crates/containerd-shim-wasm/src/sandbox/containerd/client.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/containerd/client.rs
@@ -13,8 +13,8 @@ use containerd_client::services::v1::{
     InfoRequest, ReadContentRequest, UpdateRequest, WriteAction, WriteContentRequest,
     WriteContentResponse,
 };
-use containerd_client::tonic::transport::Channel;
 use containerd_client::tonic::Streaming;
+use containerd_client::tonic::transport::Channel;
 use containerd_client::{tonic, with_namespace};
 use futures::TryStreamExt;
 use oci_spec::image::{Arch, Digest, ImageManifest, MediaType, Platform};
@@ -601,15 +601,15 @@ async fn send_message(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicI32, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicI32, Ordering};
 
     use oci_tar_builder::WASM_LAYER_MEDIA_TYPE;
 
     use super::*;
     use crate::container::RuntimeContext;
     use crate::testing::oci_helpers::ImageContent;
-    use crate::testing::{oci_helpers, TEST_NAMESPACE};
+    use crate::testing::{TEST_NAMESPACE, oci_helpers};
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_save_content() {

--- a/crates/containerd-shim-wasm/src/sandbox/containerd/lease.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/containerd/lease.rs
@@ -3,8 +3,8 @@
 use std::mem::ManuallyDrop;
 
 use anyhow::Context as _;
-use containerd_client::services::v1::leases_client::LeasesClient;
 use containerd_client::services::v1::DeleteRequest;
+use containerd_client::services::v1::leases_client::LeasesClient;
 use containerd_client::tonic::transport::Channel;
 use containerd_client::{tonic, with_namespace};
 use tonic::Request;

--- a/crates/containerd-shim-wasm/src/sandbox/error.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/error.rs
@@ -2,8 +2,8 @@
 //! This handles converting to the appropriate ttrpc error codes
 
 use anyhow::Error as AnyError;
-use containerd_shim::protos::ttrpc;
 use containerd_shim::Error as ShimError;
+use containerd_shim::protos::ttrpc;
 use oci_spec::OciSpecError;
 use thiserror::Error;
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/cli.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use containerd_shim::error::Error as ShimError;
 use containerd_shim::publisher::RemotePublisher;
 use containerd_shim::util::write_address;
-use containerd_shim::{self as shim, api, ExitSignal};
+use containerd_shim::{self as shim, ExitSignal, api};
 use oci_spec::runtime::Spec;
 use shim::Flags;
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
@@ -1,5 +1,5 @@
-use std::fs::{create_dir, File};
-use std::sync::mpsc::{channel, Sender};
+use std::fs::{File, create_dir};
+use std::sync::mpsc::{Sender, channel};
 use std::thread;
 use std::time::Duration;
 

--- a/crates/containerd-shim-wasm/src/sandbox/shim/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/mod.rs
@@ -12,4 +12,4 @@ mod task_state;
 
 pub use cli::Cli;
 #[cfg(feature = "opentelemetry")]
-pub use otel::{traces_enabled as otel_traces_enabled, Config as OtlpConfig};
+pub use otel::{Config as OtlpConfig, traces_enabled as otel_traces_enabled};

--- a/crates/containerd-shim-wasm/src/sandbox/shim/otel.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/otel.rs
@@ -25,15 +25,15 @@
 use std::collections::HashMap;
 use std::env;
 
+use opentelemetry::Context;
 use opentelemetry::global::{self, set_text_map_propagator};
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::TraceError;
-use opentelemetry::Context;
-use opentelemetry_otlp::{
-    Protocol, SpanExporterBuilder, WithExportConfig, OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT,
-};
 pub use opentelemetry_otlp::{
     OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+};
+use opentelemetry_otlp::{
+    OTEL_EXPORTER_OTLP_PROTOCOL_DEFAULT, Protocol, SpanExporterBuilder, WithExportConfig,
 };
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::{runtime, trace as sdktrace};

--- a/crates/containerd-shim-wasm/src/sandbox/sync.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/sync.rs
@@ -86,7 +86,7 @@ impl<T> WaitableCell<T> {
     /// The function `f` will always be called, regardless of whether the `WaitableCell` has a value or not.
     /// The `WaitableCell` is going to be set even in the case of an unwind. In this case, ff the function `f`
     /// panics it will cause an abort, so it's recommended to avoid any panics in `f`.
-    pub fn set_guard_with<R: Into<T>>(&self, f: impl FnOnce() -> R) -> impl Drop {
+    pub fn set_guard_with<R: Into<T>, F: FnOnce() -> R>(&self, f: F) -> impl Drop + use<F, T, R> {
         let cell = (*self).clone();
         WaitableCellSetGuard { f: Some(f), cell }
     }

--- a/crates/containerd-shim-wasm/src/sys/unix/container/container.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/container.rs
@@ -2,11 +2,11 @@ use std::cell::RefCell;
 use std::io::Error as IoError;
 use std::mem::transmute;
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use libcontainer::container::Container as YoukiContainer;
 use libcontainer::signal::Signal;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use zygote::{WireError, Zygote};
 
 thread_local! {

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::PathBuf;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use libcontainer::workload::default::DefaultExecutor;
 use libcontainer::workload::{
     Executor as LibcontainerExecutor, ExecutorError as LibcontainerExecutorError,

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use libcontainer::container::builder::ContainerBuilder;
 use libcontainer::syscall::syscall::SyscallType;
 use nix::errno::Errno;
-use nix::sys::wait::{waitid, Id as WaitID, WaitPidFlag, WaitStatus};
+use nix::sys::wait::{Id as WaitID, WaitPidFlag, WaitStatus, waitid};
 use nix::unistd::Pid;
 use oci_spec::image::Platform;
 
@@ -17,7 +17,7 @@ use crate::sandbox::async_utils::AmbientRuntime as _;
 use crate::sandbox::instance_utils::determine_rootdir;
 use crate::sandbox::sync::WaitableCell;
 use crate::sandbox::{
-    containerd, Error as SandboxError, Instance as SandboxInstance, InstanceConfig,
+    Error as SandboxError, Instance as SandboxInstance, InstanceConfig, containerd,
 };
 use crate::sys::container::executor::Executor;
 use crate::sys::stdio::open;
@@ -94,7 +94,7 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
     fn start(&self) -> Result<u32, SandboxError> {
         log::info!("starting instance: {}", self.id);
         // make sure we have an exit code by the time we finish (even if there's a panic)
-        let guard = self.exit_code.set_guard_with(|| (137, Utc::now()));
+        let guard = self.exit_code.clone().set_guard_with(|| (137, Utc::now()));
 
         let pid = self.container.pid()?;
         self.container.start()?;

--- a/crates/containerd-shim-wasm/src/test/signals.rs
+++ b/crates/containerd-shim-wasm/src/test/signals.rs
@@ -20,13 +20,13 @@
 
 use std::fs::canonicalize;
 use std::future::pending;
-use std::io::{stderr, Write as _};
-use std::sync::mpsc::channel;
+use std::io::{Write as _, stderr};
 use std::sync::Arc;
+use std::sync::mpsc::channel;
 use std::thread::sleep;
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use containerd_shim_wasm_test_modules::HELLO_WORLD;
 
 use crate::container::{Engine, Instance, RuntimeContext};

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -1,7 +1,7 @@
 //! Testing utilities used across different modules
 
 use std::collections::HashMap;
-use std::fs::{self, create_dir, read, read_to_string, write, File};
+use std::fs::{self, File, create_dir, read, read_to_string, write};
 use std::marker::PhantomData;
 use std::ops::Add;
 #[cfg(unix)]
@@ -11,12 +11,12 @@ use std::os::windows::fs::symlink_file as symlink;
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 pub use containerd_shim_wasm_test_modules as modules;
 use libc::{SIGINT, SIGTERM};
 use oci_spec::runtime::{
-    get_default_namespaces, LinuxBuilder, LinuxNamespace, LinuxNamespaceType, ProcessBuilder,
-    RootBuilder, SpecBuilder,
+    LinuxBuilder, LinuxNamespace, LinuxNamespaceType, ProcessBuilder, RootBuilder, SpecBuilder,
+    get_default_namespaces,
 };
 
 use crate::sandbox::{Instance, InstanceConfig};
@@ -311,11 +311,11 @@ where
 }
 
 pub mod oci_helpers {
-    use std::fs::{write, File};
+    use std::fs::{File, write};
     use std::process::{Command, Stdio};
     use std::time::{Duration, Instant};
 
-    use anyhow::{bail, Result};
+    use anyhow::{Result, bail};
     use oci_spec::image::{self as spec, Arch};
     use oci_tar_builder::Builder;
 

--- a/crates/containerd-shim-wasmedge/src/tests.rs
+++ b/crates/containerd-shim-wasmedge/src/tests.rs
@@ -123,7 +123,7 @@ fn test_has_default_devices() -> anyhow::Result<()> {
 fn get_wasmedge_binary_path() -> std::path::PathBuf {
     use std::os::unix::prelude::OsStrExt;
 
-    extern "C" {
+    unsafe extern "C" {
         pub fn WasmEdge_VersionGet() -> *const libc::c_char;
     }
 

--- a/crates/containerd-shim-wasmedge/src/tests.rs
+++ b/crates/containerd-shim-wasmedge/src/tests.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
+use containerd_shim_wasm::testing::WasiTest;
 //use containerd_shim_wasm::sandbox::Instance;
 use containerd_shim_wasm::testing::modules::*;
-use containerd_shim_wasm::testing::WasiTest;
 use serial_test::serial;
 
 use crate::instance::WasmEdgeInstance as WasiInstance;

--- a/crates/containerd-shim-wasmer/src/tests.rs
+++ b/crates/containerd-shim-wasmer/src/tests.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
+use containerd_shim_wasm::testing::WasiTest;
 //use containerd_shim_wasm::sandbox::Instance;
 use containerd_shim_wasm::testing::modules::*;
-use containerd_shim_wasm::testing::WasiTest;
 use serial_test::serial;
 
 use crate::instance::WasmerInstance as WasiInstance;

--- a/crates/containerd-shim-wasmtime/src/http_proxy.rs
+++ b/crates/containerd-shim-wasmtime/src/http_proxy.rs
@@ -3,25 +3,25 @@
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use containerd_shim_wasm::container::RuntimeContext;
 use hyper::server::conn::http1;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use wasmtime::component::ResourceTable;
 use wasmtime::Store;
-use wasmtime_wasi_http::bindings::http::types::Scheme;
+use wasmtime::component::ResourceTable;
 use wasmtime_wasi_http::bindings::ProxyPre;
+use wasmtime_wasi_http::bindings::http::types::Scheme;
 use wasmtime_wasi_http::body::HyperOutgoingBody;
 use wasmtime_wasi_http::io::TokioIo;
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 
-use crate::instance::{envs_from_ctx, WasiPreview2Ctx};
+use crate::instance::{WasiPreview2Ctx, envs_from_ctx};
 
 const DEFAULT_ADDR: SocketAddr =
     SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), 8080);

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::LazyLock;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use containerd_shim_wasm::container::{
     Engine, Entrypoint, Instance, RuntimeContext, WasmBinaryType,
 };
@@ -416,7 +416,7 @@ fn wasi_builder(ctx: &impl RuntimeContext) -> Result<wasi_preview2::WasiCtxBuild
 async fn wait_for_signal() -> Result<i32> {
     #[cfg(unix)]
     {
-        use tokio::signal::unix::{signal, SignalKind};
+        use tokio::signal::unix::{SignalKind, signal};
         let mut sigquit = signal(SignalKind::quit())?;
         let mut sigterm = signal(SignalKind::terminate())?;
 

--- a/crates/containerd-shim-wasmtime/src/tests.rs
+++ b/crates/containerd-shim-wasmtime/src/tests.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
+use WasmtimeTestInstance as WasiInstance;
 use containerd_shim_wasm::container::Instance;
 use containerd_shim_wasm::testing::modules::*;
-use containerd_shim_wasm::testing::{oci_helpers, WasiTest};
+use containerd_shim_wasm::testing::{WasiTest, oci_helpers};
 use serial_test::serial;
-use WasmtimeTestInstance as WasiInstance;
 
 use crate::instance::WasmtimeEngine;
 

--- a/crates/oci-tar-builder/src/bin.rs
+++ b/crates/oci-tar-builder/src/bin.rs
@@ -82,7 +82,7 @@ async fn generate_wasm_artifact(args: Args, out_dir: PathBuf) -> Result<(), anyh
                 out_dir.display(),
                 e
             );
-            fs::remove_file(out_dir).unwrap_or(print!("Failed to clean up oci tar file on error"));
+            fs::remove_file(out_dir).context("Failed to clean up oci tar file on error")?;
         }
     }
 
@@ -180,7 +180,7 @@ fn generate_wasi_image(args: Args, out_dir: PathBuf) -> Result<(), anyhow::Error
                 out_dir.display(),
                 e
             );
-            fs::remove_file(out_dir).unwrap_or(print!("Failed to remove temporary file"));
+            fs::remove_file(out_dir).context("Failed to remove temporary file")?;
         }
     }
 

--- a/crates/oci-tar-builder/src/lib.rs
+++ b/crates/oci-tar-builder/src/lib.rs
@@ -10,7 +10,7 @@ use oci_spec::image::{
     DescriptorBuilder, Digest, ImageConfiguration, ImageIndexBuilder, ImageManifestBuilder,
     MediaType, PlatformBuilder, SCHEMA_VERSION,
 };
-use oci_wasm::{WasmConfig, WASM_ARCHITECTURE};
+use oci_wasm::{WASM_ARCHITECTURE, WasmConfig};
 use serde::Serialize;
 use sha256::{digest, try_digest};
 #[derive(Debug)]
@@ -290,7 +290,7 @@ impl<C: OciConfig> Builder<C> {
         let mut th = tar::Header::new_gnu();
         th.set_path("manifest.json")?;
         th.set_mode(0o644);
-        th.set_size(mfst_data.as_bytes().len() as u64);
+        th.set_size(mfst_data.len() as u64);
         th.set_cksum();
         tb.append(&th, mfst_data.as_bytes())?;
 

--- a/crates/stress-test/src/containerd/client.rs
+++ b/crates/stress-test/src/containerd/client.rs
@@ -5,14 +5,14 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use anyhow::{bail, Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use containerd_client::services::v1::container::Runtime;
 use containerd_client::services::v1::containers_client::ContainersClient;
 use containerd_client::services::v1::content_client::ContentClient;
 use containerd_client::services::v1::images_client::ImagesClient;
 use containerd_client::services::v1::leases_client::LeasesClient;
-use containerd_client::services::v1::snapshots::snapshots_client::SnapshotsClient;
 use containerd_client::services::v1::snapshots::PrepareSnapshotRequest;
+use containerd_client::services::v1::snapshots::snapshots_client::SnapshotsClient;
 use containerd_client::services::v1::tasks_client::TasksClient;
 use containerd_client::services::v1::{
     Container as SpecContainer, CreateContainerRequest, CreateRequest, CreateTaskRequest,
@@ -25,8 +25,8 @@ use oci_spec::image::{ImageConfiguration, ImageManifest};
 use oci_spec::runtime::Spec;
 use prost_types::Any;
 use tokio_async_drop::tokio_async_drop as async_drop;
-use tonic::transport::Channel;
 use tonic::Request;
+use tonic::transport::Channel;
 
 struct ClientInner {
     channel: Channel,

--- a/crates/stress-test/src/containerd/task.rs
+++ b/crates/stress-test/src/containerd/task.rs
@@ -8,7 +8,7 @@ use tokio_async_drop::tokio_async_drop;
 
 use super::Client;
 use crate::traits::Task as _;
-use crate::utils::{make_task_id, RunOnce};
+use crate::utils::{RunOnce, make_task_id};
 
 pub struct Task {
     containerd: Client,

--- a/crates/stress-test/src/main.rs
+++ b/crates/stress-test/src/main.rs
@@ -10,7 +10,7 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Instant;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::{Parser, ValueEnum};
 use futures::future::FusedFuture as _;
 use futures::stream::FuturesUnordered;
@@ -243,7 +243,9 @@ async fn run_stress_test(cli: Cli, c8d: impl Containerd) -> Result<()> {
     }
 
     if success != count {
-        println!("\x1b[31m{success} tasks succeeded, {failed} tasks failed, {incomplete} tasks didn't finish\x1b[0m");
+        println!(
+            "\x1b[31m{success} tasks succeeded, {failed} tasks failed, {incomplete} tasks didn't finish\x1b[0m"
+        );
         bail!("Some tasks did not succeed");
     }
 

--- a/crates/stress-test/src/mocks/containerd.rs
+++ b/crates/stress-test/src/mocks/containerd.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use anyhow::Result;
-use tempfile::{tempdir, TempDir};
-use trapeze::{service, Server, ServerHandle};
+use tempfile::{TempDir, tempdir};
+use trapeze::{Server, ServerHandle, service};
 
 use super::Shim;
 use crate::containerd;

--- a/crates/stress-test/src/mocks/shim.rs
+++ b/crates/stress-test/src/mocks/shim.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use log::info;
 use oci_spec::runtime::SpecBuilder;
-use tempfile::{tempdir_in, TempDir};
+use tempfile::{TempDir, tempdir_in};
 use tokio::fs::{canonicalize, symlink};
 use tokio::process::Command;
 use tokio_async_drop::tokio_async_drop;

--- a/crates/stress-test/src/mocks/task.rs
+++ b/crates/stress-test/src/mocks/task.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use log::info;
 use nix::NixPath;
 use oci_spec::runtime::{ProcessBuilder, RootBuilder, SpecBuilder, UserBuilder};
-use tempfile::{tempdir_in, TempDir};
+use tempfile::{TempDir, tempdir_in};
 use tokio::fs::{canonicalize, create_dir_all, write};
 use tokio_async_drop::tokio_async_drop;
 use trapeze::Client;
@@ -15,7 +15,7 @@ use crate::protos::containerd::task::v2::{
 };
 use crate::protos::containerd::types::Mount;
 use crate::traits::Task as _;
-use crate::utils::{make_task_id, RunOnce};
+use crate::utils::{RunOnce, make_task_id};
 
 pub struct Task {
     id: String,

--- a/crates/stress-test/src/utils.rs
+++ b/crates/stress-test/src/utils.rs
@@ -1,11 +1,11 @@
-use std::future::{pending, Future};
+use std::future::{Future, pending};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
-use nix::sys::signal::kill;
 use nix::sys::signal::Signal::SIGKILL;
-use nix::sys::wait::{waitpid, WaitPidFlag};
+use nix::sys::signal::kill;
+use nix::sys::wait::{WaitPidFlag, waitpid};
 use nix::unistd::Pid;
 use tokio::sync::Mutex;
 use tokio::time::sleep;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel="1.81.0"
+channel="1.85.0"
 profile="default"
 targets = ["wasm32-wasip1"]


### PR DESCRIPTION
there are few places that I need to fix:

1. `std::env::set_var` is now unsafe because it's not thread-safe.
2. `WaitableCell::set_guard_with`  function signature needs to use precise capturing.
3. Fixed some cargo fmt and clippy issues.
4. `extern` blocks are `unsafe` now

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
