### PR TITLE
docs: update quickstart to use containerd v2 configuration

### DIFF
--- a/docs/src/getting-started/quickstart.md
+++ b/docs/src/getting-started/quickstart.md
@@ -48,7 +48,7 @@ kind create cluster --name runwasi-cluster --config kind-config.yaml
 kubectl cluster-info --context kind-runwasi-cluster
 
 cat << EOF | docker exec -i runwasi-cluster-control-plane tee /etc/containerd/config.toml
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.wasm]
   runtime_type = "io.containerd.wasmtime.v1"
 EOF
 
@@ -73,7 +73,7 @@ sudo make install-wasmtime
 sudo mkdir -p /var/lib/rancher/k3s/agent/etc/containerd/
 
 cat << EOF | sudo tee -a /var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wasm]
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.wasm]
   runtime_type = "io.containerd.wasmtime.v1"
 EOF
 


### PR DESCRIPTION
fix: https://github.com/containerd/runwasi/issues/1002

The latest version of kind and k3s use containerd v2, and containerd configuration did change in 2.0.

This commit updates the quickstart doc to use containerd v2 configration format.

https://github.com/kubernetes-sigs/kind/pull/3828
https://github.com/k3s-io/k3s/pull/11626