### PR TITLE
release: skip the ownership step if the crate is the initial release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ on:
         description: "The version of the crate to release. (e.g., 1.2.3)"
         type: string
         required: true
+      initial_release:
+        description: "If this is the first time releasing this crate, set to true"
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.workflow }}-${{ inputs.crate }}-${{ inputs.version }}
@@ -78,8 +82,9 @@ jobs:
               core.setOutput('is_shim', true);
             }
       ### If we are releasing a crate rather than producing a bin, check for crates.io access
+      ### If this is the first time releasing this crate, skip this step
       - name: Add crates.io ownership
-        if: ${{ steps.runtime_sub.outputs.is_shim != 'true' && github.repository == 'containerd/runwasi' }}
+        if: ${{ steps.runtime_sub.outputs.is_shim != 'true' && github.repository == 'containerd/runwasi' && inputs.initial_release != 'true' }}
         run: |
           cargo owner --list ${{ inputs.crate }} | grep github:containerd:runwasi-committers || \
           cargo owner --add github:containerd:runwasi-committers ${{ inputs.crate }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,7 +79,9 @@ In the Github release page, please provide the above command in the instructions
 ### First time release of a crate
 
 If the crate has never been published to crates.io before then ownership of the crate will need to be configured.
-The containerd/runwasi-committers team will need to be added as an owner of the crate.
+1. You should pass `first_time_release=true` to the release workflow to skip the ownership step.
+2. The containerd/runwasi-committers team will need to be added as an owner of the crate.
+
 The release workflow will automatically invite the person who triggered the workflow run to be an owner of the crate.
 That person will need to accept the invite to be an owner of the crate and then manually add the containerd/runwasi-committers team as an owner of the crate.
 


### PR DESCRIPTION
Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
