### PR TITLE
MAINTAINERS: update Jiaxiao Zhou email to personal address

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -6,7 +6,7 @@
 # COMMITTERS
 # GitHub ID, Name, Email address
 "cpuguy","Brian Goff","cpuguy83@gmail.com"
-"mossaka","Jiaxiao Zhou","jiazho@microsoft.com"
+"mossaka","Jiaxiao Zhou","duibao55328@gmail.com"
 "danbugs","Dan Chiarlone","danilochiarlone@gmail.com"
 "devigned","David Justice","david@justice.dev"
 "jprendes","Jorge Prendes","jorge.prendes@gmail.com"


### PR DESCRIPTION
## Summary
- Update my (mossaka) email in MAINTAINERS from `jiazho@microsoft.com` to my personal address `duibao55328@gmail.com`.

## Test plan
- [x] No code changes; MAINTAINERS-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)