### PR TITLE
otel: tls endpoint and otel in serve mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4661,6 +4661,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4899,6 +4900,18 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4688,6 +4688,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4925,6 +4926,18 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/crates/containerd-shimkit/Cargo.toml
+++ b/crates/containerd-shimkit/Cargo.toml
@@ -51,6 +51,7 @@ opentelemetry-otlp = { version = "0.16.0", default-features = false, features = 
     "grpc-tonic",
     "http-proto",
     "reqwest-client",
+    "reqwest-rustls",
     "trace",
 ], optional = true }
 opentelemetry_sdk = { version = "0.23", default-features = false, features = [

--- a/crates/containerd-shimkit/src/sandbox/cli.rs
+++ b/crates/containerd-shimkit/src/sandbox/cli.rs
@@ -246,13 +246,18 @@ where
     }
 
     #[cfg(feature = "opentelemetry")]
-    if otel_traces_enabled() {
+    // Only initialize OTEL in serve mode (empty action).
+    if otel_traces_enabled() && flags.action.is_empty() {
         // opentelemetry uses tokio, so we need to initialize a runtime
         async {
-            let otlp_config = OtlpConfig::build_from_env().expect("Failed to build OtelConfig.");
-            let _guard = otlp_config
-                .init()
-                .expect("Failed to initialize OpenTelemetry.");
+            let _guard = OtlpConfig::build_from_env()
+                .and_then(|c| c.init())
+                .map_err(|e| {
+                    eprintln!(
+                        "Failed to initialize OpenTelemetry (continuing without tracing): {e}"
+                    )
+                })
+                .ok();
             tokio::task::block_in_place(move || {
                 shim_main_inner::<I>(name, config);
             });

--- a/crates/containerd-shimkit/src/sandbox/shim/otel.rs
+++ b/crates/containerd-shimkit/src/sandbox/shim/otel.rs
@@ -88,7 +88,7 @@ impl Config {
     /// Initializes the tracer, sets up the telemetry and subscriber layers, and sets the global subscriber.
     ///
     /// Note: this function should be called only once and be called by the binary entry point.
-    pub fn init(&self) -> anyhow::Result<impl Drop> {
+    pub fn init(&self) -> anyhow::Result<impl Drop + use<>> {
         let tracer = self.init_tracer()?;
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
         set_text_map_propagator(TraceContextPropagator::new());

--- a/crates/containerd-shimkit/src/sandbox/shim/otel.rs
+++ b/crates/containerd-shimkit/src/sandbox/shim/otel.rs
@@ -88,7 +88,7 @@ impl Config {
     /// Initializes the tracer, sets up the telemetry and subscriber layers, and sets the global subscriber.
     ///
     /// Note: this function should be called only once and be called by the binary entry point.
-    pub fn init(&self) -> anyhow::Result<impl Drop + use<>> {
+    pub fn init(&self) -> anyhow::Result<ShutdownGuard> {
         let tracer = self.init_tracer()?;
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
         set_text_map_propagator(TraceContextPropagator::new());
@@ -154,7 +154,7 @@ impl Config {
 
 /// Shutdown of the open telemetry services will automatically called when the OtelConfig instance goes out of scope.
 #[must_use]
-struct ShutdownGuard;
+pub struct ShutdownGuard;
 
 impl Drop for ShutdownGuard {
     fn drop(&mut self) {

--- a/crates/containerd-shimkit/src/sandbox/sync.rs
+++ b/crates/containerd-shimkit/src/sandbox/sync.rs
@@ -80,7 +80,7 @@ impl<T> WaitableCell<T> {
     /// The function `f` will always be called, regardless of whether the `WaitableCell` has a value or not.
     /// The `WaitableCell` is going to be set even in the case of an unwind. In this case, ff the function `f`
     /// panics it will cause an abort, so it's recommended to avoid any panics in `f`.
-    pub fn set_guard_with<R: Into<T>, F: FnOnce() -> R>(&self, f: F) -> impl Drop + use<F, T, R> {
+    pub fn set_guard_with<R: Into<T>, F: FnOnce() -> R>(&self, f: F) -> impl Drop {
         let cell = (*self).clone();
         WaitableCellSetGuard { f: Some(f), cell }
     }


### PR DESCRIPTION
I found a couple of issues when using a TLS OTEL endpoint:

## TLS certificates for OTEL
**before**: can't be verified by the shim

 ```
OpenTelemetry trace error occurred. error sending request for url (https://...): error trying to connect: 
error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify 
failed:ssl/statem/statem_clnt.c:2124: (self-signed certificate in certificate chain)
```

**fix**: added the `rustls-native-certs` package to verify certificates
 
## OTEL configuration failure
**before**: when the OTEL configuration  is invalid, the shim fails and never return the pod uuid back to containerd

```
Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox
"3cb59679bc83014eeb5e249b740b507965ef6928d77dbf5ccfa85ab103dd9e64": failed to create containerd task: 
failed to start shim: start failed: failed to create TTRPC connection: unsupported protocol:
OpenTelemetry trace error occurred. error sending request for url (https//...
```

 **fix**: OTEL configuration is loaded only in serve mode, invalid configuration is just ignored