### PR TITLE
Move `shim_main` from free function to method in a trait

### DIFF
--- a/crates/containerd-shim-wamr/src/instance.rs
+++ b/crates/containerd-shim-wamr/src/instance.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
-use containerd_shim_wasm::shim::{Entrypoint, RuntimeContext, Sandbox, Shim};
+use containerd_shim_wasm::shim::{Entrypoint, RuntimeContext, Sandbox, Shim, Version};
+use containerd_shim_wasm::version;
 use wamr_rust_sdk::function::Function;
 use wamr_rust_sdk::instance::Instance as WamrInst;
 use wamr_rust_sdk::module::Module;
@@ -27,6 +28,10 @@ impl Shim for WamrShim {
 
     fn name() -> &'static str {
         "wamr"
+    }
+
+    fn version() -> Version {
+        version!()
     }
 }
 

--- a/crates/containerd-shim-wamr/src/main.rs
+++ b/crates/containerd-shim-wamr/src/main.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_os = "windows"))]
 use containerd_shim_wamr::WamrShim;
-use containerd_shim_wasm::{revision, shim_main, version};
+use containerd_shim_wasm::Cli;
 
 #[cfg(target_os = "windows")]
 fn main() {
@@ -9,5 +9,5 @@ fn main() {
 
 #[cfg(not(target_os = "windows"))]
 fn main() {
-    shim_main::<WamrShim>(version!(), revision!(), None);
+    WamrShim::run(None);
 }

--- a/crates/containerd-shim-wasm/README.md
+++ b/crates/containerd-shim-wasm/README.md
@@ -10,8 +10,8 @@ To implement a shim, simply implement the `Shim` and `Sandbox` trait:
 
 ```rust,no_run
 use containerd_shim_wasm::{
-    revision, shim_main, version,
-    shim::{Shim, Sandbox, RuntimeContext},
+    Cli, version,
+    shim::{Shim, Sandbox, RuntimeContext, Version},
     Config,
 };
 use anyhow::Result;
@@ -27,6 +27,10 @@ impl Shim for MyShim {
     fn name() -> &'static str {
         "my-shim"
     }
+
+    fn version() -> Version {
+        version!()
+    }
 }
 
 impl Sandbox for MySandbox {
@@ -36,11 +40,7 @@ impl Sandbox for MySandbox {
     }
 }
 
-shim_main::<MyShim>(
-    version!(),
-    revision!(),
-    None,
-);
+MyShim::run(None);
 ```
 
 The `Engine` trait provides optional methods you can override:

--- a/crates/containerd-shim-wasm/src/lib.rs
+++ b/crates/containerd-shim-wasm/src/lib.rs
@@ -19,5 +19,5 @@ pub mod testing;
 /// Tests for runwasi's containerd-shim-wasm.
 mod test;
 
-pub use containerd_shimkit::{Config, revision, version};
-pub use sandbox::cli::shim_main;
+pub use containerd_shimkit::{Config, shim_version as version};
+pub use sandbox::cli::Cli;

--- a/crates/containerd-shim-wasm/src/shim/mod.rs
+++ b/crates/containerd-shim-wasm/src/shim/mod.rs
@@ -58,7 +58,7 @@ pub(crate) use context::WasiContext;
 pub use context::{Entrypoint, RuntimeContext, Source};
 pub(crate) use instance::Instance;
 pub(crate) use path::PathResolve;
-pub use shim::{Compiler, Sandbox, Shim};
+pub use shim::{Compiler, Sandbox, Shim, Version};
 pub use wasm::WasmBinaryType;
 
 use crate::sys::container::instance;

--- a/crates/containerd-shim-wasm/src/shim/shim.rs
+++ b/crates/containerd-shim-wasm/src/shim/shim.rs
@@ -3,6 +3,8 @@ use std::hash::Hash;
 use std::io::Read;
 
 use anyhow::{Context, Result};
+#[doc(inline)]
+pub use containerd_shimkit::sandbox::cli::Version;
 
 use super::Source;
 use crate::sandbox::oci::WasmLayer;
@@ -15,6 +17,12 @@ use crate::shim::{PathResolve, RuntimeContext};
 pub trait Shim: Sync + 'static {
     /// The name to use for this shim
     fn name() -> &'static str;
+
+    /// Returns the shim version.
+    /// Usually implemented using the [`version!()`](crate::version) macro.
+    fn version() -> Version {
+        Version::default()
+    }
 
     type Sandbox: Sandbox;
 

--- a/crates/containerd-shim-wasmedge/src/instance.rs
+++ b/crates/containerd-shim-wasmedge/src/instance.rs
@@ -5,7 +5,8 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use cfg_if::cfg_if;
-use containerd_shim_wasm::shim::{Entrypoint, RuntimeContext, Sandbox, Shim};
+use containerd_shim_wasm::shim::{Entrypoint, RuntimeContext, Sandbox, Shim, Version};
+use containerd_shim_wasm::version;
 #[cfg(all(feature = "plugin", not(target_env = "musl")))]
 use wasmedge_sdk::AsInstance;
 use wasmedge_sdk::config::{CommonConfigOptions, Config, ConfigBuilder};
@@ -34,6 +35,10 @@ impl Default for WasmEdgeSandbox {
 impl Shim for WasmEdgeShim {
     fn name() -> &'static str {
         "wasmedge"
+    }
+
+    fn version() -> Version {
+        version!()
     }
 
     type Sandbox = WasmEdgeSandbox;

--- a/crates/containerd-shim-wasmedge/src/main.rs
+++ b/crates/containerd-shim-wasmedge/src/main.rs
@@ -1,6 +1,6 @@
-use containerd_shim_wasm::{revision, shim_main, version};
+use containerd_shim_wasm::Cli;
 use containerd_shim_wasmedge::WasmEdgeShim;
 
 fn main() {
-    shim_main::<WasmEdgeShim>(version!(), revision!(), None);
+    WasmEdgeShim::run(None);
 }

--- a/crates/containerd-shim-wasmer/src/instance.rs
+++ b/crates/containerd-shim-wasmer/src/instance.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use containerd_shim_wasm::shim::{Entrypoint, RuntimeContext, Sandbox, Shim};
+use containerd_shim_wasm::shim::{Entrypoint, RuntimeContext, Sandbox, Shim, Version};
+use containerd_shim_wasm::version;
 use tokio::runtime::Handle;
 use wasmer::{Module, Store};
 use wasmer_wasix::virtual_fs::host_fs::FileSystem;
@@ -15,6 +16,10 @@ pub struct WasmerSandbox {
 impl Shim for WasmerShim {
     fn name() -> &'static str {
         "wasmer"
+    }
+
+    fn version() -> Version {
+        version!()
     }
 
     type Sandbox = WasmerSandbox;

--- a/crates/containerd-shim-wasmer/src/main.rs
+++ b/crates/containerd-shim-wasmer/src/main.rs
@@ -1,6 +1,6 @@
-use containerd_shim_wasm::{revision, shim_main, version};
+use containerd_shim_wasm::Cli;
 use containerd_shim_wasmer::WasmerShim;
 
 fn main() {
-    shim_main::<WasmerShim>(version!(), revision!(), None);
+    WasmerShim::run(None);
 }

--- a/crates/containerd-shim-wasmtime/src/main.rs
+++ b/crates/containerd-shim-wasmtime/src/main.rs
@@ -1,6 +1,6 @@
-use containerd_shim_wasm::{revision, shim_main, version};
+use containerd_shim_wasm::Cli;
 use containerd_shim_wasmtime::WasmtimeShim;
 
 fn main() {
-    shim_main::<WasmtimeShim>(version!(), revision!(), None);
+    WasmtimeShim::run(None);
 }


### PR DESCRIPTION
This PR removes the `shim_main` free function and replaces it with a `ShimCli::run` trait method.
This trait is implemented for all Shim traits.
It also adds a new `fn version() -> Version` method to engine, and the corresponding `Version` struct.