### PR TITLE
fix: support `application/vnd.wasm.content.layer.v1+wasm` as oci layer type

### DIFF
--- a/crates/containerd-shim-wasm/src/shim/shim.rs
+++ b/crates/containerd-shim-wasm/src/shim/shim.rs
@@ -41,6 +41,7 @@ pub trait Shim: Sync + 'static {
         &[
             "application/vnd.bytecodealliance.wasm.component.layer.v0+wasm",
             "application/wasm",
+            "application/vnd.wasm.content.layer.v1+wasm",
         ]
     }
 }


### PR DESCRIPTION
### Summary

`supported_layers_types()` was missing `application/vnd.wasm.content.layer.v1+wasm`, a media type used by Spin tooling.

- Images using this type had their OCI layers silently filtered out during `load_modules()`, causing `wasm_layers` to be empty.
- With an empty list the executor fell back to `Source::File("/")` and `can_handle()` failed trying to read `/` as a wasm binary resulting to a `"wasmtime executor can't handle spec"`.

### Tests

- [x] Build and push a WASM image with layer media type `application/vnd.wasm.content.layer.v1+wasm`
- [x] Run it via `containerd-shim-wasmtime` — pod should reach `Succeeded` instead of `StartError`