### PR TITLE
breaking: `shim::cli` is now crate public

### DIFF
--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- `containerd_shim_wasm::sandbox::shim::Cli` -> `containerd_shim_wasm::sandbox::shim::Shim` and it is no longer public, because this was not intended to be used by users of the crate.
+
 ## [v0.10.0] - 2025-03-05
 
 ### Added

--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -9,6 +9,36 @@
 //! * Runtime overhead in in setting up a container
 //! * Less customizable
 //! * Currently only works on Linux
+//!
+//! ## Key Components
+//!
+//! - [`Engine`]: The core trait for implementing Wasm runtimes
+//! - [`RuntimeContext`]: The context for running WASI modules
+//!
+//! ## Example Usage
+//!
+//! ```rust
+//! use containerd_shim_wasm::container::{Engine, RuntimeContext};
+//! use anyhow::Result;
+//!
+//! #[derive(Clone, Default)]
+//! struct MyEngine;
+//!
+//! impl Engine for MyEngine {
+//!     fn name() -> &'static str {
+//!         "my-engine"
+//!     }
+//!
+//!     fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+//!         let args = ctx.args();
+//!         let envs = ctx.envs();
+//!         let entrypoint = ctx.entrypoint();
+//!         let platform = ctx.platform();
+//!
+//!         Ok(0)
+//!     }
+//! }
+//! ```
 
 mod context;
 mod engine;

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -85,7 +85,7 @@ use containerd_shim::{Config, parse, run};
 
 #[cfg(feature = "opentelemetry")]
 use crate::sandbox::shim::{OtlpConfig, otel_traces_enabled};
-use crate::sandbox::{Instance, ShimCli};
+use crate::sandbox::{Instance, Shim};
 
 pub mod r#impl {
     pub use git_version::git_version;
@@ -263,5 +263,5 @@ fn shim_main_inner<'a, I>(
     let lower_name = name.to_lowercase();
     let shim_id = format!("io.containerd.{lower_name}.{shim_version}");
 
-    run::<ShimCli<I>>(&shim_id, config);
+    run::<Shim<I>>(&shim_id, config);
 }

--- a/crates/containerd-shim-wasm/src/sandbox/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/mod.rs
@@ -16,38 +16,22 @@
 //! ## Key Components
 //!
 //! - [`Instance`]: Core trait for implementing container lifecycle management
-//! - [`ShimCli`]: Command-line interface implementation for containerd shims
-//! - [`WasmLayer`]: Represents WebAssembly layers in OCI containers
+//! - [`cli`]: Command line interface for the containerd shim
 //!
 //! ## Example Usage
 //!
 //! ```rust,no_run
 //! use containerd_shim_wasm::sandbox::{Instance, InstanceConfig, Error};
-//! use containerd_shim_wasm::container::{Engine, RuntimeContext};
 //! use chrono::{DateTime, Utc};
 //! use std::time::Duration;
 //! use anyhow::Result;
 //!
 //! #[derive(Clone, Default)]
-//! struct MyEngine;
-//!
-//! impl Engine for MyEngine {
-//!     fn name() -> &'static str {
-//!         "my-engine"
-//!     }
-//!
-//!     fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
-//!         Ok(0)
-//!     }
-//! }
-//!
-//! struct MyInstance {
-//!     engine: MyEngine,
-//! }
+//! struct MyInstance;
 //!
 //! impl Instance for MyInstance {
 //!     async fn new(id: String, cfg: &InstanceConfig) -> Result<Self, Error> {
-//!         Ok(MyInstance { engine: MyEngine })
+//!         Ok(MyInstance)
 //!     }
 //!
 //!     async fn start(&self) -> Result<u32, Error> {
@@ -79,7 +63,8 @@ pub mod sync;
 
 pub use error::{Error, Result};
 pub use instance::{Instance, InstanceConfig};
-pub use shim::{Cli as ShimCli, Config};
+pub use shim::Config;
+pub(crate) use shim::Shim;
 
 pub(crate) mod containerd;
 pub(crate) mod oci;

--- a/crates/containerd-shim-wasm/src/sandbox/shim/mod.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/mod.rs
@@ -1,16 +1,16 @@
-//! The shim is the entrypoint for the containerd shim API. It is responsible
-//! for commmuincating with the containerd daemon and managing the lifecycle of
-//! the container/sandbox.
+//! The shim exposes the [Config] struct to configure the shim and [OtlpConfig] module to enable tracing if the `opentelemetry` feature is enabled.
 
-mod cli;
+pub use local::Config;
+
 mod events;
 mod instance_data;
 mod local;
-pub use local::Config;
+#[allow(clippy::module_inception)]
+mod shim;
+mod task_state;
+pub(crate) use shim::Shim;
+
 #[cfg(feature = "opentelemetry")]
 mod otel;
-mod task_state;
-
-pub use cli::Cli;
 #[cfg(feature = "opentelemetry")]
 pub use otel::{Config as OtlpConfig, traces_enabled as otel_traces_enabled};

--- a/crates/containerd-shim-wasm/src/sandbox/shim/shim.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/shim/shim.rs
@@ -16,29 +16,31 @@ use crate::sandbox::shim::events::{RemoteEventSender, ToTimestamp};
 use crate::sandbox::shim::local::Local;
 use crate::sandbox::sync::WaitableCell;
 
-/// Cli implements the containerd-shim cli interface using `Local<T>` as the task service.
-pub struct Cli<T: Instance + Sync + Send> {
+/// Shim implements the [containerd_shim::Shim] trait using `Local<T>` as the task service.
+///
+/// It can be used as [containerd_shim::synchronous::run<Shim<I>>()] to start the shim.
+pub struct Shim<I: Instance + Sync + Send> {
     namespace: String,
     containerd_address: String,
     exit: WaitableCell<()>,
     _id: String,
-    _phantom: PhantomData<T>,
+    _phantom: PhantomData<I>,
 }
 
-impl<I> Debug for Cli<I>
+impl<I> Debug for Shim<I>
 where
     I: Instance + Sync + Send,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Cli {{ namespace: {:?}, containerd_address: {:?}, _id: {:?} }}",
+            "Shim {{ namespace: {:?}, containerd_address: {:?}, _id: {:?} }}",
             self.namespace, self.containerd_address, self._id
         )
     }
 }
 
-impl<I> shim::Shim for Cli<I>
+impl<I> shim::Shim for Shim<I>
 where
     I: Instance + Sync + Send,
 {
@@ -46,7 +48,7 @@ where
 
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
     fn new(_runtime_id: &str, args: &Flags, _config: &mut shim::Config) -> Self {
-        Cli {
+        Shim {
             namespace: args.namespace.to_string(),
             containerd_address: args.address.clone(),
             exit: WaitableCell::new(),

--- a/scripts/verify-jaeger-traces.sh
+++ b/scripts/verify-jaeger-traces.sh
@@ -11,7 +11,6 @@ REQUIRED_OPS=(
     "${PREFIX}::shim::local::start"
     "${PREFIX}::shim::local::delete"
     "${PREFIX}::shim::local::state"
-    "${PREFIX}::shim::cli::wait"
     "${PREFIX}::shim::local::shutdown"
     "${PREFIX}::cli::shim_main_inner"
 )


### PR DESCRIPTION
in addition, added detailed documentation for key components and example usage in the `container` module.

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
