### PR TITLE
[chore] Remove unused engine field

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ The most flexible but complex is the `sandbox::Instance` trait:
 
 ```rust
 pub trait Instance {
-    /// The WASI engine type
-    type Engine: Send + Sync + Clone;
-
     /// Create a new instance
     fn new(id: String, cfg: &InstanceConfig) -> Self;
     /// Start the instance

--- a/crates/containerd-shim-wasm/README.md
+++ b/crates/containerd-shim-wasm/README.md
@@ -83,8 +83,6 @@ struct MyInstance {
 }
 
 impl Instance for MyInstance {
-    type Engine = MyEngine;
-
     fn new(id: String, cfg: &InstanceConfig) -> Result<Self, Error> {
         Ok(MyInstance { engine: MyEngine })
     }

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -164,7 +164,6 @@ pub fn shim_main<'a, I>(
     config: Option<Config>,
 ) where
     I: 'static + Instance + Sync + Send,
-    I::Engine: Default,
 {
     #[cfg(unix)]
     zygote::Zygote::init();
@@ -203,7 +202,6 @@ fn shim_main_inner<'a, I>(
     config: Option<Config>,
 ) where
     I: 'static + Instance + Sync + Send,
-    I::Engine: Default,
 {
     #[cfg(feature = "opentelemetry")]
     {

--- a/crates/containerd-shim-wasm/src/sandbox/instance.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/instance.rs
@@ -33,9 +33,6 @@ pub struct InstanceConfig {
 /// This trait requires that any type implementing it is `'static`, similar to `std::any::Any`.
 /// This means that the type cannot contain a non-`'static` reference.
 pub trait Instance: 'static {
-    /// The WASI engine type
-    type Engine: Send + Sync + Clone;
-
     /// Create a new instance
     fn new(id: String, cfg: &InstanceConfig) -> Result<Self, Error>
     where

--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -46,8 +46,6 @@
 //! }
 //!
 //! impl Instance for MyInstance {
-//!     type Engine = MyEngine;
-//!
 //!     fn new(id: String, cfg: &InstanceConfig) -> Result<Self, Error> {
 //!         Ok(MyInstance { engine: MyEngine })
 //!     }

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local.rs
@@ -87,7 +87,6 @@ type LocalInstances<T> = RwLock<HashMap<String, Arc<InstanceData<T>>>>;
 /// Local implements the Task service for a containerd shim.
 /// It defers all task operations to the `Instance` implementation.
 pub struct Local<T: Instance + Send + Sync, E: EventSender = RemoteEventSender> {
-    pub engine: T::Engine,
     pub(super) instances: LocalInstances<T>,
     events: E,
     exit: Arc<ExitSignal>,
@@ -99,10 +98,9 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
     /// Creates a new local task service.
     #[cfg_attr(
         feature = "tracing",
-        tracing::instrument(skip(engine, events, exit), level = "Debug")
+        tracing::instrument(skip(events, exit), level = "Debug")
     )]
     pub fn new(
-        engine: T::Engine,
         events: E,
         exit: Arc<ExitSignal>,
         namespace: impl AsRef<str> + std::fmt::Debug,
@@ -112,7 +110,6 @@ impl<T: Instance + Send + Sync, E: EventSender> Local<T, E> {
         let namespace = namespace.as_ref().to_string();
         let containerd_address = containerd_address.as_ref().to_string();
         Self {
-            engine,
             instances,
             events,
             exit,

--- a/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/local/tests.rs
@@ -23,7 +23,6 @@ pub struct InstanceStub {
 }
 
 impl Instance for InstanceStub {
-    type Engine = ();
     fn new(_id: String, _cfg: &InstanceConfig) -> Result<Self, Error> {
         Ok(InstanceStub {
             exit_code: WaitableCell::new(),
@@ -106,7 +105,6 @@ fn test_delete_after_create() {
 
     let (tx, _rx) = channel();
     let local = Arc::new(Local::<InstanceStub, _>::new(
-        (),
         tx,
         Arc::new(ExitSignal::default()),
         "test_namespace",
@@ -137,7 +135,6 @@ fn test_cri_task() -> Result<()> {
     let (etx, _erx) = channel();
     let exit_signal = Arc::new(ExitSignal::default());
     let local = Arc::new(Local::<InstanceStub, _>::new(
-        (),
         etx,
         exit_signal,
         "test_namespace",
@@ -307,7 +304,6 @@ fn test_task_lifecycle() -> Result<()> {
     let (etx, _erx) = channel(); // TODO: check events
     let exit_signal = Arc::new(ExitSignal::default());
     let local = Arc::new(Local::<InstanceStub, _>::new(
-        (),
         etx,
         exit_signal,
         "test_namespace",

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -29,8 +29,6 @@ pub struct Instance<E: Engine> {
 }
 
 impl<E: Engine + Default> SandboxInstance for Instance<E> {
-    type Engine = E;
-
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
     fn new(id: String, cfg: &InstanceConfig) -> Result<Self, SandboxError> {
         // check if container is OCI image with wasm layers and attempt to read the module

--- a/crates/containerd-shim-wasm/src/sys/windows/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/windows/container/instance.rs
@@ -9,8 +9,6 @@ use crate::sandbox::{Error as SandboxError, Instance as SandboxInstance, Instanc
 pub struct Instance<E: Engine>(PhantomData<E>);
 
 impl<E: Engine> SandboxInstance for Instance<E> {
-    type Engine = E;
-
     fn new(_id: String, _cfg: &InstanceConfig) -> Result<Self, SandboxError> {
         todo!();
     }

--- a/crates/containerd-shim-wasm/src/testing.rs
+++ b/crates/containerd-shim-wasm/src/testing.rs
@@ -25,10 +25,7 @@ use crate::sandbox::{Instance, InstanceConfig};
 pub const TEST_NAMESPACE: &str = "runwasi-test";
 pub const SIGKILL: u32 = 9;
 
-pub struct WasiTestBuilder<WasiInstance: Instance>
-where
-    WasiInstance::Engine: Default + Send + Sync + Clone,
-{
+pub struct WasiTestBuilder<WasiInstance: Instance> {
     container_name: String,
     start_fn: String,
     namespaces: Vec<LinuxNamespace>,
@@ -36,18 +33,12 @@ where
     _phantom: PhantomData<WasiInstance>,
 }
 
-pub struct WasiTest<WasiInstance: Instance>
-where
-    WasiInstance::Engine: Default + Send + Sync + Clone,
-{
+pub struct WasiTest<WasiInstance: Instance> {
     instance: WasiInstance,
     tempdir: tempfile::TempDir,
 }
 
-impl<WasiInstance: Instance> WasiTestBuilder<WasiInstance>
-where
-    WasiInstance::Engine: Default + Send + Sync + Clone,
-{
+impl<WasiInstance: Instance> WasiTestBuilder<WasiInstance> {
     pub fn new() -> Result<Self> {
         zygote::Zygote::init();
 
@@ -230,10 +221,7 @@ where
     }
 }
 
-impl<WasiInstance: Instance> WasiTest<WasiInstance>
-where
-    WasiInstance::Engine: Default + Send + Sync + Clone,
-{
+impl<WasiInstance: Instance> WasiTest<WasiInstance> {
     pub fn builder() -> Result<WasiTestBuilder<WasiInstance>> {
         WasiTestBuilder::new()
     }


### PR DESCRIPTION
There's an unused engine field in the `Local` struct that somehow was not being flagged as unused.
This PR removes that field, and related now redundant types.