### PR TITLE
ci: pin github actions and fix missing action

### DIFF
--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -102,7 +102,7 @@ jobs:
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
-        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.binprefix }}${{ inputs.runtime }}-${{ inputs.slug }}
           path: dist/${{ inputs.binprefix }}${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -40,9 +40,9 @@ jobs:
       - name: describe runner
         run: |
           echo "::notice::Running job with os: '${{ inputs.os }}', arch: '${{ inputs.arch }}', slug: '${{ inputs.slug }}', runtime: '${{ inputs.runtime }}', target: '${{ inputs.target }}'"
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         env:
           RUST_CACHE_KEY_OS: rust-cache-${{ inputs.os }}-${{ inputs.slug }}
         with:
@@ -102,7 +102,7 @@ jobs:
           fi
       - name: Upload artifacts
         if: ${{ inputs.runtime != 'common' }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: ${{ inputs.binprefix }}${{ inputs.runtime }}-${{ inputs.slug }}
           path: dist/${{ inputs.binprefix }}${{ inputs.runtime }}-${{ inputs.slug }}.tar.gz

--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -17,8 +17,8 @@ jobs:
     name: lint on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         with:
           components: rustfmt, clippy
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile

--- a/.github/workflows/action-test-image.yml
+++ b/.github/workflows/action-test-image.yml
@@ -18,7 +18,7 @@ jobs:
       - name: build
         run: make dist/${{ inputs.image }}.tar
       - name: Upload artifacts
-        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-${{ inputs.image }}
           path: dist/${{ inputs.image }}.tar

--- a/.github/workflows/action-test-image.yml
+++ b/.github/workflows/action-test-image.yml
@@ -14,11 +14,11 @@ jobs:
     name: build test ${{ inputs.image }}
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: build
         run: make dist/${{ inputs.image }}.tar
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: test-${{ inputs.image }}
           path: dist/${{ inputs.image }}.tar

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -17,10 +17,10 @@ jobs:
     name: e2e k3s test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
@@ -30,7 +30,7 @@ jobs:
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: test-img
           path: dist
@@ -51,7 +51,7 @@ jobs:
           sudo chown ${USER}:${USER} k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz
       - name: upload logs
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}
           path: k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz

--- a/.github/workflows/action-test-k3s.yml
+++ b/.github/workflows/action-test-k3s.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
@@ -30,7 +30,7 @@ jobs:
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-img
           path: dist
@@ -51,7 +51,7 @@ jobs:
           sudo chown ${USER}:${USER} k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz
       - name: upload logs
         if: failure()
-        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}
           path: k3s-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -23,10 +23,10 @@ jobs:
     name: e2e kind test on ${{ inputs.os }} with ${{ inputs.image }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
@@ -36,7 +36,7 @@ jobs:
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: test-${{ inputs.image }}
           path: dist
@@ -56,7 +56,7 @@ jobs:
           tar czf kind-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C ./kind-logs .
       - name: upload logs
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
         with:
           name: kind-logs-${{ inputs.runtime }}-${{ inputs.os }}
           path: kind-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz

--- a/.github/workflows/action-test-kind.yml
+++ b/.github/workflows/action-test-kind.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
@@ -36,7 +36,7 @@ jobs:
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-${{ inputs.image }}
           path: dist
@@ -56,7 +56,7 @@ jobs:
           tar czf kind-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz -C ./kind-logs .
       - name: upload logs
         if: failure()
-        uses: actions/upload-artifact@0c366cb4fc8897159c94880f94b55bc716ad6a66 # master
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: kind-logs-${{ inputs.runtime }}-${{ inputs.os }}
           path: kind-logs-${{ inputs.runtime }}-${{ inputs.os }}.tar.gz

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -17,10 +17,10 @@ jobs:
     name: smoke test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
@@ -30,7 +30,7 @@ jobs:
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           name: test-img
           path: dist

--- a/.github/workflows/action-test-smoke.yml
+++ b/.github/workflows/action-test-smoke.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl
           path: dist
@@ -30,7 +30,7 @@ jobs:
           mkdir -p dist/bin
           tar -xzf dist/containerd-shim-${{ inputs.runtime }}-x86_64-linux-musl.tar.gz -C dist/bin
       - name: Download test image
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: test-img
           path: dist

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - uses: ./.github/actions/setup-env
@@ -36,7 +36,7 @@ jobs:
           set -o pipefail
           cargo bench -p containerd-shim-benchmarks -- --output-format bencher | tee output.txt
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.20.7
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
         with:
           name: Criterion.rs Benchmark
           tool: 'cargo'
@@ -58,8 +58,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - uses: ./.github/actions/setup-env
@@ -73,7 +73,7 @@ jobs:
           done
           cat bench-mem-* | jq -s 'flatten(1)' > bench-mem.json
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.20.7
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
         with:
           name: Criterion.rs Benchmark
           tool: 'customSmallerIsBetter'
@@ -95,8 +95,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - uses: ./.github/actions/setup-env
@@ -128,8 +128,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
         with:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - uses: ./.github/actions/setup-env
@@ -159,7 +159,7 @@ jobs:
           done
           cat stress-bench-*.json | jq -s 'flatten(1)' > stress-bench.json
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.20.7
+        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
         with:
           name: Stress Test Benchmark
           tool: 'customBiggerIsBetter'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
 
   check:
     name: ${{ matrix.runtime }}
@@ -158,10 +158,10 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - uses: ./.github/actions/setup-env
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - name: Check documentation
       run: make test-doc
     - name: Generate documentation
@@ -171,19 +171,19 @@ jobs:
     name: unused dependencies
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
     - name: Check unused dependencies
-      uses: bnjbvr/cargo-machete@v0.9.1
+      uses: bnjbvr/cargo-machete@7959c845782fed02ee69303126d4a12d64f1db18 # v0.9.1
 
   spelling:
     name: spell check with typos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Spell Check Repo
-      uses: crate-ci/typos@master
+      uses: crate-ci/typos@3bcd3b343e2ffaa3d23f8cfe7f78d0f8c2d0d0c6 # master
 
   linkChecker:
     name: link checker
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2 # v2.6.1
       with:
         fail: false # don't fail the build on broken links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,8 @@ jobs:
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -28,15 +28,15 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
       - name: install mermaid preprocessor
         run: cargo install mdbook --version 0.4.52 && cargo install mdbook-mermaid --version 0.16.0
       - name: Build mdbook
         working-directory: ./docs
         run: mdbook build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
       
       - name: Setup GitHub CLI
         if: ${{ failure() }}
-        uses: cli/setup-gh@v1
+        uses: wusatosi/setup-gh@7dae6c8246092454793fe35dd4d5a9e8bf8ed34d # v1
       
       - name: Create or update issue on link check failure
         if: ${{ failure() }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/labeler@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/release-wasi-demo-app.yml
+++ b/.github/workflows/release-wasi-demo-app.yml
@@ -30,10 +30,10 @@ jobs:
       wasi_demo_oci_artifact: ${{ steps.get_digests.outputs.wasi_demo_oci_artifact }}
       wasi_demo_http: ${{ steps.get_digests.outputs.wasi_demo_http }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Install Rust and wasm32-wasi target
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           target: wasm32-wasip1
@@ -44,7 +44,7 @@ jobs:
         run: echo "repo=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
         if: ${{ matrix.is_shim == 'true' }}
-        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: release
       - name: Cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,10 @@ jobs:
         run: |
           echo "::error::This workflow should not be triggered with workflow_dispatch on a branch other than main"
           exit 1
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       ### Determine the name of the runtime and if it is a binary release or crates.io
       - name: verify version input
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const version = '${{ inputs.version }}';
@@ -68,7 +68,7 @@ jobs:
             }
       - name: substring runtime
         id: runtime_sub
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const crate = '${{ inputs.crate }}';
@@ -132,11 +132,11 @@ jobs:
       - name: Matrix description
         run: |
           echo "::notice::Running job with dry_run: '${{ inputs.dry_run }}', crate: '${{ matrix.crate }}', version: '${{ matrix.version }}', runtime: '${{ matrix.runtime }}', and is_shim: '${{ matrix.is_shim }}'."
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-env
       - name: Download artifacts
         if: ${{ matrix.is_shim == 'true' }}
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master
         with:
           path: release
       - name: Cargo publish

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -32,7 +32,7 @@ jobs:
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository }}
@@ -77,7 +77,7 @@ jobs:
             ghcr.io/${{ env.IMG_REPOSITORY_NAME }}/$image:${SBOM_TAG}
 
       - name: Upload SBOMs as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom
           path: $image-sbom-*

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -29,7 +29,7 @@ jobs:
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository }}


### PR DESCRIPTION
Hey runwasi folks :wave:

This is a proposition for
- pinning all your github actions to avoid any supply chain attacks.
- replacing the `cli/setup-gh` with the `wusatosi/setup-gh` action ([details](https://github.com/marketplace/actions/setup-gh))
