### PR TITLE
[chore] Remove some redundant accessor methods

### DIFF
--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Engine` trait now creates a dedicated Zygote process for each container to avoid the issue of libcontainer trying to change the shim process's global state. ([#828](https://github.com/containerd/runwasi/pull/828))
 - `Engine` trait now uses `systemd_cgroup` from `InstanceConfig` to create the container's cgroup instead of hardcoding it to `false`. ([#864](https://github.com/containerd/runwasi/pull/864))
 - `containerd-shim-wasm` now uses Rust Edition 2024.
+- Breaking change: The `InstanceConfig` struct now has public members instead of accessor methods. ([#882](https://github.com/containerd/runwasi/pull/882))
 
 ### Removed
 - `containerd_shim_wasm::container::PathResolve` is now a private module ([#837](https://github.com/containerd/runwasi/pull/837))

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -1,6 +1,6 @@
 //! Abstractions for running/managing a wasm/wasi instance.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -11,103 +11,22 @@ use crate::sandbox::shim::Config;
 
 /// Generic options builder for creating a wasm instance.
 /// This is passed to the `Instance::new` method.
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct InstanceConfig {
     /// Optional stdin named pipe path.
-    stdin: PathBuf,
+    pub stdin: PathBuf,
     /// Optional stdout named pipe path.
-    stdout: PathBuf,
+    pub stdout: PathBuf,
     /// Optional stderr named pipe path.
-    stderr: PathBuf,
+    pub stderr: PathBuf,
     /// Path to the OCI bundle directory.
-    bundle: PathBuf,
+    pub bundle: PathBuf,
     /// Namespace for containerd
-    namespace: String,
+    pub namespace: String,
     /// GRPC address back to main containerd
-    containerd_address: String,
+    pub containerd_address: String,
     /// containerd runtime options config
-    config: Config,
-}
-
-impl InstanceConfig {
-    pub fn new(namespace: impl AsRef<str>, containerd_address: impl AsRef<str>) -> Self {
-        let namespace = namespace.as_ref().to_string();
-        let containerd_address = containerd_address.as_ref().to_string();
-        Self {
-            namespace,
-            containerd_address,
-            stdin: PathBuf::default(),
-            stdout: PathBuf::default(),
-            stderr: PathBuf::default(),
-            bundle: PathBuf::default(),
-            config: Config::default(),
-        }
-    }
-
-    /// set the stdin path for the instance
-    pub fn set_stdin(&mut self, stdin: impl AsRef<Path>) -> &mut Self {
-        self.stdin = stdin.as_ref().to_path_buf();
-        self
-    }
-
-    /// get the stdin path for the instance
-    pub fn get_stdin(&self) -> &Path {
-        &self.stdin
-    }
-
-    /// set the stdout path for the instance
-    pub fn set_stdout(&mut self, stdout: impl AsRef<Path>) -> &mut Self {
-        self.stdout = stdout.as_ref().to_path_buf();
-        self
-    }
-
-    /// get the stdout path for the instance
-    pub fn get_stdout(&self) -> &Path {
-        &self.stdout
-    }
-
-    /// set the stderr path for the instance
-    pub fn set_stderr(&mut self, stderr: impl AsRef<Path>) -> &mut Self {
-        self.stderr = stderr.as_ref().to_path_buf();
-        self
-    }
-
-    /// get the stderr path for the instance
-    pub fn get_stderr(&self) -> &Path {
-        &self.stderr
-    }
-
-    /// set the OCI bundle path for the instance
-    pub fn set_bundle(&mut self, bundle: impl AsRef<Path>) -> &mut Self {
-        self.bundle = bundle.as_ref().to_path_buf();
-        self
-    }
-
-    /// get the OCI bundle path for the instance
-    pub fn get_bundle(&self) -> &Path {
-        &self.bundle
-    }
-
-    /// get the namespace for the instance
-    pub fn get_namespace(&self) -> String {
-        self.namespace.clone()
-    }
-
-    /// get the containerd address for the instance
-    pub fn get_containerd_address(&self) -> String {
-        self.containerd_address.clone()
-    }
-
-    /// set the options config for the instance
-    pub fn set_config(&mut self, config: Config) -> &mut Self {
-        self.config = config;
-        self
-    }
-
-    /// get the options config for the instance
-    pub fn get_config(&self) -> &Config {
-        &self.config
-    }
+    pub config: Config,
 }
 
 /// Represents a WASI module(s).

--- a/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/instance_data.rs
@@ -8,19 +8,19 @@ use crate::sandbox::{Instance, InstanceConfig, Result};
 
 pub(super) struct InstanceData<T: Instance> {
     pub instance: T,
-    cfg: InstanceConfig,
+    pub config: InstanceConfig,
     pid: OnceLock<u32>,
     state: RwLock<TaskState>,
 }
 
 impl<T: Instance> InstanceData<T> {
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "Debug"))]
-    pub fn new(id: impl AsRef<str> + std::fmt::Debug, cfg: InstanceConfig) -> Result<Self> {
+    pub fn new(id: impl AsRef<str> + std::fmt::Debug, config: InstanceConfig) -> Result<Self> {
         let id = id.as_ref().to_string();
-        let instance = T::new(id, &cfg)?;
+        let instance = T::new(id, &config)?;
         Ok(Self {
             instance,
-            cfg,
+            config,
             pid: OnceLock::default(),
             state: RwLock::new(TaskState::Created),
         })
@@ -29,11 +29,6 @@ impl<T: Instance> InstanceData<T> {
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
     pub fn pid(&self) -> Option<u32> {
         self.pid.get().copied()
-    }
-
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]
-    pub fn config(&self) -> &InstanceConfig {
-        &self.cfg
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), level = "Debug"))]

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -214,11 +214,15 @@ where
 
         log::info!("building wasi test: {}", dir.display());
 
-        let mut cfg = InstanceConfig::new(TEST_NAMESPACE, "/run/containerd/containerd.sock");
-        cfg.set_bundle(dir)
-            .set_stdout(dir.join("stdout"))
-            .set_stderr(dir.join("stderr"))
-            .set_stdin(dir.join("stdin"));
+        let cfg = InstanceConfig {
+            namespace: TEST_NAMESPACE.to_string(),
+            containerd_address: "/run/containerd/containerd.sock".to_string(),
+            bundle: dir.to_path_buf(),
+            stdout: dir.join("stdout"),
+            stderr: dir.join("stderr"),
+            stdin: dir.join("stdin"),
+            ..Default::default()
+        };
 
         let instance = WasiInstance::new(self.container_name, &cfg)?;
         Ok(WasiTest { instance, tempdir })


### PR DESCRIPTION
As in the title.
This PR removes some accessor methods that aren't very rusty, and replaces it with `pub` struct members instead.