### PR TITLE
ci(all): add read-all permission to all workflows

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -30,6 +30,8 @@ on:
         type: string
         required: false
 
+permissions: read-all
+
 jobs:
   build-sign-upload:
     permissions:

--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -12,6 +12,8 @@ on:
         required: true
         type: string
 
+permissions: read-all
+
 jobs:
   check:
     name: lint on ${{ inputs.os }}

--- a/.github/workflows/action-test-image.yml
+++ b/.github/workflows/action-test-image.yml
@@ -9,6 +9,8 @@ on:
         type: string
         default: img
 
+permissions: read-all
+
 jobs:
   test-image:
     name: build test ${{ inputs.image }}

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -12,6 +12,8 @@ on:
         required: true
         type: string
 
+permissions: read-all
+
 jobs:
   e2e-k3s:
     name: e2e k3s test on ${{ inputs.os }}

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -18,6 +18,8 @@ on:
         type: string
         required: true
 
+permissions: read-all
+
 jobs:
   e2e-kind:
     name: e2e kind test on ${{ inputs.os }} with ${{ inputs.image }}

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -12,6 +12,8 @@ on:
         required: true
         type: string
 
+permissions: read-all
+
 jobs:
   smoke-test:
     name: smoke test on ${{ inputs.os }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,16 +5,16 @@ on:
     - cron: '0 0 * * *'  # Runs daily at midnight
   pull_request:
 
-permissions:
-  # deployments permission to deploy GitHub pages website
-  deployments: write
-  # contents permission to update benchmark contents in gh-pages branch
-  contents: write
+permissions: read-all
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-
+    permissions:
+      # deployments permission to deploy GitHub pages website
+      deployments: write
+      # contents permission to update benchmark contents in gh-pages branch
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -48,7 +48,11 @@ jobs:
 
   benchmark-mem:
     runs-on: ubuntu-latest
-
+    permissions:
+      # deployments permission to deploy GitHub pages website
+      deployments: write
+      # contents permission to update benchmark contents in gh-pages branch
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -85,7 +89,11 @@ jobs:
   
   benchmark-http:
     runs-on: ubuntu-latest
-
+    permissions:
+      # deployments permission to deploy GitHub pages website
+      deployments: write
+      # contents permission to update benchmark contents in gh-pages branch
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -118,7 +126,11 @@ jobs:
 
   benchmark-stress:
     runs-on: ubuntu-latest
-
+    permissions:
+      # deployments permission to deploy GitHub pages website
+      deployments: write
+      # contents permission to update benchmark contents in gh-pages branch
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: read-all
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   changes:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-wasi-demo-app.yml
+++ b/.github/workflows/release-wasi-demo-app.yml
@@ -19,6 +19,8 @@ env:
   CARGO_TERM_COLOR: always
   IMAGES: "wasi-demo-app wasi-demo-oci wasi-demo-oci-artifact wasi-demo-http"
 
+permissions: read-all
+
 jobs:
   release-wasi-demo:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+permissions: read-all
+
 jobs:
   pre-release:
     name: pre-release checks

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,6 +10,8 @@ on:
         type: string
         required: true
 
+permissions: read-all
+
 jobs:
   sbom:
     name: Generate SBOM, sign and attach them to OCI image

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -10,13 +10,14 @@ on:
         type: string
         required: true
 
+permissions: read-all
+
 jobs:
   sign:
     name: Sign image
     permissions:
-      packages: write
-      id-token: write
-
+      packages: write # needed to authenticate and interact with the GitHub Container Registry
+      id-token: write # needed for the cosign signing process
     runs-on: ubuntu-latest
     steps:
       - name: Sanitize image name


### PR DESCRIPTION
By explicitly adding the read-all permission to all workflows, we can
reduce the number of false positives in the scorecard check.

E.g. https://github.com/containerd/runwasi/security/code-scanning/21

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
