### PR TITLE
wasmtime: read config from env variable TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,9 @@ dependencies = [
  "serial_test",
  "tokio",
  "tokio-util",
+ "toml",
  "wasmtime",
+ "wasmtime-cli-flags",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
 ]
@@ -6254,7 +6256,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.4",
  "static_assertions",
 ]
 
@@ -7242,6 +7244,21 @@ dependencies = [
  "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-cli-flags"
+version = "36.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1198e9381c2da98f784ca1c098001996b915502ee640718e3baae2015bab3b"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rayon",
+ "serde",
+ "serde_derive",
+ "toml",
+ "wasmtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,11 @@ hyper = "1.6.0"
 tokio = { version = "1.45.1", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 cfg-if = "1.0"
+toml = "0.8"
 
 # wasmtime
-wasmtime = { version = "36.0.6", features = ["async"] }
+wasmtime = { version = "36.0.6", features = ["async", "gc"] }
+wasmtime-cli-flags = { version = "36.0.6", features = ["component-model", "gc", "parallel-compilation", "pooling-allocator"] }
 wasmtime-wasi = { version = "36.0.6" }
 wasmtime-wasi-http = { version = "36.0.6" }
 

--- a/crates/containerd-shim-wasm/src/containerd/client.rs
+++ b/crates/containerd-shim-wasm/src/containerd/client.rs
@@ -394,6 +394,7 @@ impl Client {
         engine_name: impl AsRef<str> + Debug,
         supported_layer_types: &[&str],
         compiler: Option<&impl Compiler>,
+        envs: &[String],
     ) -> Result<Vec<WasmLayer>> {
         let container = self.get_container(containerd_id).await?;
         let (manifest, image_digest) = self.get_image_manifest_and_digest(&container.image).await?;
@@ -435,7 +436,7 @@ impl Client {
             return Ok(layers);
         };
 
-        let precompile_id = precompile_label(engine_name.as_ref(), compiler.cache_key());
+        let precompile_id = precompile_label(engine_name.as_ref(), compiler.cache_key(envs));
 
         let image_info = self.get_info(&image_digest).await?;
         let mut needs_precompile = !image_info.labels.contains_key(&precompile_id);
@@ -459,7 +460,7 @@ impl Client {
 
         if needs_precompile {
             log::info!("precompiling layers for image: {}", container.image);
-            let compiled_layers = match compiler.compile(&layers).await {
+            let compiled_layers = match compiler.compile(&layers, envs).await {
                 Ok(compiled_layers) => {
                     if compiled_layers.len() != layers.len() {
                         return Err(ShimError::FailedPrecondition(
@@ -695,6 +696,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 NO_COMPILER.as_ref(),
+                &[],
             )
             .await
             .unwrap();
@@ -723,6 +725,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -735,6 +738,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -764,6 +768,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -776,6 +781,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -796,7 +802,7 @@ mod tests {
         let fake_precompiled_bytes = generate_content("precompiled", WASM_LAYER_MEDIA_TYPE);
         let mut engine = FakePrecomipler::new();
         engine.add_precompiled_bits(fake_bytes.bytes.clone(), &fake_precompiled_bytes);
-        let expected_id = precompile_label("fake", engine.cache_key());
+        let expected_id = precompile_label("fake", engine.cache_key(&[]));
 
         let layers = client
             .load_modules(
@@ -804,6 +810,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -848,6 +855,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE, "textfile"],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -880,6 +888,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -914,6 +923,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -943,6 +953,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -962,6 +973,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -991,7 +1003,7 @@ mod tests {
         engine.add_precompiled_bits(fake_bytes.bytes.clone(), &fake_precompiled_bytes);
         engine.add_precompiled_bits(fake_bytes2.bytes.clone(), &fake_precompiled_bytes2);
 
-        let expected_id = precompile_label("fake", engine.cache_key());
+        let expected_id = precompile_label("fake", engine.cache_key(&[]));
 
         let layers = client
             .load_modules(
@@ -999,6 +1011,7 @@ mod tests {
                 "fake",
                 &[WASM_LAYER_MEDIA_TYPE],
                 Some(&engine),
+                &[],
             )
             .await
             .unwrap();
@@ -1097,11 +1110,15 @@ mod tests {
     }
 
     impl Compiler for FakePrecomipler {
-        fn cache_key(&self) -> impl Hash {
+        fn cache_key(&self, _envs: &[String]) -> impl Hash {
             self.precompile_id.clone()
         }
 
-        async fn compile(&self, layers: &[WasmLayer]) -> anyhow::Result<Vec<Option<Vec<u8>>>> {
+        async fn compile(
+            &self,
+            layers: &[WasmLayer],
+            _envs: &[String],
+        ) -> anyhow::Result<Vec<Option<Vec<u8>>>> {
             self.layers_compiled_per_call.store(0, Ordering::SeqCst);
             self.precompile_called.fetch_add(1, Ordering::SeqCst);
             let mut compiled_layers = vec![];

--- a/crates/containerd-shim-wasm/src/shim/shim.rs
+++ b/crates/containerd-shim-wasm/src/shim/shim.rs
@@ -55,7 +55,7 @@ pub trait Compiler: Sync {
     ///
     /// This hash will be used in the following way:
     /// "runwasi.io/precompiled/<Shim::name()>/<cache_key>"
-    fn cache_key(&self) -> impl Hash;
+    fn cache_key(&self, _envs: &[String]) -> impl Hash;
 
     /// `compile` passes supported OCI layers to engine for compilation.
     /// This is used to precompile the layers before they are run.
@@ -63,7 +63,11 @@ pub trait Compiler: Sync {
     /// The cached, precompiled layers will be reloaded on subsequent runs.
     /// The runtime is expected to return the same number of layers passed in, if the layer cannot be precompiled it should return `None` for that layer.
     /// In some edge cases it is possible that the layers may already be precompiled and None should be returned in this case.
-    async fn compile(&self, _layers: &[WasmLayer]) -> Result<Vec<Option<Vec<u8>>>>;
+    async fn compile(
+        &self,
+        _layers: &[WasmLayer],
+        _envs: &[String],
+    ) -> Result<Vec<Option<Vec<u8>>>>;
 }
 
 /// Like the unstable never type, this type can never be constructed.
@@ -78,11 +82,15 @@ pub enum NoCompiler {}
 pub const NO_COMPILER: Option<NoCompiler> = None;
 
 impl Compiler for NoCompiler {
-    fn cache_key(&self) -> impl Hash {
+    fn cache_key(&self, _envs: &[String]) -> impl Hash {
         unreachable!()
     }
 
-    async fn compile(&self, _layers: &[WasmLayer]) -> anyhow::Result<Vec<Option<Vec<u8>>>> {
+    async fn compile(
+        &self,
+        _layers: &[WasmLayer],
+        _envs: &[String],
+    ) -> anyhow::Result<Vec<Option<Vec<u8>>>> {
         unreachable!()
     }
 }

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -29,7 +29,8 @@ pub struct Instance<S: Shim> {
 
 #[async_trait]
 trait OciClient {
-    async fn load_modules(&self, id: &str) -> Result<Vec<WasmLayer>, SandboxError>;
+    async fn load_modules(&self, id: &str, envs: &[String])
+    -> Result<Vec<WasmLayer>, SandboxError>;
 }
 
 struct EngineOciClient<P: Compiler> {
@@ -41,13 +42,18 @@ struct EngineOciClient<P: Compiler> {
 
 #[async_trait]
 impl<P: Compiler> OciClient for EngineOciClient<P> {
-    async fn load_modules(&self, id: &str) -> Result<Vec<WasmLayer>, SandboxError> {
+    async fn load_modules(
+        &self,
+        id: &str,
+        envs: &[String],
+    ) -> Result<Vec<WasmLayer>, SandboxError> {
         self.client
             .load_modules(
                 id,
                 self.name,
                 self.supported_layer_types,
                 self.precompiler.as_ref(),
+                envs,
             )
             .await
     }
@@ -74,9 +80,22 @@ impl<S: Shim> SandboxInstance for Instance<S> {
             })
             .await?;
 
+        // Precompile runs before `RuntimeContext` exists, so read workload env
+        // from the OCI runtime-spec bundle (`<bundle>/config.json`), specifically
+        // the `process.env` field:
+        // https://github.com/opencontainers/runtime-spec/blob/6f7b71c2d216403715f7364ac88dec88d9da989c/config.md#process
+        let source_spec_path = cfg.bundle.join("config.json");
+        let spec = Spec::load(&source_spec_path)?;
+        let envs = spec
+            .process()
+            .as_ref()
+            .and_then(|p| p.env().as_ref())
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+
         // check if container is OCI image with wasm layers and attempt to read the module
         let modules = oci_client
-            .load_modules(&id)
+            .load_modules(&id, envs)
             .await
             .unwrap_or_else(|e| {
                 log::warn!("Error obtaining wasm layers for container {id}.  Will attempt to use files inside container image. Error: {e}");

--- a/crates/containerd-shim-wasmtime/Cargo.toml
+++ b/crates/containerd-shim-wasmtime/Cargo.toml
@@ -11,8 +11,10 @@ log = { workspace = true }
 hyper = { workspace = true }
 tokio = { workspace = true, features = ["signal", "macros"] }
 tokio-util = { workspace = true, features = ["rt"] }
+toml = { workspace = true }
 
 wasmtime = { workspace = true }
+wasmtime-cli-flags = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 

--- a/crates/containerd-shim-wasmtime/src/instance.rs
+++ b/crates/containerd-shim-wasmtime/src/instance.rs
@@ -1,4 +1,5 @@
-use std::hash::Hash;
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::sync::LazyLock;
 
 use anyhow::{Context, Result, bail};
@@ -11,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use wasmtime::component::types::ComponentItem;
 use wasmtime::component::{self, Component, ResourceTable};
 use wasmtime::{Config, Module, Precompiled, Store};
+use wasmtime_cli_flags::CommonOptions;
 use wasmtime_wasi::p2::bindings::Command;
 use wasmtime_wasi::preview1::{self as wasi_preview1, WasiP1Ctx};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
@@ -18,6 +20,9 @@ use wasmtime_wasi_http::bindings::ProxyPre;
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 
 use crate::http_proxy::serve_conn;
+
+const WASMTIME_CONFIG_TOML_ENV: &str = "RUNWASI_WASMTIME_CONFIG_TOML";
+type EnvMap<'a> = HashMap<&'a str, &'a str>;
 
 /// Represents the WASI API that the component is targeting.
 enum ComponentTarget<'a> {
@@ -61,18 +66,8 @@ pub struct WasmtimeSandbox {
 
 impl Default for WasmtimeSandbox {
     fn default() -> Self {
-        let mut config = wasmtime::Config::new();
-
-        // Disable Wasmtime parallel compilation for the tests
-        // see https://github.com/containerd/runwasi/pull/405#issuecomment-1928468714 for details
-        config.parallel_compilation(!cfg!(test));
-        config.wasm_component_model(true); // enable component linking
-        config.async_support(true); // must be on
-
-        if use_pooling_allocator_by_default() {
-            let cfg = wasmtime::PoolingAllocationConfig::default();
-            config.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(cfg));
-        }
+        let config = create_engine_config(&CommonOptions::default(), true)
+            .expect("failed to create wasmtime config");
 
         Self {
             engine: wasmtime::Engine::new(&config)
@@ -133,17 +128,10 @@ impl Shim for WasmtimeShim {
 
     #[allow(refining_impl_trait)]
     async fn compiler() -> Option<WasmtimeCompiler> {
-        let mut config = wasmtime::Config::new();
-
-        // Disable Wasmtime parallel compilation for the tests
-        // see https://github.com/containerd/runwasi/pull/405#issuecomment-1928468714 for details
-        config.parallel_compilation(!cfg!(test));
-        config.wasm_component_model(true); // enable component linking
-        config.async_support(true); // must be on
-
+        let config = create_engine_config(&CommonOptions::default(), false)
+            .expect("failed to create wasmtime precompilation config");
         let engine = wasmtime::Engine::new(&config)
             .expect("failed to create wasmtime precompilation engine");
-
         Some(WasmtimeCompiler(engine))
     }
 }
@@ -160,17 +148,31 @@ impl Sandbox for WasmtimeSandbox {
         } = ctx.entrypoint();
 
         let wasm_bytes = &source.as_bytes()?;
+        let envs = env_map(ctx.envs());
 
-        self.execute(ctx, wasm_bytes, func).await.into_error_code()
+        if let Some(sandbox) = load_custom_engine(&envs, self.cancel.clone())? {
+            sandbox
+                .execute(ctx, wasm_bytes, func)
+                .await
+                .into_error_code()
+        } else {
+            self.execute(ctx, wasm_bytes, func).await.into_error_code()
+        }
     }
 }
 
 impl Compiler for WasmtimeCompiler {
-    fn cache_key(&self) -> impl Hash {
-        self.0.precompile_compatibility_hash()
+    fn cache_key(&self, envs: &[String]) -> impl Hash {
+        let envs = env_map(envs);
+        let mut hasher = DefaultHasher::new();
+        self.0.precompile_compatibility_hash().hash(&mut hasher);
+        envs.get(WASMTIME_CONFIG_TOML_ENV).hash(&mut hasher);
+        hasher.finish()
     }
 
-    async fn compile(&self, layers: &[WasmLayer]) -> Result<Vec<Option<Vec<u8>>>> {
+    async fn compile(&self, layers: &[WasmLayer], envs: &[String]) -> Result<Vec<Option<Vec<u8>>>> {
+        let envs = env_map(envs);
+        let engine = create_precompile_engine(&envs)?;
         let mut compiled_layers = Vec::<Option<Vec<u8>>>::with_capacity(layers.len());
 
         for layer in layers {
@@ -181,8 +183,8 @@ impl Compiler for WasmtimeCompiler {
             }
 
             let compiled_layer = match WasmBinaryType::from_bytes(&layer.layer) {
-                Some(WasmBinaryType::Module) => self.0.precompile_module(&layer.layer)?,
-                Some(WasmBinaryType::Component) => self.0.precompile_component(&layer.layer)?,
+                Some(WasmBinaryType::Module) => engine.precompile_module(&layer.layer)?,
+                Some(WasmBinaryType::Component) => engine.precompile_component(&layer.layer)?,
                 None => {
                     log::warn!("Unknown WASM binary type");
                     continue;
@@ -395,6 +397,76 @@ fn store_for_context<T: WasiView + 'static>(
     wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
 
     Ok((store, linker))
+}
+
+fn load_custom_engine(
+    envs: &EnvMap<'_>,
+    cancel: CancellationToken,
+) -> Result<Option<WasmtimeSandbox>> {
+    let Some(options) = load_config_from_envs(envs)? else {
+        return Ok(None);
+    };
+
+    let sandbox = WasmtimeSandbox {
+        engine: wasmtime::Engine::new(&create_engine_config(&options, true)?)
+            .context("failed to create wasmtime engine")?,
+        cancel,
+    };
+
+    Ok(Some(sandbox))
+}
+
+fn load_config_from_envs(envs: &EnvMap<'_>) -> Result<Option<CommonOptions>> {
+    let Some(config_toml) = envs.get(WASMTIME_CONFIG_TOML_ENV).copied() else {
+        return Ok(None);
+    };
+    if config_toml.is_empty() {
+        return Ok(None);
+    }
+
+    let config = toml::from_str::<CommonOptions>(config_toml).with_context(|| {
+        format!("failed to parse wasmtime config from {WASMTIME_CONFIG_TOML_ENV}")
+    })?;
+    Ok(Some(config))
+}
+
+fn env_map<'a>(envs: &'a [String]) -> EnvMap<'a> {
+    let mut map = HashMap::with_capacity(envs.len());
+    for entry in envs {
+        let (env_key, env_value) = entry.split_once('=').unwrap_or((entry.as_str(), ""));
+        map.entry(env_key).or_insert(env_value);
+    }
+    map
+}
+
+fn create_precompile_engine(envs: &EnvMap<'_>) -> Result<wasmtime::Engine> {
+    let options = load_config_from_envs(envs)?.unwrap_or_default();
+    let config = create_engine_config(&options, false)?;
+    wasmtime::Engine::new(&config).context("failed to create wasmtime precompilation engine")
+}
+
+fn create_engine_config(
+    toml_config: &CommonOptions,
+    include_pooling: bool,
+) -> Result<wasmtime::Config> {
+    let mut options = toml_config.clone();
+    if options.codegen.parallel_compilation.is_none() {
+        // Disable Wasmtime parallel compilation for the tests.
+        // See https://github.com/containerd/runwasi/pull/405#issuecomment-1928468714
+        options.codegen.parallel_compilation = Some(!cfg!(test));
+    }
+    if options.wasm.component_model.is_none() {
+        options.wasm.component_model = Some(true);
+    }
+
+    let mut config = options
+        .config(include_pooling.then(use_pooling_allocator_by_default))
+        .context("failed to construct wasmtime::Config from workload config")?;
+    if !include_pooling {
+        config.allocation_strategy(wasmtime::InstanceAllocationStrategy::OnDemand);
+    }
+    config.async_support(true); // must be on
+    Ok(config)
 }
 
 fn wasi_builder(ctx: &impl RuntimeContext) -> Result<WasiCtxBuilder, anyhow::Error> {


### PR DESCRIPTION
fix https://github.com/containerd/runwasi/issues/1004 and
https://github.com/containerd/runwasi/issues/847 ?

Allow workloads to configure Wasmtime per deployment by setting `RUNWASI_WASMTIME_CONFIG_TOML` environment varialbe toml string. Not sure this is the best way to passing configuration, but it'd be a good starting point for discussing the design :)

Example:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: wasmtime-config
data:
  wasmtime.toml: |
    [wasm]
    gc = true
    function-references = true
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hello
spec:
  template:
    spec:
      runtimeClassName: wasmtime
      containers:
        - name: app
          image: ghcr.io/example/hello-wasm:latest
          command: ["/"]
          env:
            - name: RUNWASI_WASMTIME_CONFIG_TOML
              valueFrom:
                configMapKeyRef:
                  name: wasmtime-config
                  key: wasmtime.toml
```