### PR TITLE
[CI] pin the k3s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,12 @@ test/k8s/clean: bin/kind
 .PHONY: bin/k3s
 bin/k3s:
 	mkdir -p bin && \
-	curl -sfL https://get.k3s.io | INSTALL_K3S_BIN_DIR=$(PWD)/bin INSTALL_K3S_SYMLINK=skip INSTALL_K3S_NAME=runwasi sh -
+	curl -sfL https://get.k3s.io | env \
+		INSTALL_K3S_BIN_DIR=$(PWD)/bin \
+		INSTALL_K3S_SYMLINK=skip \
+		INSTALL_K3S_NAME=runwasi \
+		INSTALL_K3S_VERSION="v1.32.1+k3s1" \
+		sh -
 
 .PHONY: bin/k3s/clean
 bin/k3s/clean:


### PR DESCRIPTION
Recently the k3s e2e tests have started failing with
```
Events:
  Type     Reason                  Age                  From               Message
  ----     ------                  ----                 ----               -------
  Normal   Scheduled               5m                   default-scheduler  Successfully assigned default/wasi-demo-77898cb6bf-bmkrm to fv-az1207-240
  Warning  FailedCreatePodSandBox  5m                   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "2c50cc6abfb505d18e8a7e8e5c865c5941646d1b36b565428e2e583bba01baaa": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  4m46s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "c105840db1884bff78f996111b07e62df50fd1d9220c32113ecc9f3b3182dfd1": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  4m31s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "2d92b513bb2047d3e91a3fe3b8832bb54bb3d67a5487ff5bb7ee892d4f47cc49": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  4m18s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "3030a802bb2a8c11d9d05a3a55505949079d56010597f8252e7ff6139e9f3935": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  4m3s                 kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "84f292af541e3f2f3d01cc465108b301291804f7a2eba0c62fd0ce19a32d2329": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  3m52s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "e67a7354bf57b2d8a308b795a4c4723a41d5bb1aa480c80dd586c1363a03e519": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  3m39s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "6d9bbb989da83f98a7ae923a95097079f5b141fff5e8bbb8036213e011b0adcd": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  3m28s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "1f6251a5d62ed928b8d77f5d2a43f13efcbcd623a7b33509fea77323c1fc496b": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  3m17s                kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "6fede7f26df6cb3d343c9328f78bf75c42aabd6a6817cae2efda4707d896b6f0": no runtime for "wasm" is configured
  Warning  FailedCreatePodSandBox  14s (x14 over 3m3s)  kubelet            (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = unable to get OCI runtime for sandbox "5d3387cdb1b694104d98fd2193391127c4639ba563b2cbb5a85cc59a1a8bf1da": no runtime for "wasm" is configured
```

This coincides with a new release of k3s.
This PR attempts to fix CI by pinning k3s to an older release.