### PR TITLE
Add plugin support to WasmEdge runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ name = "containerd-shim-wasmedge"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "cfg-if 1.0.0",
  "containerd-shim-wasm",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "crates/containerd-shim-wasmer",
     "crates/containerd-shim-wamr",
     "crates/stress-test",
-    "benches/containerd-shim-benchmarks", 
+    "benches/containerd-shim-benchmarks",
 ]
 resolver = "2"
 
@@ -48,6 +48,7 @@ tracing = "0.1"
 hyper = "1.6.0"
 tokio = { version = "1.43.0", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
+cfg-if = "1.0"
 
 # wasmtime
 wasmtime = { version = "27.0.0", features = ["async"] }

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 anyhow = { workspace = true }
 containerd-shim-wasm = { workspace = true, features = ["opentelemetry"] }
 log = { workspace = true }
+cfg-if = { workspace = true }
 
 # may need to bump wasmedge version in scripts/setup-windows.sh
 wasmedge-sdk = { version = "0.14.0", default-features = false }
@@ -17,7 +18,7 @@ libc = { workspace = true }
 serial_test = { workspace = true }
 
 [features]
-default = ["standalone", "static"]
+default = ["standalone", "static", "wasi_nn"]
 standalone = ["wasmedge-sdk/standalone"]
 static = ["wasmedge-sdk/static"]
 wasi_nn = ["wasmedge-sdk/wasi_nn"]

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -18,10 +18,10 @@ libc = { workspace = true }
 serial_test = { workspace = true }
 
 [features]
-default = ["standalone", "static", "wasi_nn"]
+default = ["standalone", "static", "plugin"]
 standalone = ["wasmedge-sdk/standalone"]
 static = ["wasmedge-sdk/static"]
-wasi_nn = ["wasmedge-sdk/wasi_nn"]
+plugin = ["wasmedge-sdk/wasi_nn"]
 
 [[bin]]
 name = "containerd-shim-wasmedge-v1"

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -1,8 +1,17 @@
 use std::collections::HashMap;
+use std::env;
+#[cfg(feature = "wasi_nn")]
+use std::str::FromStr;
 
 use anyhow::{Context, Result};
+use cfg_if::cfg_if;
 use containerd_shim_wasm::container::{Engine, Entrypoint, Instance, RuntimeContext};
+#[cfg(feature = "wasi_nn")]
+use wasmedge_sdk::AsInstance;
 use wasmedge_sdk::config::{CommonConfigOptions, Config, ConfigBuilder};
+#[cfg(feature = "wasi_nn")]
+use wasmedge_sdk::plugin::NNPreload;
+use wasmedge_sdk::plugin::PluginManager;
 use wasmedge_sdk::wasi::WasiModule;
 use wasmedge_sdk::{Module, Store, Vm};
 
@@ -39,16 +48,45 @@ impl Engine for WasmEdgeEngine {
 
         containerd_shim_wasm::debug!(ctx, "initializing WasmEdge runtime");
 
+        let prefix = "WASMEDGE_";
+        for env in envs.iter().filter(|env| env.starts_with(prefix)) {
+            if let Some((key, value)) = env.split_once('=') {
+                unsafe {
+                    env::set_var(key, value);
+                }
+            }
+        }
+
+        PluginManager::load(None)?;
+
+        let mut instances = HashMap::new();
+
+        cfg_if! {
+            if #[cfg(feature = "wasi_nn")] {
+                match env::var("WASMEDGE_WASINN_PRELOAD") {
+                    Ok(value) => PluginManager::nn_preload(vec![NNPreload::from_str(value.as_str())?]),
+                    Err(_) => log::debug!("No specific nn_preload parameter for wasi_nn plugin"),
+                }
+
+                let mut wasi_nn = PluginManager::names()
+                    .contains(&"wasi_nn".to_string())
+                    .then(PluginManager::load_plugin_wasi_nn)
+                    .transpose()?;
+                if let Some(ref mut nn) = wasi_nn {
+                    instances.insert(nn.name().unwrap().to_string(), nn);
+                }
+            }
+        }
+
         let mut wasi_module = WasiModule::create(
             Some(args.iter().map(String::as_str).collect()),
             Some(envs.iter().map(String::as_str).collect()),
             Some(vec!["/:/"]),
         )?;
+        instances.insert(wasi_module.name().to_string(), wasi_module.as_mut());
+
         let wasm_bytes = source.as_bytes()?;
         let module = Module::from_bytes(Some(&self.config), &wasm_bytes)?;
-
-        let mut instances = HashMap::new();
-        instances.insert(wasi_module.name().to_string(), wasi_module.as_mut());
         let mut vm = Vm::new(Store::new(Some(&self.config), instances).unwrap());
         let mod_name = name.unwrap_or_else(|| "main".to_string());
 


### PR DESCRIPTION
As title.

I have prepared a verification repo demonstrating how to use the wasi_nn plugin with ggml backend.

https://github.com/CaptainVincent/runwasi-wasmedge-demo

And a CI workflow testing in [here](https://github.com/CaptainVincent/runwasi-wasmedge-demo/actions).