### PR TITLE
fix: avoid panicking when prestart hooks are missing

### DIFF
--- a/crates/containerd-shimkit/src/sandbox/oci.rs
+++ b/crates/containerd-shimkit/src/sandbox/oci.rs
@@ -26,7 +26,9 @@ fn parse_env(envs: &[String]) -> HashMap<String, String> {
 
 pub(crate) fn setup_prestart_hooks(hooks: &Option<oci_spec::runtime::Hooks>) -> Result<()> {
     if let Some(hooks) = hooks {
-        let prestart_hooks = hooks.prestart().as_ref().unwrap();
+        let Some(prestart_hooks) = hooks.prestart().as_ref() else {
+            return Ok(());
+        };
 
         for hook in prestart_hooks {
             let mut hook_command = process::Command::new(hook.path());
@@ -93,4 +95,48 @@ pub(crate) fn setup_prestart_hooks(hooks: &Option<oci_spec::runtime::Hooks>) -> 
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use oci_spec::runtime::{HookBuilder, HooksBuilder};
+    use tempfile::tempdir;
+
+    use super::setup_prestart_hooks;
+
+    #[test]
+    fn setup_prestart_hooks_ignores_missing_prestart_list() {
+        let hooks = HooksBuilder::default()
+            .create_runtime(vec![
+                HookBuilder::default().path("/bin/true").build().unwrap(),
+            ])
+            .build()
+            .unwrap();
+
+        setup_prestart_hooks(&Some(hooks)).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn setup_prestart_hooks_still_runs_prestart_hooks() {
+        let tempdir = tempdir().unwrap();
+        let marker = tempdir.path().join("prestart-ran");
+        let command = format!("touch {}", marker.display());
+        let hooks = HooksBuilder::default()
+            .prestart(vec![
+                HookBuilder::default()
+                    .path("/bin/sh")
+                    .args(vec!["sh".to_string(), "-c".to_string(), command])
+                    .build()
+                    .unwrap(),
+            ])
+            .build()
+            .unwrap();
+
+        setup_prestart_hooks(&Some(hooks)).unwrap();
+
+        assert!(fs::metadata(marker).is_ok());
+    }
 }


### PR DESCRIPTION
Tiny panic fix.

If an OCI spec has `hooks` but no `prestart`, `setup_prestart_hooks` hits `unwrap()` and `task create` can blow up. That spec shape is valid, so this edge is real.

This just returns early when `prestart` is missing. Also adds one test for the panic path, and one to make sure real `prestart` hooks still run. pretty small diff, no funny business.

Repro
1. Build `Hooks` with `createRuntime` set and no `prestart`
2. Call `setup_prestart_hooks(&Some(hooks))`
3. Before this PR it panics on `hooks.prestart().as_ref().unwrap()`
4. After this PR it becomes a no-op, which is the right move here

Tests
`LIBRARY_PATH=/tmp/runwasi-libs RUSTUP_TOOLCHAIN=stable /home/pc/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo test -q -p containerd-shimkit --lib --no-run`
`./target/debug/deps/containerd_shimkit-c41fc23cdc67215a --exact sandbox::oci::tests::setup_prestart_hooks_ignores_missing_prestart_list --nocapture`
`./target/debug/deps/containerd_shimkit-c41fc23cdc67215a --exact sandbox::oci::tests::setup_prestart_hooks_still_runs_prestart_hooks --nocapture`
