### PR TITLE
Remove cgroup v1 and Ubuntu 20.04 tests from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,7 @@ jobs:
     needs: [build-ubuntu, test-image]
     strategy:
       matrix:
-        # 20.04 uses cgroupv1, 22.04 uses cgroupv2
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-22.04"]
         runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-smoke.yml
     with:
@@ -120,8 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 20.04 uses cgroupv1, 22.04 uses cgroupv2
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-22.04"]
         runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-kind.yml
     with:
@@ -149,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-20.04", "ubuntu-22.04"]
+        os: ["ubuntu-22.04"]
         runtime: ["wasmtime", "wasmedge", "wasmer", "wamr"]
     uses: ./.github/workflows/action-test-k3s.yml
     with:


### PR DESCRIPTION
**Solves:** [https://github.com/containerd/runwasi/issues/995](https://github.com/containerd/runwasi/issues/995)

Ubuntu 20.04 LTS has reached EOL and has been removed from GitHub-hosted runners. runwasi ci initially used it to test cgroups v1, but after reviewing all currently supported GitHub-hosted Linux runners, none appear to support cgroups v1 by default.

Given this, I've removed the Ubuntu 20.04 runner and the corresponding cgroups v1 test.
Let me know if you'd like any adjustments. Happy to help!