### PR TITLE
add container ID and pod ID to RuntimeContext and logs

### DIFF
--- a/crates/containerd-shim-wamr/Cargo.toml
+++ b/crates/containerd-shim-wamr/Cargo.toml
@@ -19,3 +19,6 @@ serial_test = { workspace = true }
 [[bin]]
 name = "containerd-shim-wamr-v1"
 path = "src/main.rs"
+
+[package.metadata.cargo-machete]
+ignored = ["log"]

--- a/crates/containerd-shim-wamr/src/instance.rs
+++ b/crates/containerd-shim-wamr/src/instance.rs
@@ -47,7 +47,7 @@ impl Engine for WamrEngine {
             .as_bytes()
             .context("Failed to get bytes from source")?;
 
-        log::info!("Create a WAMR module");
+        containerd_shim_wasm::info!(ctx, "Create a WAMR module");
 
         // TODO: error handling isn't ideal
 
@@ -56,7 +56,7 @@ impl Engine for WamrEngine {
         let mut module = Module::from_buf(&self.runtime, &wasm_bytes, &mod_name)
             .context("Failed to create module from bytes")?;
 
-        log::info!("Create a WASI context");
+        containerd_shim_wasm::info!(ctx, "Create a WASI context");
 
         let wasi_ctx = WasiCtxBuilder::new()
             .set_pre_open_path(vec!["/"], vec![])
@@ -68,19 +68,19 @@ impl Engine for WamrEngine {
 
         // TODO: no way to register a named module with bytes?
 
-        log::info!("Create a WAMR instance");
+        containerd_shim_wasm::info!(ctx, "Create a WAMR instance");
 
         let instance = WamrInst::new(&self.runtime, &module, 1024 * 64)
             .context("Failed to create instance")?;
 
-        log::info!("Running {func:?}");
+        containerd_shim_wasm::info!(ctx, "Running {func:?}");
         let function =
             Function::find_export_func(&instance, &func).context("Failed to find function")?;
         let status = function
             .call(&instance, &vec![])
             .map(|_| 0)
             .map_err(|err| {
-                log::error!("Error: {:?}", err);
+                containerd_shim_wasm::error!(ctx, "Error: {:?}", err);
                 err
             })
             .context("Failed to call function")?;

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 - Support for parsing SystemdCgroup from the containerd config file ([#864](https://github.com/containerd/runwasi/pull/864))\
 - Added more parameters info to the traces (must enable `tracing` feature) ([#853](https://github.com/containerd/runwasi/pull/853))
+- Added structured logging macros to the crate ([#879](https://github.com/containerd/runwasi/pull/879))
 
 ### Changed
 - `Engine` trait now creates a dedicated Zygote process for each container to avoid the issue of libcontainer trying to change the shim process's global state. ([#828](https://github.com/containerd/runwasi/pull/828))

--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -39,6 +39,13 @@ pub trait RuntimeContext {
 
     // the container id for the running container
     fn container_id(&self) -> &str;
+
+    // the pod id for the running container (if available)
+    // In Kubernetes environments, containers run within pods, and the pod ID is usually
+    // stored in the OCI spec annotations under "io.kubernetes.cri.sandbox-id"
+    fn pod_id(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// The source for a WASI module / components.
@@ -105,7 +112,7 @@ impl RuntimeContext for WasiContext<'_> {
             .process()
             .as_ref()
             .and_then(|p| p.env().as_ref())
-            .map(|e| e.as_slice())
+            .map(|a| a.as_slice())
             .unwrap_or_default()
     }
 
@@ -141,6 +148,14 @@ impl RuntimeContext for WasiContext<'_> {
 
     fn container_id(&self) -> &str {
         &self.id
+    }
+
+    fn pod_id(&self) -> Option<&str> {
+        self.spec
+            .annotations()
+            .as_ref()
+            .and_then(|a| a.get("io.kubernetes.cri.sandbox-id"))
+            .map(|s| s.as_str())
     }
 }
 
@@ -465,6 +480,53 @@ mod tests {
 
         let envs = ctx.envs();
         assert_eq!(envs.len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_pod_id() -> Result<()> {
+        use std::collections::HashMap;
+
+        let mut annotations = HashMap::new();
+        annotations.insert(
+            "io.kubernetes.cri.sandbox-id".to_string(),
+            "test-pod-id".to_string(),
+        );
+
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(ProcessBuilder::default().cwd("/").build()?)
+            .annotations(annotations)
+            .build()?;
+
+        let ctx = WasiContext {
+            spec: &spec,
+            wasm_layers: &[],
+            platform: &Platform::default(),
+            id: "test-container".to_string(),
+        };
+
+        assert_eq!(ctx.pod_id(), Some("test-pod-id"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_pod_id_no_annotation() -> Result<()> {
+        let spec = SpecBuilder::default()
+            .root(RootBuilder::default().path("rootfs").build()?)
+            .process(ProcessBuilder::default().cwd("/").build()?)
+            .build()?;
+
+        let ctx = WasiContext {
+            spec: &spec,
+            wasm_layers: &[],
+            platform: &Platform::default(),
+            id: "test-container".to_string(),
+        };
+
+        assert_eq!(ctx.pod_id(), None);
 
         Ok(())
     }

--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -36,6 +36,9 @@ pub trait RuntimeContext {
     // the platform for the container using the struct defined on the OCI spec definition
     // https://github.com/opencontainers/image-spec/blob/v1.1.0-rc5/image-index.md
     fn platform(&self) -> &Platform;
+
+    // the container id for the running container
+    fn container_id(&self) -> &str;
 }
 
 /// The source for a WASI module / components.
@@ -84,6 +87,7 @@ pub(crate) struct WasiContext<'a> {
     pub spec: &'a Spec,
     pub wasm_layers: &'a [WasmLayer],
     pub platform: &'a Platform,
+    pub id: String,
 }
 
 impl RuntimeContext for WasiContext<'_> {
@@ -134,6 +138,10 @@ impl RuntimeContext for WasiContext<'_> {
     fn platform(&self) -> &Platform {
         self.platform
     }
+
+    fn container_id(&self) -> &str {
+        &self.id
+    }
 }
 
 #[cfg(test)]
@@ -160,6 +168,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let args = ctx.args();
@@ -180,6 +189,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let args = ctx.args();
@@ -208,6 +218,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let args = ctx.args();
@@ -230,6 +241,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let path = ctx.entrypoint().source;
@@ -261,6 +273,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let expected_path = PathBuf::from("hello.wat");
@@ -301,6 +314,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let expected_path = PathBuf::from("/root/hello.wat");
@@ -341,6 +355,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let expected_path = PathBuf::from("/root/hello.wat");
@@ -379,6 +394,7 @@ mod tests {
                 ),
             }],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         assert!(matches!(ctx.entrypoint().source, Source::Oci(_)));
@@ -402,6 +418,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let envs = ctx.envs();
@@ -423,6 +440,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let envs = ctx.envs();
@@ -442,6 +460,7 @@ mod tests {
             spec: &spec,
             wasm_layers: &[],
             platform: &Platform::default(),
+            id: "test".to_string(),
         };
 
         let envs = ctx.envs();

--- a/crates/containerd-shim-wasm/src/container/log.rs
+++ b/crates/containerd-shim-wasm/src/container/log.rs
@@ -3,27 +3,57 @@
 macro_rules! log_with_ctx {
     // Info level log
     (info, $ctx:expr, $($arg:tt)+) => {
-        log::info!(instance = $ctx.container_id(); $($arg)+)
+        {
+            let ctx = $ctx;
+            match ctx.pod_id() {
+                Some(pod_id) => log::info!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
+                None => log::info!(instance = ctx.container_id(); $($arg)+)
+            }
+        }
     };
 
     // Debug level log
     (debug, $ctx:expr, $($arg:tt)+) => {
-        log::debug!(instance = $ctx.container_id(); $($arg)+)
+        {
+            let ctx = $ctx;
+            match ctx.pod_id() {
+                Some(pod_id) => log::debug!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
+                None => log::debug!(instance = ctx.container_id(); $($arg)+)
+            }
+        }
     };
 
     // Warn level log
     (warn, $ctx:expr, $($arg:tt)+) => {
-        log::warn!(instance = $ctx.container_id(); $($arg)+)
+        {
+            let ctx = $ctx;
+            match ctx.pod_id() {
+                Some(pod_id) => log::warn!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
+                None => log::warn!(instance = ctx.container_id(); $($arg)+)
+            }
+        }
     };
 
     // Error level log
     (error, $ctx:expr, $($arg:tt)+) => {
-        log::error!(instance = $ctx.container_id(); $($arg)+)
+        {
+            let ctx = $ctx;
+            match ctx.pod_id() {
+                Some(pod_id) => log::error!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
+                None => log::error!(instance = ctx.container_id(); $($arg)+)
+            }
+        }
     };
 
     // Trace level log
     (trace, $ctx:expr, $($arg:tt)+) => {
-        log::trace!(instance = $ctx.container_id(); $($arg)+)
+        {
+            let ctx = $ctx;
+            match ctx.pod_id() {
+                Some(pod_id) => log::trace!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
+                None => log::trace!(instance = ctx.container_id(); $($arg)+)
+            }
+        }
     };
 }
 

--- a/crates/containerd-shim-wasm/src/container/log.rs
+++ b/crates/containerd-shim-wasm/src/container/log.rs
@@ -1,3 +1,24 @@
+//! # Logging Utilities
+//!
+//! This module provides structured logging macros that automatically include container runtime  
+//! context information in log messages, making it easier to trace and debug container operations.
+//!
+//! ## Usage
+//!
+//! To use these macros, you need to have a context object that implements methods:
+//! - `container_id()` - returns the ID of the container
+//! - `pod_id()` - returns an Option containing the pod ID if available
+//!
+//! ### Example
+//!
+//! ```ignore
+//! containerd_shim_wasm::info!(ctx, "Starting container initialization");
+//! ```
+//!
+//! The resulting log entries will automatically include the container ID and pod ID (if available)
+//! as structured fields, making it easier to filter and analyze logs.
+//!
+
 /// Macros for logging with context information (container ID) automatically included.
 #[macro_export]
 macro_rules! log_with_ctx {

--- a/crates/containerd-shim-wasm/src/container/log.rs
+++ b/crates/containerd-shim-wasm/src/container/log.rs
@@ -22,57 +22,12 @@
 /// Macros for logging with context information (container ID) automatically included.
 #[macro_export]
 macro_rules! log_with_ctx {
-    // Info level log
-    (info, $ctx:expr, $($arg:tt)+) => {
+    ($level:ident, $ctx:expr, $($arg:tt)+) => {
         {
             let ctx = $ctx;
             match ctx.pod_id() {
-                Some(pod_id) => log::info!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
-                None => log::info!(instance = ctx.container_id(); $($arg)+)
-            }
-        }
-    };
-
-    // Debug level log
-    (debug, $ctx:expr, $($arg:tt)+) => {
-        {
-            let ctx = $ctx;
-            match ctx.pod_id() {
-                Some(pod_id) => log::debug!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
-                None => log::debug!(instance = ctx.container_id(); $($arg)+)
-            }
-        }
-    };
-
-    // Warn level log
-    (warn, $ctx:expr, $($arg:tt)+) => {
-        {
-            let ctx = $ctx;
-            match ctx.pod_id() {
-                Some(pod_id) => log::warn!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
-                None => log::warn!(instance = ctx.container_id(); $($arg)+)
-            }
-        }
-    };
-
-    // Error level log
-    (error, $ctx:expr, $($arg:tt)+) => {
-        {
-            let ctx = $ctx;
-            match ctx.pod_id() {
-                Some(pod_id) => log::error!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
-                None => log::error!(instance = ctx.container_id(); $($arg)+)
-            }
-        }
-    };
-
-    // Trace level log
-    (trace, $ctx:expr, $($arg:tt)+) => {
-        {
-            let ctx = $ctx;
-            match ctx.pod_id() {
-                Some(pod_id) => log::trace!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
-                None => log::trace!(instance = ctx.container_id(); $($arg)+)
+                Some(pod_id) => log::$level!(instance = ctx.container_id(), pod = pod_id; $($arg)+),
+                None => log::$level!(instance = ctx.container_id(); $($arg)+)
             }
         }
     };

--- a/crates/containerd-shim-wasm/src/container/log.rs
+++ b/crates/containerd-shim-wasm/src/container/log.rs
@@ -1,0 +1,68 @@
+/// Macros for logging with context information (container ID) automatically included.
+#[macro_export]
+macro_rules! log_with_ctx {
+    // Info level log
+    (info, $ctx:expr, $($arg:tt)+) => {
+        log::info!(instance = $ctx.container_id(); $($arg)+)
+    };
+
+    // Debug level log
+    (debug, $ctx:expr, $($arg:tt)+) => {
+        log::debug!(instance = $ctx.container_id(); $($arg)+)
+    };
+
+    // Warn level log
+    (warn, $ctx:expr, $($arg:tt)+) => {
+        log::warn!(instance = $ctx.container_id(); $($arg)+)
+    };
+
+    // Error level log
+    (error, $ctx:expr, $($arg:tt)+) => {
+        log::error!(instance = $ctx.container_id(); $($arg)+)
+    };
+
+    // Trace level log
+    (trace, $ctx:expr, $($arg:tt)+) => {
+        log::trace!(instance = $ctx.container_id(); $($arg)+)
+    };
+}
+
+/// Convenience macro for info level logs
+#[macro_export]
+macro_rules! info {
+    ($ctx:expr, $($arg:tt)+) => {
+        $crate::log_with_ctx!(info, $ctx, $($arg)+)
+    };
+}
+
+/// Convenience macro for debug level logs
+#[macro_export]
+macro_rules! debug {
+    ($ctx:expr, $($arg:tt)+) => {
+        $crate::log_with_ctx!(debug, $ctx, $($arg)+)
+    };
+}
+
+/// Convenience macro for warn level logs
+#[macro_export]
+macro_rules! warn {
+    ($ctx:expr, $($arg:tt)+) => {
+        $crate::log_with_ctx!(warn, $ctx, $($arg)+)
+    };
+}
+
+/// Convenience macro for error level logs
+#[macro_export]
+macro_rules! error {
+    ($ctx:expr, $($arg:tt)+) => {
+        $crate::log_with_ctx!(error, $ctx, $($arg)+)
+    };
+}
+
+/// Convenience macro for trace level logs
+#[macro_export]
+macro_rules! trace {
+    ($ctx:expr, $($arg:tt)+) => {
+        $crate::log_with_ctx!(trace, $ctx, $($arg)+)
+    };
+}

--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -12,6 +12,7 @@
 
 mod context;
 mod engine;
+pub mod log;
 mod path;
 mod wasm;
 

--- a/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/executor.rs
@@ -30,6 +30,7 @@ pub(crate) struct Executor<E: Engine> {
     inner: OnceCell<InnerExecutor>,
     wasm_layers: Vec<WasmLayer>,
     platform: Platform,
+    id: String,
 }
 
 impl<E: Engine> LibcontainerExecutor for Executor<E> {
@@ -53,8 +54,9 @@ impl<E: Engine> LibcontainerExecutor for Executor<E> {
                 DefaultExecutor {}.exec(spec)
             }
             InnerExecutor::Wasm => {
+                let ctx = self.ctx(spec);
                 log::info!("calling start function");
-                match self.engine.run_wasi(&self.ctx(spec)) {
+                match self.engine.run_wasi(&ctx) {
                     Ok(code) => std::process::exit(code),
                     Err(err) => {
                         log::info!("error running start function: {err}");
@@ -82,12 +84,13 @@ impl<E: Engine> LibcontainerExecutor for Executor<E> {
 }
 
 impl<E: Engine> Executor<E> {
-    pub fn new(engine: E, wasm_layers: Vec<WasmLayer>, platform: Platform) -> Self {
+    pub fn new(engine: E, wasm_layers: Vec<WasmLayer>, platform: Platform, id: String) -> Self {
         Self {
             engine,
             inner: Default::default(),
             wasm_layers,
             platform,
+            id,
         }
     }
 
@@ -98,6 +101,7 @@ impl<E: Engine> Executor<E> {
             spec,
             wasm_layers,
             platform,
+            id: self.id.clone(),
         }
     }
 

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -47,7 +47,7 @@ impl<E: Engine + Default> SandboxInstance for Instance<E> {
                 let engine = E::default();
 
                 let mut builder = ContainerBuilder::new(id.clone(), SyscallType::Linux)
-                    .with_executor(Executor::new(engine, modules, platform))
+                    .with_executor(Executor::new(engine, modules, platform, id))
                     .with_root_path(rootdir.clone())?;
 
                 if let Ok(f) = open(&cfg.stdin) {

--- a/crates/containerd-shim-wasmedge/Cargo.toml
+++ b/crates/containerd-shim-wasmedge/Cargo.toml
@@ -25,3 +25,6 @@ wasi_nn = ["wasmedge-sdk/wasi_nn"]
 [[bin]]
 name = "containerd-shim-wasmedge-v1"
 path = "src/main.rs"
+
+[package.metadata.cargo-machete]
+ignored = ["log"]

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -37,6 +37,8 @@ impl Engine for WasmEdgeEngine {
             name,
         } = ctx.entrypoint();
 
+        containerd_shim_wasm::debug!(ctx, "initializing WasmEdge runtime");
+
         let mut wasi_module = WasiModule::create(
             Some(args.iter().map(String::as_str).collect()),
             Some(envs.iter().map(String::as_str).collect()),
@@ -54,7 +56,7 @@ impl Engine for WasmEdgeEngine {
             .register_module(Some(&mod_name), module)
             .context("registering module")?;
 
-        log::debug!("running with method {func:?}");
+        containerd_shim_wasm::debug!(ctx, "running with method {func:?}");
         vm.run_func(Some(&mod_name), func, vec![])?;
 
         Ok(wasi_module.exit_code() as i32)

--- a/crates/containerd-shim-wasmer/Cargo.toml
+++ b/crates/containerd-shim-wasmer/Cargo.toml
@@ -22,4 +22,4 @@ name = "containerd-shim-wasmer-v1"
 path = "src/main.rs"
 
 [package.metadata.cargo-machete]
-ignored = ["mio"] # wasmer depends on mio but the latest version of mio moved features behind a feature flag
+ignored = ["mio", "log"] # wasmer depends on mio but the latest version of mio moved features behind a feature flag

--- a/crates/containerd-shim-wasmer/src/instance.rs
+++ b/crates/containerd-shim-wasmer/src/instance.rs
@@ -36,7 +36,7 @@ impl Engine for WasmerEngine {
 
         let mod_name = name.unwrap_or_else(|| "main".to_string());
 
-        log::info!("Create a Store");
+        containerd_shim_wasm::info!(ctx, "Create a Store");
         let mut store = Store::new(self.engine.clone());
 
         let wasm_bytes = source.as_bytes()?;
@@ -47,7 +47,7 @@ impl Engine for WasmerEngine {
             .build()?;
         let _guard = runtime.enter();
 
-        log::info!("Creating `WasiEnv`...: args {args:?}, envs: {envs:?}");
+        containerd_shim_wasm::info!(ctx, "Creating `WasiEnv`...: args {args:?}, envs: {envs:?}");
         let fs = FileSystem::new(Handle::current(), "/")?;
         let (instance, wasi_env) = WasiEnv::builder(mod_name)
             .args(&args[1..])
@@ -56,7 +56,7 @@ impl Engine for WasmerEngine {
             .preopen_dir("/")?
             .instantiate(module, &mut store)?;
 
-        log::info!("Running {func:?}");
+        containerd_shim_wasm::info!(ctx, "Running {func:?}");
         let start = instance.exports.get_function(&func)?;
         wasi_env.data(&store).thread.set_status_running();
         let status = start.call(&mut store, &[]).map(|_| 0).or_else(|err| {

--- a/crates/containerd-shim-wasmtime/src/http_proxy.rs
+++ b/crates/containerd-shim-wasmtime/src/http_proxy.rs
@@ -100,7 +100,7 @@ pub(crate) async fn serve_conn(
     let listener = socket.listen(backlog)?;
     let tracker = TaskTracker::new();
 
-    log::info!("Serving HTTP on http://{}/", listener.local_addr()?);
+    containerd_shim_wasm::info!(ctx, "Serving HTTP on http://{}/", listener.local_addr()?);
 
     let env = env.into_iter().collect();
     let handler = Arc::new(ProxyHandler::new(instance, env, tracker.clone()));

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -215,16 +215,16 @@ impl WasmtimeEngineImpl {
         })?;
 
         wasmtime_wasi::runtime::in_tokio(async move {
-            log::info!("instantiating instance");
+            containerd_shim_wasm::info!(ctx, "instantiating instance");
             let instance: wasmtime::Instance =
                 module_linker.instantiate_async(&mut store, &module).await?;
 
-            log::debug!("getting start function");
+            containerd_shim_wasm::debug!(ctx, "getting start function");
             let start_func = instance
                 .get_func(&mut store, func)
                 .context("module does not have a WASI start function")?;
 
-            log::info!("running start function {func:?}");
+            containerd_shim_wasm::info!(ctx, "running start function {func:?}");
 
             start_func
                 .call_async(&mut store, &[], &mut [])


### PR DESCRIPTION
- **containerd-shim-wasm/src/sandbox/cli: add logger to the container process**
- **feat(all): add container id to runtimeContext so that logs can refer to it**

The purpose of adding `id` to RuntimeContext is that containers can add the id to their log messages to differentiate from other containers in the same pod. 

The disadvantage of this method is that functions that do not import `ctx: RuntimeContext` will not be able to have the container id in their logs.

This builds on top of #878 

---

## Example

The following is containerd log for a pod that has three wasm tasks. 

```console
time="2025-02-25T22:12:39.421124341Z" level=info instance="7e7916133550e01b22c57fbcb85ae0b18282a28dac7a61da18d0ebc52f5cc43c" msg="setting up wasi"
time="2025-02-25T22:12:39.918793845Z" level=info instance="45facf66a6c0fd780272599bf7a1a15604445b9811102c9ebd39dfc24a7690c6" msg="setting up wasi"
time="2025-02-25T22:12:40.460339278Z" level=info instance="60ad7697d284b0ab4a51664ae30da83aefc95284213156ee8d1c5cc1929a3144" msg="setting up wasi"
```
