### PR TITLE
ci: unbreak Linux build matrix and benchmark-http

### DIFF
--- a/.github/actions/run-hey-load-test/action.yml
+++ b/.github/actions/run-hey-load-test/action.yml
@@ -9,13 +9,32 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install hey  
+    - name: Install hey
       shell: bash
+      # rakyll/hey used to ship a Linux binary at
+      # https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 but
+      # that bucket now returns an XML error page, which the previous
+      # implementation happily chmod+x'd and executed. rakyll/hey publishes
+      # no binary assets on its GitHub releases, so we build from the
+      # tagged source tarball instead. The tarball is fetched with `curl
+      # -fL` (fail loudly on non-2xx) and its sha256 is verified against a
+      # pinned digest so a future tampered or replaced archive aborts the
+      # job instead of silently feeding garbage into `go build`.
       run: |
-        curl -LO https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
-        chmod +x hey_linux_amd64
-        sudo mv hey_linux_amd64 /usr/local/bin/hey
-        hey --help
+        set -euo pipefail
+        HEY_VERSION="v0.1.4"
+        HEY_TARBALL_SHA256="944097e62dd0bd5012d3b355d9fe2e7b7afcf13cc0b2c06151e0f4c2babfc279"
+        workdir="$(mktemp -d)"
+        trap 'rm -rf "$workdir"' EXIT
+        curl -fL --retry 5 --retry-all-errors \
+          -o "$workdir/hey-src.tar.gz" \
+          "https://github.com/rakyll/hey/archive/refs/tags/${HEY_VERSION}.tar.gz"
+        echo "${HEY_TARBALL_SHA256}  $workdir/hey-src.tar.gz" | sha256sum -c -
+        tar -xzf "$workdir/hey-src.tar.gz" -C "$workdir"
+        (cd "$workdir/hey-${HEY_VERSION#v}" && go build -trimpath -o "$workdir/hey" .)
+        file "$workdir/hey" | grep -q "ELF .* executable"
+        sudo install -m 0755 "$workdir/hey" /usr/local/bin/hey
+        hey -h 2>&1 | head -1 || true
     - name: Run hey benchmark
       shell: bash
       run: |

--- a/.github/workflows/action-build.yml
+++ b/.github/workflows/action-build.yml
@@ -49,6 +49,12 @@ jobs:
           rustflags: '' #Disable.  By default this action sets environment variable is set to -D warnings.  We manage this in the Makefile
       - name: Setup cross-rs
         if: runner.os == 'Linux'
+        # Pass GITHUB_TOKEN so cargo-binstall authenticates to the GitHub
+        # releases API and is not subject to the anonymous rate limit. When
+        # that limit is hit binstall silently falls back to building from
+        # source, which the pinned Rust toolchain cannot satisfy.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/setup-cross.sh ${{ inputs.target }}
       - name: Setup build profile
         shell: bash

--- a/scripts/setup-cross.sh
+++ b/scripts/setup-cross.sh
@@ -10,8 +10,13 @@ fi
 
 # Install cross using cargo-binstall (downloads pre-built binary)
 # Use --force to ensure the binary is actually present even if metadata
-# says it's already installed (the Rust cache may have cleaned the binary)
-cargo binstall cross --version 0.2.5 --no-confirm --force
+# says it's already installed (the Rust cache may have cleaned the binary).
+# Use --locked so that if cargo-binstall falls back to a source build
+# (e.g. when the GitHub releases API is rate-limited and metadata can't be
+# fetched), the resulting `cargo install` honours cross's own Cargo.lock
+# instead of re-resolving dependencies to versions that require a newer
+# rustc than the toolchain pinned in rust-toolchain.toml.
+cargo binstall cross --version 0.2.5 --locked --no-confirm --force
 
 if [ ! -z "$CI" ]; then
 


### PR DESCRIPTION
## Summary

Fixes two unrelated, ongoing CI failures on `main`:

### 1. Linux build matrix (CI run `25725213908`, commit `b456f0b`)

All 14 `build for *-linux-{gnu,musl}` jobs fail when the runner trips GitHub's unauthenticated rate limit for the cross-rs releases API. `cargo-binstall` then silently falls back to building `cross` from source **without `--locked`**, re-resolving deps to versions like `home@0.5.12` (rust-version 1.88) that the pinned 1.86.0 toolchain rejects.

* `scripts/setup-cross.sh` now passes `--locked`, so the source-build fallback honours cross's own `Cargo.lock` (MSRV-compatible).
* `.github/workflows/action-build.yml` exposes `GITHUB_TOKEN` to the `Setup cross-rs` step so cargo-binstall is no longer subject to the anonymous rate limit and the prebuilt-binary fast path keeps working.

### 2. `benchmark-http` nightly job

`https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64` now returns an S3 XML error body. `curl -LO` (no `-f`) wrote the XML to disk, the step chmod+x'd it and moved it to `/usr/local/bin/hey`, and bash then died parsing `<?xml…?>` as a script.

`rakyll/hey` ships no binary assets on its GitHub releases, so this PR switches to building from the v0.1.4 source tarball:

* `curl -fL` so any non-2xx response aborts the step.
* SHA256 of the tarball is pinned (`944097e62dd0bd5012d3b355d9fe2e7b7afcf13cc0b2c06151e0f4c2babfc279`) so a future tampered or replaced archive fails loudly instead of being silently compiled.
* An `ELF .* executable` sanity check on the built binary ensures we never install something that isn't a Linux executable (which was the original failure mode).

Go is preinstalled on `ubuntu-latest`, so no extra setup is needed.

## Test plan

- [ ] CI Linux matrix (`build for *-linux-{gnu,musl}`) succeeds without falling back to a source build of `cross`.
- [ ] `Run Benchmarks / benchmark-http` installs `hey`, the ELF sanity check passes, and the load test runs to completion.
- [ ] `actionlint` and `python3 -c 'import yaml; yaml.safe_load(...)'` pass on the modified workflow / composite-action YAML (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)