### PR TITLE
make the engine trait async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "tokio-async-drop",
  "tokio-stream",
  "tracing",
+ "trait-variant",
  "ttrpc-codegen",
  "wasmparser 0.227.1",
  "wat",

--- a/crates/containerd-shim-wamr/src/instance.rs
+++ b/crates/containerd-shim-wamr/src/instance.rs
@@ -34,7 +34,7 @@ impl Engine for WamrEngine {
         "wamr"
     }
 
-    fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+    async fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
         let args = ctx.args();
         let envs = ctx.envs();
         let Entrypoint {

--- a/crates/containerd-shim-wasm/CHANGELOG.md
+++ b/crates/containerd-shim-wasm/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - `containerd_shim_wasm::sandbox::shim::Cli` -> `containerd_shim_wasm::sandbox::shim::Shim` and it is no longer public, because this was not intended to be used by users of the crate.
+- Breaking change: All methods in the `Engine` trait (except `name` and `supported_layers_types`) are now async. ([#931](https://github.com/containerd/runwasi/pull/931))
 
 ## [v0.10.0] - 2025-03-05
 

--- a/crates/containerd-shim-wasm/Cargo.toml
+++ b/crates/containerd-shim-wasm/Cargo.toml
@@ -34,6 +34,7 @@ tokio-stream = { version = "0.1" }
 sha256 = { workspace = true }
 serde_bytes = "0.11"
 tokio-async-drop = "0.1"
+trait-variant = "0.1"
 
 # tracing
 # note: it's important to keep the version of tracing in sync with containerd-shimkit's tracing-subscriber

--- a/crates/containerd-shim-wasm/README.md
+++ b/crates/containerd-shim-wasm/README.md
@@ -24,7 +24,7 @@ impl Engine for MyEngine {
         "my-engine"
     }
 
-    fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+    async fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
         // Implement your Wasm runtime logic here
         Ok(0)
     }

--- a/crates/containerd-shim-wasm/src/container/context.rs
+++ b/crates/containerd-shim-wasm/src/container/context.rs
@@ -10,7 +10,7 @@ use crate::sandbox::oci::WasmLayer;
 
 /// The `RuntimeContext` trait provides access to the runtime context that includes
 /// the arguments, environment variables, and entrypoint for the container.
-pub trait RuntimeContext {
+pub trait RuntimeContext: Send + Sync {
     /// Returns arguments from the runtime spec process field, including the
     /// path to the entrypoint executable.
     fn args(&self) -> &[String];

--- a/crates/containerd-shim-wasm/src/container/mod.rs
+++ b/crates/containerd-shim-wasm/src/container/mod.rs
@@ -29,7 +29,7 @@
 //!         "my-engine"
 //!     }
 //!
-//!     fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+//!     async fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
 //!         let args = ctx.args();
 //!         let envs = ctx.envs();
 //!         let entrypoint = ctx.entrypoint();

--- a/crates/containerd-shim-wasm/src/container/tests.rs
+++ b/crates/containerd-shim-wasm/src/container/tests.rs
@@ -10,10 +10,10 @@ impl Engine for EngineFailingValidation {
     fn name() -> &'static str {
         "wasi_instance"
     }
-    fn can_handle(&self, _ctx: &impl RuntimeContext) -> anyhow::Result<()> {
+    async fn can_handle(&self, _ctx: &impl RuntimeContext) -> anyhow::Result<()> {
         bail!("can't handle");
     }
-    fn run_wasi(&self, _ctx: &impl RuntimeContext) -> anyhow::Result<i32> {
+    async fn run_wasi(&self, _ctx: &impl RuntimeContext) -> anyhow::Result<i32> {
         Ok(0)
     }
 }

--- a/crates/containerd-shim-wasm/src/sandbox/cli.rs
+++ b/crates/containerd-shim-wasm/src/sandbox/cli.rs
@@ -52,7 +52,7 @@
 //!         "my-engine"
 //!     }
 //!
-//!     fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+//!     async fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
 //!         Ok(0)
 //!     }
 //! }

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -35,7 +35,7 @@ impl Engine for WasmEdgeEngine {
         "wasmedge"
     }
 
-    fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
+    async fn run_wasi(&self, ctx: &impl RuntimeContext) -> Result<i32> {
         let args = ctx.args();
         let envs = ctx.envs();
         let Entrypoint {


### PR DESCRIPTION
This PR makes most of the methods in the `Engine` trait `async`.
The `name` and `supported_layers_types` methods are left as non-async methods, as they are intended more as configuration than for doing any actual computation.