### PR TITLE
Add OCI spec aware compiler hook (for precompile)

### DIFF
--- a/crates/containerd-shim-wasm/src/shim/shim.rs
+++ b/crates/containerd-shim-wasm/src/shim/shim.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use anyhow::Result;
 #[doc(inline)]
 pub use containerd_shimkit::sandbox::cli::Version;
+use oci_spec::runtime::Spec;
 
 use crate::sandbox::Sandbox;
 use crate::sandbox::context::WasmLayer;
@@ -29,6 +30,11 @@ pub trait Shim: Sync + 'static {
     /// to precompile layers.
     async fn compiler() -> Option<impl Compiler> {
         async move { NO_COMPILER }
+    }
+
+    /// Returns the compiler to be used by this engine with access to the OCI spec.
+    async fn compiler_with_spec(_spec: &Spec) -> Option<impl Compiler> {
+        Self::compiler()
     }
 
     /// Return the supported OCI layer types

--- a/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
+++ b/crates/containerd-shim-wasm/src/sys/unix/container/instance.rs
@@ -29,31 +29,33 @@ pub struct Instance<S: Shim> {
 
 #[async_trait]
 trait OciClient {
-    async fn load_modules(&self, id: &str) -> Result<Vec<WasmLayer>, SandboxError>;
+    async fn load_modules<P: Compiler>(
+        &self,
+        id: &str,
+        precompiler: Option<&P>,
+    ) -> Result<Vec<WasmLayer>, SandboxError>;
 }
 
-struct EngineOciClient<P: Compiler> {
+struct EngineOciClient {
     client: containerd::Client,
-    precompiler: Option<P>,
     supported_layer_types: &'static [&'static str],
     name: &'static str,
 }
 
 #[async_trait]
-impl<P: Compiler> OciClient for EngineOciClient<P> {
-    async fn load_modules(&self, id: &str) -> Result<Vec<WasmLayer>, SandboxError> {
+impl OciClient for EngineOciClient {
+    async fn load_modules<P: Compiler>(
+        &self,
+        id: &str,
+        precompiler: Option<&P>,
+    ) -> Result<Vec<WasmLayer>, SandboxError> {
         self.client
-            .load_modules(
-                id,
-                self.name,
-                self.supported_layer_types,
-                self.precompiler.as_ref(),
-            )
+            .load_modules(id, self.name, self.supported_layer_types, precompiler)
             .await
     }
 }
 
-static OCI_CLIENT: OnceCell<Box<dyn OciClient + Send + Sync + 'static>> = OnceCell::const_new();
+static OCI_CLIENT: OnceCell<Box<EngineOciClient>> = OnceCell::const_new();
 
 impl<S: Shim> SandboxInstance for Instance<S> {
     #[cfg_attr(feature = "tracing", tracing::instrument(level = "Info"))]
@@ -62,21 +64,23 @@ impl<S: Shim> SandboxInstance for Instance<S> {
             .get_or_try_init(|| async {
                 let client =
                     containerd::Client::connect(&cfg.containerd_address, &cfg.namespace).await?;
-                let precompiler = S::compiler().await;
                 let supported_layer_types = S::supported_layers_types();
                 let name = S::name();
                 Result::<_, SandboxError>::Ok(Box::new(EngineOciClient {
                     client,
-                    precompiler,
                     supported_layer_types,
                     name,
-                }) as _)
+                }))
             })
             .await?;
 
+        let source_spec_path = cfg.bundle.join("config.json");
+        let spec = Spec::load(&source_spec_path)?;
+        let precompiler = S::compiler_with_spec(&spec).await;
+
         // check if container is OCI image with wasm layers and attempt to read the module
         let modules = oci_client
-            .load_modules(&id)
+            .load_modules(&id, precompiler.as_ref())
             .await
             .unwrap_or_else(|e| {
                 log::warn!("Error obtaining wasm layers for container {id}.  Will attempt to use files inside container image. Error: {e}");


### PR DESCRIPTION
spinframework/containerd-shim-spin#444 adds Wasmtime TOML feature configuration. Runtime configuration can be provided through a Pod mounted `/runtime/wasmtime.toml` for example, but precompilation currently creates the compiler before the shim has access to the configuration.

This commits adds `Shim::compiler_with_spec(&Spec)`. Instance creation now loads `config.json` before loading OCI Wasm layers and passes the spec to the compiler through that new API.
Downstream shims precompilation should be able to read the spec to configure the wasmtime engine.

Concerns, this might add a small per-container-start cost: 🤔 
- we read `config.json` before precopmile
- construct a precompiler per container rather than once per shim process.