### PR TITLE
fix(shimkit): fix OTEL init in start mode, TLS OTEL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -4177,7 +4177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4633,6 +4633,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4870,6 +4871,18 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/crates/containerd-shimkit/Cargo.toml
+++ b/crates/containerd-shimkit/Cargo.toml
@@ -51,6 +51,7 @@ opentelemetry-otlp = { version = "0.16.0", default-features = false, features = 
     "grpc-tonic",
     "http-proto",
     "reqwest-client",
+    "reqwest-rustls",
     "trace",
 ], optional = true }
 opentelemetry_sdk = { version = "0.23", default-features = false, features = [

--- a/crates/containerd-shimkit/src/sandbox/cli.rs
+++ b/crates/containerd-shimkit/src/sandbox/cli.rs
@@ -246,13 +246,21 @@ where
     }
 
     #[cfg(feature = "opentelemetry")]
-    if otel_traces_enabled() {
+    // Only initialize OTEL in serve mode (empty action). In start/delete mode,
+    // containerd reads the shim's stdout+stderr together to parse the TTRPC socket
+    // address; any extraneous output (including OTEL error eprintln!) would corrupt
+    // the address string and cause "unsupported protocol" TTRPC connection failures.
+    if otel_traces_enabled() && flags.action.is_empty() {
         // opentelemetry uses tokio, so we need to initialize a runtime
         async {
-            let otlp_config = OtlpConfig::build_from_env().expect("Failed to build OtelConfig.");
-            let _guard = otlp_config
-                .init()
-                .expect("Failed to initialize OpenTelemetry.");
+            let _guard = OtlpConfig::build_from_env()
+                .and_then(|c| c.init())
+                .map_err(|e| {
+                    eprintln!(
+                        "Failed to initialize OpenTelemetry (continuing without tracing): {e}"
+                    )
+                })
+                .ok();
             tokio::task::block_in_place(move || {
                 shim_main_inner::<I>(name, config);
             });

--- a/crates/containerd-shimkit/src/sandbox/shim/otel.rs
+++ b/crates/containerd-shimkit/src/sandbox/shim/otel.rs
@@ -88,7 +88,7 @@ impl Config {
     /// Initializes the tracer, sets up the telemetry and subscriber layers, and sets the global subscriber.
     ///
     /// Note: this function should be called only once and be called by the binary entry point.
-    pub fn init(&self) -> anyhow::Result<impl Drop> {
+    pub fn init(&self) -> anyhow::Result<impl Drop + use<>> {
         let tracer = self.init_tracer()?;
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
         set_text_map_propagator(TraceContextPropagator::new());


### PR DESCRIPTION
### Summary

Fix three bugs in containerd-shimkit triggered when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is set.
- OTEL was initialized before start-vs-serve mode was determined, causing its output to corrupt the TTRPC socket address parsed by containerd in start mode, **gated behind serve mode only**.
- The reqwest-client feature was built without TLS, rejecting HTTPS endpoints, fixed by adding `reqwest-rustls`.
- Finally, the otel.rs init() return  type needed `+ use<>` to satisfy Rust.

### Tests

- [x] Set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://...` on a node with the shim installed
- [x] Run a WASM pod
- [x] Verify OTEL traces are exported over HTTPS without TLS errors