### PR TITLE
.github/workflows/release: Update crates.io ownership check to use GH actor instead of runwasi committers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Add crates.io ownership
         if: ${{ steps.runtime_sub.outputs.is_shim != 'true' && github.repository == 'containerd/runwasi' && !inputs.initial_release }}
         run: |
-          cargo owner --list ${{ inputs.crate }} | grep ${{ github.actor }} || \
+          cargo owner --list ${{ inputs.crate }} | grep -E 'github:containerd:runwasi-committers|${{ github.actor }}' || \
           cargo owner --add ${{ github.actor }} ${{ inputs.crate }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Add crates.io ownership
         if: ${{ steps.runtime_sub.outputs.is_shim != 'true' && github.repository == 'containerd/runwasi' && !inputs.initial_release }}
         run: |
-          cargo owner --list ${{ inputs.crate }} | grep github:containerd:runwasi-committers || \
-          cargo owner --add github:containerd:runwasi-committers ${{ inputs.crate }}
+          cargo owner --list ${{ inputs.crate }} | grep ${{ github.actor }} || \
+          cargo owner --add ${{ github.actor }} ${{ inputs.crate }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_PUBLISH_TOKEN }}
       - name: Verify version matches


### PR DESCRIPTION
the issue with adding runwasi committers as an owner is that the release bot does not have the visibility to see it.

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
